### PR TITLE
Update Submit-PnPTeamsChannelMessage.md

### DIFF
--- a/documentation/Submit-PnPTeamsChannelMessage.md
+++ b/documentation/Submit-PnPTeamsChannelMessage.md
@@ -13,7 +13,7 @@ online version: https://pnp.github.io/powershell/cmdlets/Submit-PnPTeamsChannelM
 
 **Required Permissions**
 
-  * Microsoft Graph API: Group.ReadWrite.All
+  * Microsoft Graph API: API required one of 'Teamwork.Migrate.All, ChannelMessage.ReadWrite.All'.
 
 Sends a message to a Microsoft Teams Channel.
 


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [x] Sample

## Related Issues? ##
None

## What is in this Pull Request ? ##
Fix required permission on doc, as the command currently warn with the previously writed permission (Group.ReadWrite.All) : 
Submit-PnPTeamsChannelMessage: Missing role permissions on the request. API required one of 'Teamwork.Migrate.All, ChannelMessage.ReadWrite.All'. 
Roles on the request 'Group.ReadWrite.All'
