### PR TITLE
Bugfix in New-PnPTenantSite when using server relative URL

### DIFF
--- a/documentation/New-PnPTenantSite.md
+++ b/documentation/New-PnPTenantSite.md
@@ -27,8 +27,7 @@ New-PnPTenantSite -Title <String> -Url <String> -Owner <String> [-Lcid <UInt32>]
 ```
 
 ## DESCRIPTION
-The New-PnPTenantSite cmdlet creates a new site collection for the current company. However, creating a new SharePoint
-Online site collection fails if a deleted site with the same URL exists in the Recycle Bin. If you want to use this command for an on-premises farm, please refer to http://blogs.msdn.com/b/vesku/archive/2014/06/09/provisioning-site-collections-using-sp-app-model-in-on-premises-with-just-csom.aspx 
+The New-PnPTenantSite cmdlet creates a new site collection for the current company. However, creating a new SharePoint Online site collection fails if a deleted site with the same URL exists in the Recycle Bin
 
 ## EXAMPLES
 

--- a/documentation/New-PnPTenantSite.md
+++ b/documentation/New-PnPTenantSite.md
@@ -22,7 +22,7 @@ Creates a new (classic) site collection for the current tenant
 ```powershell
 New-PnPTenantSite -Title <String> -Url <String> -Owner <String> [-Lcid <UInt32>] [-Template <String>]
  -TimeZone <Int32> [-ResourceQuota <Double>] [-ResourceQuotaWarningLevel <Double>] [-StorageQuota <Int64>]
- [-StorageQuotaWarningLevel <Int64>] [-RemoveDeletedSite] [-Wait] [-Force] [-Connection <PnPConnection>]
+ [-StorageQuotaWarningLevel <Int64>] [-RemoveDeletedSite] [-Wait] [-Connection <PnPConnection>]
  [<CommonParameters>]
 ```
 
@@ -53,20 +53,6 @@ Optional connection to be used by the cmdlet. Retrieve the value for this parame
 
 ```yaml
 Type: PnPConnection
