### PR TITLE
Usage clarification for GetDocumentMetadataViaSiteIdUniqueId.ps1

### DIFF
--- a/samples/MetadataViaSiteIdUniqueId/GetDocumentMetadataViaSiteIdUniqueId.ps1
+++ b/samples/MetadataViaSiteIdUniqueId/GetDocumentMetadataViaSiteIdUniqueId.ps1
@@ -1,3 +1,12 @@
+<############################################################################################
+    This script running requires an interactive session to retrieve the data properly,
+    you should use the interactive paramenter with the Connect-PnPOnline, i.e.:
+        Connect-PnPOnline -Url https://contoso.sharepoint.com -Interactive
+    
+    To learn more about usage of this script see:
+    https://github.com/pnp/powershell/blob/f3a46f8b8b3c326b12da56b04ec931fdd65bf30c/samples/MetadataViaSiteIdUniqueId/readme.md
+#############################################################################################>
+
 Param(
     [String] $SiteId,
     [String] $DocId


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [x] Sample

## Related Issues? ##
None

## What is in this Pull Request ? ##
Many customers are trying to use this script following a non-interactive PnP Connection, which is leading them to raise support tickets. Without the "interactive" parameter in the connection the result will always be this error: "Submit-PnPSearchQuery : Sequence contains no elements"

### Guidance ###
Added comments to improve the usage experience.
