### PR TITLE
Replace Thread.Sleep() with Task.Delay() in async methods

### DIFF
--- a/src/Commands/Utilities/CopyMover.cs
+++ b/src/Commands/Utilities/CopyMover.cs
@@ -61,8 +61,8 @@ namespace PnP.PowerShell.Commands.Utilities
                     }
                     while (copyJob.JobState != 0)
                     {
-                        // sleep 5 seconds
-                        System.Threading.Thread.Sleep(1000);
+                        // sleep 1 second
+                        await Task.Delay(1000);
                         copyJob = await Utilities.REST.RestHelper.PostAsync<CopyMigrationJob>(httpClient, $"{currentContextUri}/_api/site/GetCopyJobProgress", clientContext, copyJobInfo, false);
                     }
                     foreach (var log in copyJob.Logs)
@@ -90,8 +90,8 @@ namespace PnP.PowerShell.Commands.Utilities
                 {
                     while (copyJob.JobState != 0)
                     {
-                        // sleep 5 seconds
-                        System.Threading.Thread.Sleep(1000);
+                        // sleep 1 second
+                        await Task.Delay(1000);
                         copyJob = await Utilities.REST.RestHelper.PostAsync<CopyMigrationJob>(httpClient, $"{currentContextUri}/_api/site/GetCopyJobProgress", clientContext, copyJobInfo, false);
                     }
                 }

--- a/src/Commands/Utilities/REST/GraphHelper.cs
+++ b/src/Commands/Utilities/REST/GraphHelper.cs
@@ -303,7 +303,7 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             {
                 // throttled
                 var retryAfter = response.Headers.RetryAfter;
-                Thread.Sleep(retryAfter.Delta.Value.Seconds * 1000);
+                await Task.Delay(retryAfter.Delta.Value.Seconds * 1000);
                 response = await httpClient.SendAsync(CloneMessage(message));
             }
             if (response.IsSuccessStatusCode)
@@ -328,7 +328,7 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             {
                 // throttled
                 var retryAfter = response.Headers.RetryAfter;
-                Thread.Sleep(retryAfter.Delta.Value.Seconds * 1000);
+                await Task.Delay(retryAfter.Delta.Value.Seconds * 1000);
                 response = await httpClient.SendAsync(CloneMessage(message));
             }
             return response;

--- a/src/Commands/Utilities/REST/RestHelper.cs
+++ b/src/Commands/Utilities/REST/RestHelper.cs
@@ -546,7 +546,7 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             {
                 // throttled
                 var retryAfter = response.Headers.RetryAfter;
-                Thread.Sleep(retryAfter.Delta.Value.Seconds * 1000);
+                await Task.Delay(retryAfter.Delta.Value.Seconds * 1000);
                 response = await httpClient.SendAsync(CloneMessage(message));
             }
             if (response.IsSuccessStatusCode)

--- a/src/Commands/Utilities/TeamsUtility.cs
+++ b/src/Commands/Utilities/TeamsUtility.cs
@@ -140,7 +140,7 @@ namespace PnP.PowerShell.Commands.Utilities
                     catch (Exception)
                     {
                         // In case of exception wait for 5 secs
-                        System.Threading.Thread.Sleep(TimeSpan.FromSeconds(5));
+                        await Task.Delay(TimeSpan.FromSeconds(5));
                     }
 
                     // Don't wait more than 1 minute
@@ -179,7 +179,7 @@ namespace PnP.PowerShell.Commands.Utilities
 
                     catch (Exception)
                     {
-                        System.Threading.Thread.Sleep(5000);
+                        await Task.Delay(5000);
                         iteration++;
                     }
 


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
No referenced github issues

## What is in this Pull Request ? ##
Replace Thread.Sleep() with Task.Delay() in async methods as Thread.Sleep() suspends the current thread that, in case of async methods, could be a thread-pool thread, not allowing it to process other tasks.
