### PR TITLE
#299 - improved the logging message in consent URL

### DIFF
--- a/documentation/Register-PnPManagementShellAccess.md
+++ b/documentation/Register-PnPManagementShellAccess.md
@@ -39,14 +39,14 @@ Register-PnPManagementShellAccess
 Register-PnPManagementShellAccess -ShowConsentUrl
 ```
 
-Launches the consent flow to grant the PnP Management Shell Azure AD Application delegate access to the tenant and also displays the consent URL which can be shared with Azure AD administrators, Global administrators or folks with necessary permissions.
+Launches the consent flow to grant the PnP Management Shell Azure AD Application delegate access to the tenant and also displays the consent URL which can be shared with Azure AD administrators or Global administrators.
 
 ### EXAMPLE 3
 ```powershell
 Register-PnPManagementShellAccess -ShowConsentUrl -TenantName yourtenant.onmicrosoft.com
 ```
 
-Displays the consent URL which can be shared with Azure AD admininstrators, Global administrators or folks with necessary permissions.
+Displays the consent URL which can be shared with Azure AD administrators or Global administrators.
 
 ## PARAMETERS
 
@@ -78,7 +78,7 @@ Accept wildcard characters: False
 ```
 
 ### -TenantName
-The name of the tenant.
+The name of the tenant. Example - ( yourtenant.onmicrosoft.com)
 
 ```yaml
 Type: SwitchParameter

--- a/documentation/Register-PnPManagementShellAccess.md
+++ b/documentation/Register-PnPManagementShellAccess.md
@@ -34,7 +34,19 @@ This cmdlet grants access to the tenant for the PnP Management Shell Multi-Tenan
 Register-PnPManagementShellAccess
 ```
 
-Launches the consent flow to grant the PnP Management Shell Azure AD Application delegate access to the tenant.
+### EXAMPLE 2
+```powershell
+Register-PnPManagementShellAccess -ShowConsentUrl
+```
+
+Launches the consent flow to grant the PnP Management Shell Azure AD Application delegate access to the tenant and also displays the consent URL which can be shared with Azure AD administrators, Global administrators or folks with necessary permissions.
+
+### EXAMPLE 3
+```powershell
+Register-PnPManagementShellAccess -ShowConsentUrl -TenantName yourtenant.onmicrosoft.com
+```
+
+Displays the consent URL which can be shared with Azure AD admininstrators, Global administrators or folks with necessary permissions.
 
 ## PARAMETERS
 
@@ -61,6 +73,19 @@ Accepted values: Production, PPE, China, Germany, USGovernment
 Required: False
 Position: Named
 Default value: Production
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TenantName
+The name of the tenant.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Show Consent Url
+
+Required: False
+Position: Named
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/src/Commands/Base/RegisterManagementShellAccess.cs
+++ b/src/Commands/Base/RegisterManagementShellAccess.cs
@@ -73,7 +73,7 @@ namespace PnP.PowerShell.Commands.Base
                     failureMessageHtml: $"You failed to login succesfully. Feel free to close this browser window.",
                                         azureEnvironment: AzureEnvironment))
                     {
-                        var tenantId = "{azure-tenant-id}";
+                        var tenantId = "{M365-Tenant-Id}";
                         var accessToken = string.Empty;
                         try
                         {
@@ -114,6 +114,10 @@ namespace PnP.PowerShell.Commands.Base
                             }
                         }
                         messageWriter.WriteMessage($"Share the following URL with a person that has appropriate access rights on the Azure AD to grant consent for Application Registrations:\n\nhttps://login.microsoftonline.com/{tenantId}/adminconsent?client_id={PnPConnection.PnPManagementShellClientId}");
+                        if (tenantId == "{M365-Tenant-Id}")
+                        {
+                            messageWriter.WriteMessage($"To get M365-Tenant-Id value, use the Get-PnPTenantId cmdlet:\nhttps://pnp.github.io/powershell/cmdlets/Get-PnPTenantId.html");
+                        }
                     }
                 }
                 messageWriter.Finished = true;


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
#299 

## What is in this Pull Request ? ##
- Improved the consent URL logging message.
- Replaced Azure Tenant Id with M365 Tenant Id to avoid confusion. Some M365 tenants don't necessarily have Azure subscription.
- Added additional help message to point to docs on how to get the actual value of the Tenant Id.