### PR TITLE
Fix #516 - Added retry for SharePoint site url delays

### DIFF
--- a/src/Commands/Utilities/Microsoft365GroupsUtility.cs
+++ b/src/Commands/Utilities/Microsoft365GroupsUtility.cs
@@ -66,11 +66,38 @@ namespace PnP.PowerShell.Commands.Utilities
             var group = await GraphHelper.GetAsync<Microsoft365Group>(httpClient, $"v1.0/groups/{groupId}", accessToken);
             if (includeSiteUrl)
             {
-                var siteUrlResult = await GraphHelper.GetAsync(httpClient, $"v1.0/groups/{group.Id}/sites/root?$select=webUrl", accessToken);
-                var resultElement = JsonSerializer.Deserialize<JsonElement>(siteUrlResult);
-                if (resultElement.TryGetProperty("webUrl", out JsonElement webUrlElement))
+                bool wait = true;
+                var iterations = 0;
+
+                while (wait)
                 {
-                    group.SiteUrl = webUrlElement.GetString();
+                    iterations++;
+                    try
+                    {
+                        var siteUrlResult = await GraphHelper.GetAsync(httpClient, $"v1.0/groups/{group.Id}/sites/root?$select=webUrl", accessToken);
+                        if (!string.IsNullOrEmpty(siteUrlResult))
+                        {
+                            wait = false;
+                            var resultElement = JsonSerializer.Deserialize<JsonElement>(siteUrlResult);
+                            if (resultElement.TryGetProperty("webUrl", out JsonElement webUrlElement))
+                            {
+                                group.SiteUrl = webUrlElement.GetString();
+                            }
+                            break;
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        if (iterations * 30 >= 300)
+                        {
+                            wait = false;
+                            throw;
+                        }
+                        else
+                        {
+                            await Task.Delay(TimeSpan.FromSeconds(30));
+                        }
+                    }
                 }
             }
             if (includeOwners)


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #516

## What is in this Pull Request ? ##
While provisioning M365 groups, there is some delay in provisioning SP sites, so added a retry mechanism to handle that delay.

