### PR TITLE
Fix content type not set while updating list item

### DIFF
--- a/src/Commands/Lists/SetListItem.cs
+++ b/src/Commands/Lists/SetListItem.cs
@@ -118,12 +118,11 @@ namespace PnP.PowerShell.Commands.Lists
                     if (ContentType != null)
                     {
                         ContentType ct = ContentType.GetContentType(list);
-
                         if (ct != null)
                         {
-
                             item["ContentTypeId"] = ct.EnsureProperty(w => w.StringId); ;
-                            updateRequired = true;
+                            ListItemHelper.UpdateListItem(item, UpdateType);
+                            ClientContext.ExecuteQueryRetry();
                         }
                     }
                     if (Values != null)


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
NA

## What is in this Pull Request ? ##

Currently while using this code:
```
Set-PnPListItem -List "test" -Identity 1 -ContentType "Custom CT" -Values @{			
			"Title" = "Update title"
			"Description"="desc"
		} | Out-Null
```
the values are updated but the content type is not set.

This PR fixes that issue, behavior is similar to that used in Add-PnPListItem, Add-PnPPage and Set-PnPPage.

