### PR TITLE
Updated the registration command and added a step

### DIFF
--- a/pages/articles/connecting.md
+++ b/pages/articles/connecting.md
@@ -27,12 +27,14 @@ Connect-PnPOnline -Url "https://[yourtenant].sharepoint.com" -Credentials (Get-C
 You will have to create your own Azure AD Application registration, or you can create one:
 
 ```powershell
-Register-PnPAzureADApp -Name "YourApplicationName" -Tenant [yourtenant.onmicrosoft.com] -DeviceLogin
+Register-PnPAzureADApp -ApplicationName "YourApplicationName" -Tenant [yourtenant.onmicrosoft.com] -DeviceLogin
 ```
 
 This will launch a authentication dialog where need to authenticate. After closing this window the cmdlet will continue to register a new application with a set of default permissions. By default a certificate will be generated and stored in the current folder, named after the application you want to create. You can specify your own certificate by using the `-CertificatePath` parameter and optional `-CertificatePassword` parameter.
 
 You can add permissions by using the `-Scope` parameter. The cmdlet will output the Azure AppId/client id, the name and location of the certificates created (if any) and the thumbprint of the certificate. It is possible to add the certificate created to the certificate management store in Windows by adding the `-Store` parameter.
+
+Before connecting using the Connect-PnPOnline cmdlet, make sure to go to the app registration. Select Manifest under the Manage section, then change the "allowPublicClient" property to true. 
 
 ```powershell
 Connect-PnPOnline -Url "https://[yourtenant.sharepoint.com] -Credentials (Get-Credential) -ClientId [clientid]

--- a/pages/articles/connecting.md
+++ b/pages/articles/connecting.md
@@ -34,7 +34,7 @@ This will launch a authentication dialog where need to authenticate. After closi
 
 You can add permissions by using the `-Scope` parameter. The cmdlet will output the Azure AppId/client id, the name and location of the certificates created (if any) and the thumbprint of the certificate. It is possible to add the certificate created to the certificate management store in Windows by adding the `-Store` parameter.
 
-Before connecting using the Connect-PnPOnline cmdlet, make sure to go to the app registration. Select Manifest under the Manage section, then change the "allowPublicClient" property to true. 
+Note if you are using Credential Based Authentication, you will need to make a change to the app registration manifest file. Go to the app registration, select Manifest under the Manage section, then change the "allowPublicClient" property to true and click save.
 
 ```powershell
 Connect-PnPOnline -Url "https://[yourtenant.sharepoint.com] -Credentials (Get-Credential) -ClientId [clientid]


### PR DESCRIPTION
## Type ##
- [x] Documentation Update

Without changing the allowPublicClient to true, users will get an error like this when trying to connect with credentials: 
AADSTS7000218: The request body must contain the following parameter: 'client_assertion' or 'client_secret'.

The solution is mentioned in step number 5 in this page: https://github.com/Azure-Samples/active-directory-dotnetcore-devicecodeflow-v2#register-the-client-app-active-directory-dotnet-deviceprofile

