### PR TITLE
Improve error message in Find-PnPFile when the specified list/folder is not found

### DIFF
--- a/src/Commands/Files/FindFile.cs
+++ b/src/Commands/Files/FindFile.cs
@@ -1,4 +1,5 @@
-﻿using System.Management.Automation;
+﻿using System;
+using System.Management.Automation;
 using Microsoft.SharePoint.Client;
 
 using PnP.PowerShell.Commands.Base.PipeBinds;
@@ -26,12 +27,16 @@ namespace PnP.PowerShell.Commands.Files
                 case "List":
                 {
                     var list = List.GetList(CurrentWeb);
+                    if (list == null)
+                        throw new ArgumentException("The specified list was not found");
                     WriteObject(list.FindFiles(Match));
                     break;
                 }
                 case "Folder":
                 {
                     var folder = Folder.GetFolder(CurrentWeb);
+                    if (folder == null)
+                        throw new ArgumentException("The specified folder was not found");
                     WriteObject(folder.FindFiles(Match));
                     break;
                 }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
None

## What is in this Pull Request ? ##
This PR improves the error message displayed by Find-PnPFile cmdlet when passing a list or folder that don't exist.

Before this PR the error message would be "Object reference not set to an instance of an object" when specifying a list that doesn't exist and "File Not Found" when a folder doesn't exist:
![image](https://user-images.githubusercontent.com/1153754/119850527-ec028400-bf0d-11eb-9339-94b89d60a5fc.png)

With this PR the error message for the List case changes to "The specified list was not found":
![image](https://user-images.githubusercontent.com/1153754/119849524-fe2ff280-bf0c-11eb-8ce7-5a867c009aa7.png)

The Folder case still shows the same message because FolderPipeBind.GetFolder() calls web.GetFolderByServerRelativePath(), then Load() the result and finally calls web.Context.ExecuteQueryRetry() which triggers a ServerException. It might be good to make FolderPipeBind.GetFolder() return null if a ServerException happens but that fits better in another PR, even better if a maintainer decides how to handle the case.
For now I left the code handling a null folder object anyway.

Please let me know if I should change anything.