### PR TITLE
Fix the RSACng cast issue

### DIFF
--- a/src/Commands/Base/PnPConnectionHelper.cs
+++ b/src/Commands/Base/PnPConnectionHelper.cs
@@ -402,8 +402,11 @@ namespace PnP.PowerShell.Commands.Base
             }
             if (Utilities.OperatingSystem.IsWindows())
             {
-                var privateKey = (RSACryptoServiceProvider)certificate.PrivateKey;
-                string uniqueKeyContainerName = privateKey.CspKeyContainerInfo.UniqueKeyContainerName;
+                var privateKey = (certificate.PrivateKey as RSACng)?.Key;
+                if (privateKey == null)
+                    return;
+
+                string uniqueKeyContainerName = privateKey.UniqueName;
                 certificate.Reset();
 
                 var programDataPath = Environment.GetEnvironmentVariable("ProgramData");


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
None that I am aware of - the issue was introduced in my recent [PR 249](https://github.com/pnp/powershell/pull/249)

## What is in this Pull Request ? ##
When running the Disconnect-PnPOnline cmdlet on a connection that was initiated with a AAD App (certificate on the filesystem), the certificate.PrivateKey cannot be cast to RSACryptoServiceProvider as it is currently of type RSACng. Therefore, this PR safely casts to RSACng so the temp cert file can be cleaned up.

@erwinvanhunen sorry I missed this on my original [PR 249](https://github.com/pnp/powershell/pull/249)
