### PR TITLE
Changing the Url paramameter to HomeSiteUrl in Set-PnPHomeSite

### DIFF
--- a/documentation/Set-PnPHomeSite.md
+++ b/documentation/Set-PnPHomeSite.md
@@ -67,4 +67,4 @@ Accept wildcard characters: False
 ## RELATED LINKS
 
 [Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)
-[Set up a home site for your organization](https://docs.microsoft.com/en-us/sharepoint/home-site)
+[Set up a home site for your organization](https://docs.microsoft.com/sharepoint/home-site)

--- a/documentation/Set-PnPHomeSite.md
+++ b/documentation/Set-PnPHomeSite.md
@@ -15,12 +15,12 @@ online version: https://pnp.github.io/powershell/cmdlets/Set-PnPHomeSite.html
 
 * SharePoint: Access to the SharePoint Tenant Administration site
 
-Sets the home site for your tenant
+Sets the home site for your tenant. The home site needs to be a communication site.
 
 ## SYNTAX
 
 ```powershell
-Set-PnPHomeSite -Url <String> [-Connection <PnPConnection>] [<CommonParameters>]
+Set-PnPHomeSite -HomeSiteUrl <String> [-Connection <PnPConnection>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -29,7 +29,7 @@ Set-PnPHomeSite -Url <String> [-Connection <PnPConnection>] [<CommonParameters>]
 
 ### EXAMPLE 1
 ```powershell
-Set-PnPHomeSite -Url "https://yourtenant.sharepoint.com/sites/myhome"
+Set-PnPHomeSite -HomeSiteUrl "https://yourtenant.sharepoint.com/sites/myhome"
 ```
 
 Sets the home site to the provided site collection url
@@ -50,7 +50,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Url
+### -HomeSiteUrl
 The url of the site to set as the home site
 
 ```yaml
@@ -67,4 +67,4 @@ Accept wildcard characters: False
 ## RELATED LINKS
 
 [Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)
-
+[Set up a home site for your organization](https://docs.microsoft.com/en-us/sharepoint/home-site)

--- a/src/Commands/Admin/SetHomeSite.cs
+++ b/src/Commands/Admin/SetHomeSite.cs
@@ -8,12 +8,13 @@ namespace PnP.PowerShell.Commands.Admin
     [Cmdlet(VerbsCommon.Set, "PnPHomeSite")]
     public class SetHomeSite : PnPAdminCmdlet
     {
+        [Alias("Url")]
         [Parameter(Mandatory = true)]
-        public string Url;
+        public string HomeSiteUrl;
 
         protected override void ExecuteCmdlet()
         {
-            Tenant.SetSPHSite(Url);
+            Tenant.SetSPHSite(HomeSiteUrl);
             ClientContext.ExecuteQueryRetry();
         }
     }


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample
- [X] SPO Management Shell parity

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Changing the Url paramameter to HomeSiteUrl to match with the SPO Management Shell. Added an alias for Url for backwards compatibility.

https://docs.microsoft.com/en-us/sharepoint/home-site#set-a-site-as-your-home-site