### PR TITLE
Fixed JSON parsing of GroupVisibility enum to solve Issue #613

### DIFF
--- a/src/Commands/Model/Teams/Team.cs
+++ b/src/Commands/Model/Teams/Team.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using PnP.PowerShell.Commands.Model.Graph;
 
 namespace PnP.PowerShell.Commands.Model.Teams
@@ -79,6 +80,7 @@ namespace PnP.PowerShell.Commands.Model.Teams
         /// </summary>
         public string Description { get; set; }
 
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public GroupVisibility? Visibility { get; set; }
 
         #endregion


### PR DESCRIPTION
## Type ##
- [x ] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #613

## What is in this Pull Request ? ##
Added JsonConvert decoration for the GroupVisibility property on the Teams model, to enable Json conversion.

