### PR TITLE
Fix Set-PnPTeamsTeamArchivedState throwing a NullReferenceException

### DIFF
--- a/src/Commands/Base/PipeBinds/TeamsTeamPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/TeamsTeamPipeBind.cs
@@ -80,7 +80,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             {
                 if (!string.IsNullOrEmpty(_id))
                 {
-                    return GraphHelper.GetAsync<Team>(httpClient, $"v1.0/teams/{_id}", accessToken).GetAwaiter().GetResult();
+                    return GraphHelper.GetAsync<Team>(httpClient, $"v1.0/teams/{_id}", accessToken, false).GetAwaiter().GetResult();
                 }
                 else
                 {
@@ -89,7 +89,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
                     {
                         if (collection.Items.Count() == 1)
                         {
-                            return GraphHelper.GetAsync<Team>(httpClient, $"v1.0/teams/{collection.Items.First().Id}", accessToken).GetAwaiter().GetResult();
+                            return GraphHelper.GetAsync<Team>(httpClient, $"v1.0/teams/{collection.Items.First().Id}", accessToken, false).GetAwaiter().GetResult();
                         }
                         else
                         {
@@ -101,7 +101,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
                         collection = GraphHelper.GetAsync<RestResultCollection<Model.Graph.Group>>(httpClient, $"beta/groups?$filter=(resourceProvisioningOptions/Any(x:x eq 'Team') and mailNickname eq '{_stringValue}')&$select=Id", accessToken).GetAwaiter().GetResult();
                         if (collection != null && collection.Items.Count() == 1)
                         {
-                            return GraphHelper.GetAsync<Team>(httpClient, $"v1.0/teams/{collection.Items.First().Id}", accessToken).GetAwaiter().GetResult();
+                            return GraphHelper.GetAsync<Team>(httpClient, $"v1.0/teams/{collection.Items.First().Id}", accessToken, false).GetAwaiter().GetResult();
                         }
                     }
                 }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes a NullReferenceException not yet reported on GitHub.

## What is in this Pull Request ? ##
Fix Set-PnPTeamsTeamArchivedState throwing a NullReferenceException happening when retrieving the Team from Graph caused by parsing the json response with CamelCase policy.
This PR applies the same changes as d31a6bc6edc624aa632f1f79190b82fd5954a91d to other places that retrieve a Team.
