### PR TITLE
Update Add-PnPPlannerBucket.md

### DIFF
--- a/documentation/Add-PnPPlannerBucket.md
+++ b/documentation/Add-PnPPlannerBucket.md
@@ -41,7 +41,7 @@ Adds a new bucket called "Project Todos" to the plan with the specified plan id 
 ## PARAMETERS
 
 ### -Group
-Specify the group id of group owning the plan.
+Specify the group id, mailNickname or display name of the group to use.
 
 ```yaml
 Type: PlannerGroupPipeBind

--- a/documentation/Add-PnPPlannerBucket.md
+++ b/documentation/Add-PnPPlannerBucket.md
@@ -10,11 +10,15 @@ title: add-pnpplannerbucket
 # Add-PnPPlannerBucket
 
 ## SYNOPSIS
+
+**Required Permissions**
+
+  * Microsoft Graph API: Group.ReadWrite.All
+
 Adds a new bucket to a Planner plan
 
 ## SYNTAX
 
-### By Group
 ```powershell
 Add-PnPPlannerBucket -Group <PlannerGroupPipeBind> -Plan <PlannerPlanPipeBind> -Name <String> [<CommonParameters>]
 ```

--- a/documentation/Add-PnPPlannerBucket.md
+++ b/documentation/Add-PnPPlannerBucket.md
@@ -19,11 +19,6 @@ Adds a new bucket to a Planner plan
 Add-PnPPlannerBucket -Group <PlannerGroupPipeBind> -Plan <PlannerPlanPipeBind> -Name <String> [<CommonParameters>]
 ```
 
-### By Plan Id
-```powershell
-Add-PnPPlannerBucket -PlanId <String> -Name <String> [<CommonParameters>]
-```
-
 ## DESCRIPTION
 This cmdlets creates a new bucket for tasks in a Planner plan.
 
@@ -34,14 +29,14 @@ This cmdlets creates a new bucket for tasks in a Planner plan.
 Add-PnPPlannerBucket -Group "My Group" -Plan "My Plan" -Name "Project Todos"
 ```
 
-Adds a new bucket called "Project Todos" to the specified plans
+Adds a new bucket called "Project Todos" to the specified named plan and named group.
 
 ### Example 2
 ```powershell
-Add-PnPPlannerBucket -PlanId "QvfkTd1mc02gwxHjHC_43JYABhAy" -Name "Project Todos"
+Add-PnPPlannerBucket -Group "baba9192-55be-488a-9fb7-2e2e76edbef2" -PlanId "QvfkTd1mc02gwxHjHC_43JYABhAy" -Name "Project Todos"
 ```
 
-Adds a new bucket called "Project Todos" to the plan with the specified id.
+Adds a new bucket called "Project Todos" to the plan with the specified plan id and group id.
 
 ## PARAMETERS
 


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##


## What is in this Pull Request ? ##
Added Graph permissions and remove by plan id examples as this is not possible as Group is a required parameter. Added extra example to add planner bucket by ID. Added extra info for -Group parameter.


