### PR TITLE
Fix #530 , Added retry for new groups properties

### DIFF
--- a/src/Commands/AzureAD/SetAzureADGroup.cs
+++ b/src/Commands/AzureAD/SetAzureADGroup.cs
@@ -68,7 +68,7 @@ namespace PnP.PowerShell.Commands.Graph
                     if (ParameterSpecified(nameof(HideFromAddressLists)) || ParameterSpecified(nameof(HideFromOutlookClients)))
                     {
                         // For this scenario a separate call needs to be made
-                        GroupsUtility.SetGroupVisibility(group.Id, AccessToken, HideFromAddressLists, HideFromOutlookClients);
+                        Utilities.Microsoft365GroupsUtility.SetVisibilityAsync(HttpClient, AccessToken, new Guid(group.Id), HideFromAddressLists, HideFromOutlookClients).GetAwaiter().GetResult();
                     }
                 }
                 catch(Exception e)

--- a/src/Commands/Utilities/Microsoft365GroupsUtility.cs
+++ b/src/Commands/Utilities/Microsoft365GroupsUtility.cs
@@ -535,7 +535,28 @@ namespace PnP.PowerShell.Commands.Utilities
                 hideFromAddressLists = hideFromAddressLists,
                 hideFromOutlookClients = hideFromOutlookClients
             };
-            await GraphHelper.PatchAsync(httpClient, accessToken, $"v1.0/groups/{groupId}", patchData);
+
+            var retry = true;
+            var iteration = 0;
+            while (retry)
+            {
+                try
+                {
+                    await GraphHelper.PatchAsync<dynamic>(httpClient, accessToken, $"v1.0/groups/{groupId}", patchData);
+                    retry = false;
+                }
+
+                catch (Exception)
+                {
+                    await Task.Delay(5000);
+                    iteration++;
+                }
+
+                if (iteration > 10) // don't try more than 10 times
+                {
+                    retry = false;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Type ##
- [x ] Bug Fix
- [ x] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #530

## What is in this Pull Request ? ##

Fixes #530.
Added retry for setting properties, it throws 404 error currently for `New-PnPMicrosoft365Group` cmdlet if we set `HideFromOutlookClients` or `HideFromAddressLists` properties