-Parameter Sets: (All)
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Force
-Do not ask for confirmation.
-
-```yaml
-Type: SwitchParameter
 Parameter Sets: (All)
 
 Required: False

--- a/src/Commands/Admin/NewTenantSite.cs
+++ b/src/Commands/Admin/NewTenantSite.cs
@@ -65,7 +65,6 @@ namespace PnP.PowerShell.Commands
             }
             if (shouldContinue)
             {
-
                 Func<TenantOperationMessage, bool> timeoutFunction = TimeoutFunction;
 
                 Tenant.CreateSiteCollection(Url, Title, Owner, Template, (int)StorageQuota,

--- a/src/Commands/Admin/NewTenantSite.cs
+++ b/src/Commands/Admin/NewTenantSite.cs
@@ -48,16 +48,12 @@ namespace PnP.PowerShell.Commands
         [Parameter(Mandatory = false)]
         public SwitchParameter Wait;
 
+        [Obsolete("The Force parameter has been deprecated and is no longer required to be provided. It will be removed in a future version.")] 
         [Parameter(Mandatory = false)]
         public SwitchParameter Force;
 
         protected override void ExecuteCmdlet()
         {
-            if (ParameterSpecified(nameof(Force)))
-            {
-                WriteWarning("The Force parameter has been deprecated and is no longer required to be provided. It will be removed in a future version.");
-            }
-
             if (!Url.ToLower().StartsWith("https://") && !Url.ToLower().StartsWith("http://"))
             {
                 Uri uri = BaseUri;

--- a/src/Commands/Admin/NewTenantSite.cs
+++ b/src/Commands/Admin/NewTenantSite.cs
@@ -48,29 +48,18 @@ namespace PnP.PowerShell.Commands
         [Parameter(Mandatory = false)]
         public SwitchParameter Wait;
 
-        [Parameter(Mandatory = false)]
-        public SwitchParameter Force;
-
         protected override void ExecuteCmdlet()
         {
-            bool shouldContinue = true;
             if (!Url.ToLower().StartsWith("https://") && !Url.ToLower().StartsWith("http://"))
             {
                 Uri uri = BaseUri;
                 Url = $"{uri.ToString().TrimEnd('/')}/{Url.TrimStart('/')}";
-                if (!Force)
-                {
-                    shouldContinue = ShouldContinue(string.Format(Resources.CreateSiteWithUrl0, Url), Resources.Confirm);
-                }
             }
-            if (shouldContinue)
-            {
-                Func<TenantOperationMessage, bool> timeoutFunction = TimeoutFunction;
+            Func<TenantOperationMessage, bool> timeoutFunction = TimeoutFunction;
 
-                Tenant.CreateSiteCollection(Url, Title, Owner, Template, (int)StorageQuota,
-                    (int)StorageQuotaWarningLevel, TimeZone, (int)ResourceQuota, (int)ResourceQuotaWarningLevel, Lcid,
-                    RemoveDeletedSite, Wait, Wait == true ? timeoutFunction : null);
-            }
+            Tenant.CreateSiteCollection(Url, Title, Owner, Template, (int)StorageQuota,
+                (int)StorageQuotaWarningLevel, TimeZone, (int)ResourceQuota, (int)ResourceQuotaWarningLevel, Lcid,
+                RemoveDeletedSite, Wait, Wait == true ? timeoutFunction : null);
         }
 
         private bool TimeoutFunction(TenantOperationMessage message)

--- a/src/Commands/Admin/NewTenantSite.cs
+++ b/src/Commands/Admin/NewTenantSite.cs
@@ -48,8 +48,16 @@ namespace PnP.PowerShell.Commands
         [Parameter(Mandatory = false)]
         public SwitchParameter Wait;
 
+        [Parameter(Mandatory = false)]
+        public SwitchParameter Force;
+
         protected override void ExecuteCmdlet()
         {
+            if (ParameterSpecified(nameof(Force)))
+            {
+                WriteWarning("The Force parameter has been deprecated and is no longer required to be provided. It will be removed in a future version.");
+            }
+
             if (!Url.ToLower().StartsWith("https://") && !Url.ToLower().StartsWith("http://"))
             {
                 Uri uri = BaseUri;

--- a/src/Commands/Base/PnPAdminCmdlet.cs
+++ b/src/Commands/Base/PnPAdminCmdlet.cs
@@ -41,7 +41,6 @@ namespace PnP.PowerShell.Commands.Base
                 throw new InvalidOperationException(Resources.NoSharePointConnection);
             }
 
-
             PnPConnection.CurrentConnection.CacheContext();
 
             if (PnPConnection.CurrentConnection.TenantAdminUrl != null &&
@@ -51,9 +50,7 @@ namespace PnP.PowerShell.Commands.Base
                 var uriParts = uri.Host.Split('.');
                 if (uriParts[0].ToLower().EndsWith("-admin"))
                 {
-                    _baseUri =
-                        new Uri(
-                            $"{uri.Scheme}://{uriParts[0].ToLower().Replace("-admin", "")}.{string.Join(".", uriParts.Skip(1))}{(!uri.IsDefaultPort ? ":" + uri.Port : "")}");
+                    _baseUri = new Uri($"{uri.Scheme}://{uriParts[0].ToLower().Replace("-admin", "")}.{string.Join(".", uriParts.Skip(1))}{(!uri.IsDefaultPort ? ":" + uri.Port : "")}");
                 }
                 else
                 {
@@ -76,12 +73,9 @@ namespace PnP.PowerShell.Commands.Base
                     PnPConnection.CurrentConnection.Context =
                         PnPConnection.CurrentConnection.CloneContext(adminUrl);
                 }
-                else if (PnPConnection.CurrentConnection.ConnectionType == ConnectionType.TenantAdmin)
+                else
                 {
-                    _baseUri =
-                       new Uri(
-                           $"{uri.Scheme}://{uriParts[0].ToLower().Replace("-admin", "")}{(uriParts.Length > 1 ? $".{string.Join(".", uriParts.Skip(1))}" : string.Empty)}{(!uri.IsDefaultPort ? ":" + uri.Port : "")}");
-
+                    _baseUri = new Uri($"{uri.Scheme}://{uriParts[0].ToLower().Replace("-admin", "")}{(uriParts.Length > 1 ? $".{string.Join(".", uriParts.Skip(1))}" : string.Empty)}{(!uri.IsDefaultPort ? ":" + uri.Port : "")}");
                 }
             }
         }
@@ -102,6 +96,5 @@ namespace PnP.PowerShell.Commands.Base
             base.EndProcessing();
             PnPConnection.CurrentConnection.RestoreCachedContext(PnPConnection.CurrentConnection.Url);
         }
-
     }
 }


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Fixing a bug when using a server relative URL with `New-PnPTenantSite`, i.e.:

```powershell
New-PnPTenantSite -Title "BLANKINTERNET#0" -Url "/sites/BLANKINTERNET4" -Owner "admin@xxx.onmicrosoft.com" -Lcid 1033 -TimeZone 4
```

This would result in an exception.

Also removed the -Force option and the confirmation prompt as confirmation was being asked when providing a server relative URL but not when providing a full URL, which is inconsistent. The SPO Management Shell also doesn't prompt for confirmation so to align with its behavior, removing the entire prompt here as well.