### PR TITLE
Added cmdlets for disabling SharePoint Spaces

### DIFF
--- a/documentation/Get-PnPDisableSpacesActivation.md
+++ b/documentation/Get-PnPDisableSpacesActivation.md
@@ -1,0 +1,59 @@
+---
+Module Name: PnP.PowerShell
+schema: 2.0.0
+applicable: SharePoint Online
+online version: https://pnp.github.io/powershell/cmdlets/Get-PnPDisableSpacesActivation.html
+external help file: PnP.PowerShell.dll-Help.xml
+title: Get-PnPDisableSpacesActivation
+---
+  
+# Get-PnPDisableSpacesActivation
+
+## SYNOPSIS
+
+**Required Permissions**
+
+* SharePoint: Access to the SharePoint Tenant Administration site
+
+Retrieves if SharePoint Spaces is disabled on the entire tenant
+
+## SYNTAX
+
+```powershell
+Get-PnPDisableSpacesActivation [-Connection <PnPConnection>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Retrieves if SharePoint Spaces is disabled on the entire tenant. At this point there is no API yet for retrieving the setting for a specific site, although you can set it for a specific site.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-PnPDisableSpacesActivation
+```
+
+Returns if SharePoint Spaces is disabled on the tenant
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)
+
+

--- a/documentation/Set-PnPDisableSpacesActivation.md
+++ b/documentation/Set-PnPDisableSpacesActivation.md
@@ -1,0 +1,101 @@
+---
+Module Name: PnP.PowerShell
+title: Set-PnPDisableSpacesActivation
+schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/Set-PnPDisableSpacesActivation.html
+---
+ 
+# Set-PnPDisableSpacesActivation
+
+## SYNOPSIS
+Sets if SharePoint Spaces should be disabled
+
+## SYNTAX
+
+```powershell
+Set-PnPDisableSpacesActivation -Disable <SwitchParameter> [-Scope <String>] [-Identity <SitePipeBind>] [-Connection <PnPConnection>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Set-PnPDisableSpacesActivation -Disable $true -Scope Tenant
+```
+
+Disables SharePoint Spaces on the entire tenant
+
+### EXAMPLE 2
+```powershell
+Set-PnPDisableSpacesActivation -Disable $true -Scope Site -Identity "https://contoso.sharepoint.com"
+```
+
+Disables SharePoint Spaces on https://contoso.sharepoint.com
+
+## PARAMETERS
+
+### -Disable
+Sets if SharePoint Spaces should be enabled or disabled
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+Specifies the URL of the SharePoint Site on which SharePoint Spaces should be disabled. Must be provided if Scope is set to Tenant.
+
+```yaml
+Type: SPOSitePipeBind
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True
+Accept wildcard characters: False
+```
+
+### -Scope
+Defines if SharePoint Spaces should be disabled for the entire tenant or for a specific site collection
+
+```yaml
+Type: DisableSpacesScope
+Parameter Sets: (All)
+Accepted values: Tenant, Site
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)
+

--- a/src/Commands/Admin/GetDisableSpacesActivation.cs
+++ b/src/Commands/Admin/GetDisableSpacesActivation.cs
@@ -1,0 +1,20 @@
+﻿using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+
+using PnP.PowerShell.Commands.Base;
+using Microsoft.Online.SharePoint.TenantAdministration;
+
+namespace PnP.PowerShell.Commands
+{
+    [Cmdlet(VerbsCommon.Get, "PnPDisableSpacesActivation")]
+    public class GetDisableSpacesActivation : PnPAdminCmdlet
+    {
+        protected override void ExecuteCmdlet()
+        {
+            ClientContext.Load(Tenant, t => t.DisableSpacesActivation);
+            ClientContext.ExecuteQueryRetry();
+
+            WriteObject(Tenant.DisableSpacesActivation, false);
+        }
+    }
+}

--- a/src/Commands/Admin/SetDisableSpacesActivation.cs
+++ b/src/Commands/Admin/SetDisableSpacesActivation.cs
@@ -1,0 +1,40 @@
+﻿using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+
+using PnP.PowerShell.Commands.Base;
+using Microsoft.Online.SharePoint.TenantAdministration;
+using PnP.PowerShell.Commands.Base.PipeBinds;
+using System;
+
+namespace PnP.PowerShell.Commands
+{
+    [Cmdlet(VerbsCommon.Set, "PnPDisableSpacesActivation")]
+    public class SetDisableSpacesActivation : PnPAdminCmdlet
+    {
+        [Parameter(Mandatory = false, Position = 0, ValueFromPipeline = true)]
+        public SPOSitePipeBind Identity;
+
+        [Parameter(Mandatory = true)]
+        public SwitchParameter Disable;
+
+        [Parameter(Mandatory = true)]
+        public Enums.DisableSpacesScope Scope;
+
+        protected override void ExecuteCmdlet()
+        {
+            if(Scope == Enums.DisableSpacesScope.Tenant)
+            {
+                Tenant.DisableSpacesActivation = Disable.ToBool();
+            }
+            else
+            {
+                if(!ParameterSpecified(nameof(Identity)) || string.IsNullOrEmpty(Identity.Url))
+                {
+                    throw new ArgumentNullException($"{nameof(Identity)} must be provided when setting {nameof(Scope)} to Site");
+                }
+                Tenant.DisableSpacesActivationOnSite(Identity.Url, Disable.ToBool());
+            }
+            ClientContext.ExecuteQueryRetry();
+        }
+    }
+}

--- a/src/Commands/Enums/DisableSpacesScope.cs
+++ b/src/Commands/Enums/DisableSpacesScope.cs
@@ -1,0 +1,18 @@
+﻿namespace PnP.PowerShell.Commands.Enums
+{
+    /// <summary>
+    /// Available scopes for disabling SharePoint Spaces functionality
+    /// </summary>
+    public enum DisableSpacesScope
+    {
+        /// <summary>
+        /// Disable on the entire tenant
+        /// </summary>
+        Tenant = 0,
+
+        /// <summary>
+        /// Disable on a specific site
+        /// </summary>
+        Site = 1
+    }
+}


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Added cmdlets for disabling SharePoint Spaces:
`Get-PnPDisableSpacesActivation`
`Set-PnPDisableSpacesActivation`

Note that CSOM does support setting this on an individual site collection but provides no API for getting the current value for a specific site collection, only for the tenant wide setting. Same applies to the SPO Management Shell module.