### PR TITLE
Updated Get-PnPAAdUser to allow retrieval of all users

### DIFF
--- a/documentation/Get-PnPAADUser.md
+++ b/documentation/Get-PnPAADUser.md
@@ -21,7 +21,7 @@ Retrieves users from Azure Active Directory
 
 ### Return a list (Default)
 ```powershell
-Get-PnPAADUser [-Filter <String>] [-OrderBy <String>] [-Select <String[]>] [<CommonParameters>]
+Get-PnPAADUser [-Filter <String>] [-OrderBy <String>] [-Select <String[]>] [-StartIndex <Int32>] [-EndIndex<Int32>] [<CommonParameters>]
 ```
 
 ### Return by specific ID
@@ -31,7 +31,7 @@ Get-PnPAADUser [-Identity <String>] [-Select <String[]>] [<CommonParameters>]
 
 ### Return the delta
 ```powershell
-Get-PnPAADUser [-Filter <String>] [-OrderBy <String>] [-Select <String[]>] [-Delta] [-DeltaToken <String>] [<CommonParameters>]
+Get-PnPAADUser [-Filter <String>] [-OrderBy <String>] [-Select <String[]>] [-Delta] [-DeltaToken <String>] [-StartIndex <Int32>] [-EndIndex<Int32>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -43,56 +43,70 @@ Get-PnPAADUser [-Filter <String>] [-OrderBy <String>] [-Select <String[]>] [-Del
 Get-PnPAADUser
 ```
 
-Retrieves all users from Azure Active Directory
+Retrieves the first 1000 users from Azure Active Directory
 
 ### EXAMPLE 2
+```powershell
+Get-PnPAADUser -EndIndex $null
+```
+
+Retrieves all users from Azure Active Directory
+
+### EXAMPLE 3
 ```powershell
 Get-PnPAADUser -Identity 328c7693-5524-44ac-a946-73e02d6b0f98
 ```
 
 Retrieves the user from Azure Active Directory with the id 328c7693-5524-44ac-a946-73e02d6b0f98
 
-### EXAMPLE 3
+### EXAMPLE 4
 ```powershell
 Get-PnPAADUser -Identity john@contoso.com
 ```
 
 Retrieves the user from Azure Active Directory with the user principal name john@contoso.com
 
-### EXAMPLE 4
+### EXAMPLE 5
 ```powershell
 Get-PnPAADUser -Identity john@contoso.com -Select "DisplayName","extension_3721d05137db455ad81aa442e3c2d4f9_extensionAttribute1"
 ```
 
 Retrieves only the DisplayName and extensionAttribute1 properties of the user from Azure Active Directory which has the user principal name john@contoso.com
 
-### EXAMPLE 5
+### EXAMPLE 6
 ```powershell
 Get-PnPAADUser -Filter "accountEnabled eq false"
 ```
 
 Retrieves all the disabled users from Azure Active Directory
 
-### EXAMPLE 6
+### EXAMPLE 7
 ```powershell
 Get-PnPAADUser -Filter "startswith(DisplayName, 'John')" -OrderBy "DisplayName"
 ```
 
 Retrieves all the users from Azure Active Directory of which their DisplayName starts with 'John' and sort the results by the DisplayName
 
-### EXAMPLE 7
+### EXAMPLE 8
 ```powershell
 Get-PnPAADUser -Delta
 ```
 
 Retrieves all the users from Azure Active Directory and include a delta DeltaToken which can be used by providing -DeltaToken <token> to query for changes to users in Active Directory since this run
 
-### EXAMPLE 8
+### EXAMPLE 9
 ```powershell
 Get-PnPAADUser -Delta -DeltaToken abcdef
 ```
 
 Retrieves all the users from Azure Active Directory which have had changes since the provided DeltaToken was given out
+
+### EXAMPLE 10
+```powershell
+Get-PnPAADUser -StartIndex 10 -EndIndex 20
+```
+
+Retrieves the 10th through the 20th user from Azure Active Directory
 
 ## PARAMETERS
 
@@ -176,6 +190,34 @@ Parameter Sets: (All)
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -StartIndex
+Allows defining the first result to return. Useful for i.e. paging.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EndIndex
+Allows defining the last result to return. Useful for i.e. pagina. If omitted, it will use 999. If set to $null, it will return all users from Azure Active Directory.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: 999
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/src/Commands/Graph/GetAADUser.cs
+++ b/src/Commands/Graph/GetAADUser.cs
@@ -37,6 +37,14 @@ namespace PnP.PowerShell.Commands.Graph
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_DELTA)]
         public string DeltaToken;
 
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_LIST)]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_DELTA)]
+        public int StartIndex = 0;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_LIST)]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_DELTA)]
+        public int? EndIndex = 999;
+
         protected override void ExecuteCmdlet()
         {
             if (PnPConnection.CurrentConnection.ClientId == PnPConnection.PnPManagementShellClientId)
@@ -58,12 +66,12 @@ namespace PnP.PowerShell.Commands.Graph
             }
             else if (ParameterSpecified(nameof(Delta)))
             {
-                PnP.Framework.Graph.Model.UserDelta userDelta = PnP.Framework.Graph.UsersUtility.ListUserDelta(AccessToken, DeltaToken, Filter, OrderBy, Select);
+                PnP.Framework.Graph.Model.UserDelta userDelta = PnP.Framework.Graph.UsersUtility.ListUserDelta(AccessToken, DeltaToken, Filter, OrderBy, Select, StartIndex, EndIndex);
                 WriteObject(userDelta);
             } 
             else
             {
-                List<PnP.Framework.Graph.Model.User> users = PnP.Framework.Graph.UsersUtility.ListUsers(AccessToken, Filter, OrderBy, Select);
+                List<PnP.Framework.Graph.Model.User> users = PnP.Framework.Graph.UsersUtility.ListUsers(AccessToken, Filter, OrderBy, Select, StartIndex, EndIndex);
                 WriteObject(users, true);
             }
         }


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Updated `Get-PnPAAdUser` to allow retrieval of all users. The current implementation only returns the first 1000 users in an Azure Active Directory due to the default EndIndex of 999 in the underlying PnP Framework. Changed the implementation in PnP Framework through [PR #157](https://github.com/pnp/pnpframework/pull/157) to allow the EndIndex to be nullable in which case it will return all available results from Azure Active Directory. For backwards compatibility in PnP PowerShell when using `Get-PnPAadUser`, I have made it so that the current cmdlet still returns the first 1000 results and only if `-EndIndex $null` is provided it will return all users.