### PR TITLE
Update Remove-PnPTeamsTab.md

### DIFF
--- a/documentation/Remove-PnPTeamsTab.md
+++ b/documentation/Remove-PnPTeamsTab.md
@@ -30,14 +30,14 @@ Remove-PnPTeamsTab -Team <TeamsTeamPipeBind> -Channel <TeamsChannelPipeBind> -Id
 
 ### EXAMPLE 1
 ```powershell
-Remove-PnPTeamsTab -GroupId 5beb63c5-0571-499e-94d5-3279fdd9b6b5 -ChannelId 19:796d063b63e34497aeaf092c8fb9b44e@thread.skype -Identity Wiki
+Remove-PnPTeamsTab -Team 5beb63c5-0571-499e-94d5-3279fdd9b6b5 -Channel General -Identity Wiki
 ```
 
-Removes the tab with the display name 'Wiki' from the channel
+Removes the tab with the display name 'Wiki' from the channel named 'General'
 
 ### EXAMPLE 2
 ```powershell
-Remove-PnPTeamsTab -GroupId 5beb63c5-0571-499e-94d5-3279fdd9b6b5 -ChannelId 19:796d063b63e34497aeaf092c8fb9b44e@thread.skype -Identity fcef815d-2e8e-47a5-b06b-9bebba5c7852
+Remove-PnPTeamsTab -Team5beb63c5-0571-499e-94d5-3279fdd9b6b5 -Channel General -Identity d8740a7a-e44e-46c5-8f13-e699f964fc25
 ```
 
 Removes a tab with the specified id from the channel
@@ -73,7 +73,7 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Specify the id of the tab 
+Specify the id or display name of the tab 
 
 ```yaml
 Type: TeamsTabPipeBind

--- a/documentation/Remove-PnPTeamsTab.md
+++ b/documentation/Remove-PnPTeamsTab.md
@@ -37,7 +37,7 @@ Removes the tab with the display name 'Wiki' from the channel named 'General'
 
 ### EXAMPLE 2
 ```powershell
-Remove-PnPTeamsTab -Team5beb63c5-0571-499e-94d5-3279fdd9b6b5 -Channel General -Identity d8740a7a-e44e-46c5-8f13-e699f964fc25
+Remove-PnPTeamsTab -Team 5beb63c5-0571-499e-94d5-3279fdd9b6b5 -Channel General -Identity d8740a7a-e44e-46c5-8f13-e699f964fc25
 ```
 
 Removes a tab with the specified id from the channel


### PR DESCRIPTION

## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##


## What is in this Pull Request ? ##
Updated examples to remove reference to GroupId and ChannelId

Also tested commands and I note that -Team can accept Team display name and groupId  but -Channel can only accept channel display name and if you put in the channel id you get the error message below.

![image](https://user-images.githubusercontent.com/12968962/103896246-96a61180-50e9-11eb-8c54-e40bbf7ce217.png)

