### PR TITLE
Solving inconsistency with Set-PnPTenantSite -NoScriptSite

### DIFF
--- a/documentation/Set-PnPTenantSite.md
+++ b/documentation/Set-PnPTenantSite.md
@@ -75,10 +75,10 @@ This will add user1@contoso.onmicrosoft.com and user2@contoso.onmicrosoft.com as
 
 ### EXAMPLE 5
 ```powershell
-Set-PnPTenantSite -Identity "https://contoso.sharepoint.com/sites/sales" -NoScriptSite:$false
+Set-PnPTenantSite -Identity "https://contoso.sharepoint.com/sites/sales" -DenyAddAndCustomizePages:$false
 ```
 
-This will enable script support for the site 'https://contoso.sharepoint.com/sites/sales' if disabled.
+This will enable script support for the site 'https://contoso.sharepoint.com/sites/sales'
 
 ## PARAMETERS
 

--- a/src/Commands/Admin/SetTenantSite.cs
+++ b/src/Commands/Admin/SetTenantSite.cs
@@ -37,6 +37,7 @@ namespace PnP.PowerShell.Commands
         public List<string> Owners;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        [Alias("NoScriptSite")]
         public SwitchParameter DenyAddAndCustomizePages;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
https://github.com/pnp/powershell/issues/224

## What is in this Pull Request ? ##
Fixes situation described in https://github.com/pnp/powershell/issues/224 by adding the alias which was in the documentation but not in the cmdlet and updating the sample in the documentation to use the primary attribute instead of the alias.

@erwinvanhunen Do we need to mark -NoScriptSite as deprecated as well or is it fine like this?