### PR TITLE
[UPDATE] Support for OrgAssetType in Add-PnPOrgAssetsLibrary

### DIFF
--- a/documentation/Add-PnPOrgAssetsLibrary.md
+++ b/documentation/Add-PnPOrgAssetsLibrary.md
@@ -20,7 +20,7 @@ Adds a given document library as a organizational asset source
 ## SYNTAX
 
 ```powershell
-Add-PnPOrgAssetsLibrary -LibraryUrl <String> [-ThumbnailUrl <String>] [-CdnType <SPOTenantCdnType>]
+Add-PnPOrgAssetsLibrary -LibraryUrl <String> [-ThumbnailUrl <String>] [-CdnType <SPOTenantCdnType>] [-OrgAssetType <OrgAssetType>]
  [-Connection <PnPConnection>] [<CommonParameters>]
 ```
 
@@ -62,7 +62,7 @@ Accepted values: Public, Private
 
 Required: False
 Position: Named
-Default value: None
+Default value: Public
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -91,6 +91,23 @@ Parameter Sets: (All)
 Required: True
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OrgAssetType
+Indicates the type of content in this library. Currently supported values are "ImageDocumentLibrary" and "OfficeTemplateLibrary".
+
+ImageDocumentLibrary is the default OrgAssetType and is best used for images. You can access the contents of this library from any site or page in the SharePoint filepicker. OfficeTemplateLibrary is the suggested type for Office files and will show up in the UI of all Office desktop apps and Office online in the templates section.
+
+```yaml
+Type: OrgAssetType
+Parameter Sets: (All)
+Accepted values: ImageDocumentLibrary, OfficeTemplateLibrary
+
+Required: False
+Position: Named
+Default value: ImageDocumentLibrary
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/src/Commands/Admin/AddOrgAssetsLibrary.cs
+++ b/src/Commands/Admin/AddOrgAssetsLibrary.cs
@@ -3,6 +3,7 @@
 using PnP.PowerShell.Commands.Base;
 using System.Management.Automation;
 using Microsoft.Online.SharePoint.TenantAdministration;
+using Microsoft.SharePoint.Administration;
 
 namespace PnP.PowerShell.Commands.Admin
 {
@@ -18,9 +19,12 @@ namespace PnP.PowerShell.Commands.Admin
         [Parameter(Mandatory = false)]
         public SPOTenantCdnType CdnType = SPOTenantCdnType.Public;
 
+        [Parameter(Mandatory = false)]
+        public OrgAssetType OrgAssetType = OrgAssetType.ImageDocumentLibrary;
+
         protected override void ExecuteCmdlet()
         {
-            Tenant.AddToOrgAssetsLibAndCdn(CdnType, LibraryUrl, ThumbnailUrl);
+            Tenant.AddToOrgAssetsLibAndCdnWithType(CdnType, LibraryUrl, ThumbnailUrl, OrgAssetType);
             ClientContext.ExecuteQueryRetry();
         }
     }


### PR DESCRIPTION
- Fixed docs to show correct default value for CdnType (Public)
- Added support for specifying the OrgAssetType that will be stored in the org asset library, default value "ImageDocumentLibrary". Brings it in line with the Add-SPOOrgAssetsLibrary