### PR TITLE
Updating Invoke-PnPQuery Documentation to reflect -RetryWait parameter no longer being available

### DIFF
--- a/documentation/Invoke-PnPQuery.md
+++ b/documentation/Invoke-PnPQuery.md
@@ -15,7 +15,7 @@ Executes the currently queued actions
 ## SYNTAX
 
 ```powershell
-Invoke-PnPQuery [-RetryCount <Int32>] [-RetryWait <Int32>] [-Connection <PnPConnection>] [<CommonParameters>]
+Invoke-PnPQuery [-RetryCount <Int32>] [-Connection <PnPConnection>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -29,13 +29,6 @@ Invoke-PnPQuery -RetryCount 5
 ```
 
 This will execute any queued actions / changes on the SharePoint Client Side Object Model Context and will retry 5 times in case of throttling.
-
-### EXAMPLE 2
-```powershell
-Invoke-PnPQuery -RetryWait 10
-```
-
-This will execute any queued actions / changes on the SharePoint Client Side Object Model Context and delay the execution for 10 seconds before it retries the execution.
 
 ## PARAMETERS
 
@@ -67,19 +60,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -RetryWait
-Delay in seconds. Defaults to 1.
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
 
 ## RELATED LINKS
 


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##


## What is in this Pull Request ? ##
Just been using Invoke-PnPQuery and it appears -RetryWait is missing but this appears on the documentation. So I have corrected the documentation

Checking the code page https://github.com/pnp/powershell/blob/dev/src/Commands/Base/InvokeQuery.cs and it appears there is no longer a -RetryWait parameter.

Happy for this Pull Request to be deleted if -RetryWait has accidently been deleted from the code.

Thanks


