### PR TITLE
Add document template to content type

### DIFF
--- a/documentation/Add-PnPContentType.md
+++ b/documentation/Add-PnPContentType.md
@@ -30,6 +30,13 @@ Add-PnPContentType -Name "Project Document" -Description "Use for Contoso projec
 
 This will add a new content type based on the parent content type stored in the $ct variable.
 
+### EXAMPLE 2
+```powershell
+Add-PnPContentType -Name "Project Document" -Description "Use for Contoso projects" -Group "Contoso Content Types" -ParentContentType (Get-PnPContentType -Identity 0x0101) -DocumentTemplate "/_cts/Project Document/template.docx"
+```
+
+This will add a new content type based on the standard document content type and assigns the document template template.docx to it
+
 ## PARAMETERS
 
 ### -Connection
@@ -116,7 +123,19 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -DocumentTemplate
+Allows providing a server relative path to a file which should be used as the document template for this content type
 
+```yaml
+Type: String
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ## RELATED LINKS
 

--- a/src/Commands/ContentTypes/AddContentType.cs
+++ b/src/Commands/ContentTypes/AddContentType.cs
@@ -22,14 +22,22 @@ namespace PnP.PowerShell.Commands.ContentTypes
         [Parameter(Mandatory = false)]
         public ContentType ParentContentType;
 
+        [Parameter(Mandatory = false)]
+        public string DocumentTemplate;        
+
         protected override void ExecuteCmdlet()
         {
             var ct = CurrentWeb.CreateContentType(Name, Description, ContentTypeId, Group, ParentContentType);
+
+            if (ParameterSpecified(nameof(DocumentTemplate)))
+            {
+                ct.DocumentTemplate = DocumentTemplate;
+                ct.Update(true);
+            }
+
             ClientContext.Load(ct);
             ClientContext.ExecuteQueryRetry();
             WriteObject(ct);
         }
-
-
     }
 }

--- a/src/Commands/Files/AddFile.cs
+++ b/src/Commands/Files/AddFile.cs
@@ -4,9 +4,7 @@ using System.Management.Automation;
 using Microsoft.SharePoint.Client;
 using PnP.Framework.Utilities;
 using PnP.PowerShell.Commands.Base.PipeBinds;
-using System;
 using PnP.PowerShell.Commands.Utilities;
-using PnP.PowerShell.Commands.Enums;
 
 namespace PnP.PowerShell.Commands.Files
 {
@@ -158,7 +156,16 @@ namespace PnP.PowerShell.Commands.Files
             }
 
             ClientContext.Load(file);
-            ClientContext.ExecuteQueryRetry();
+            try
+            {
+                ClientContext.ExecuteQueryRetry();
+            }
+            catch (ServerException)
+            {
+                // Can happen when uploading a file to a location not residing inside a document library, such as to the _cts folder. Switch to fallback option so that the upload doesn't result in an error.
+                ClientContext.Load(file, f => f.Length, f => f.Name, f => f.TimeCreated, f => f.TimeLastModified, f => f.Title);
+                ClientContext.ExecuteQueryRetry();
+            }
             WriteObject(file);
         }
 


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
- Added `-DocumentTemplate` flag to `Add-PnPContentType` which allows setting a document template on a new content type
- Added fallback option in `Add-PnPFile` for the scenario where a file is uploaded to a non document library location such as the _cts folder for content types. This would previously upload the file, but still throw an exception. With this fix, it will not throw the exception anymore.