### PR TITLE
Updated  Restore-PnPRecycleBinItem documentation

### DIFF
--- a/documentation/Restore-PnPRecycleBinItem.md
+++ b/documentation/Restore-PnPRecycleBinItem.md
@@ -39,10 +39,10 @@ Restores all the items in the first and second stage recycle bins to their origi
 
 ### EXAMPLE 3
 ```powershell
-Restore-PnPRecycleBinItem -All -RowLimit 10000
+Get-PnPRecycleBinItem -RowLimit 10000 | Restore-PnPRecycleBinItem -Force
 ```
 
-Permanently restores up to 10,000 items in the recycle bin
+Permanently restores up to 10,000 items in the recycle bin without asking for confirmation.
 
 ## PARAMETERS
 


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Mentioned in https://github.com/pnp/powershell/issues/273#issuecomment-778841403

## What is in this Pull Request ? ##
Updated the documentation for Restore-PnPRecycleBinItem to remove -All parameter which is no longer there.

Although I'm not sure on what the behaviour should be for Restore-PnPRecycleBinItem on it's own? Should it restore all items without the need for a piped input or -Identity parameter? Would you use -RowLimit to limit the amount of items returned and restored? I note -Identity is a required field which means it doesn't allow this behaviour.


