### PR TITLE
Update SetAzureADAppSitePermission.cs

### DIFF
--- a/src/Commands/Apps/SetAzureADAppSitePermission.cs
+++ b/src/Commands/Apps/SetAzureADAppSitePermission.cs
@@ -21,7 +21,7 @@ namespace PnP.PowerShell.Commands.Apps
         public SitePipeBind Site;
 
         [Parameter(Mandatory = true)]
-        [ValidateSet("Write", "Read")]
+        [ValidateSet("Write", "Read", "Manage", "FullControl")]
         public string[] Permissions;
 
         protected override void ExecuteCmdlet()


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##

## What is in this Pull Request ? ##
The Grant-PnPAzureADAppSitePermission doesn't allow "Manage" or "FullControl" on the POST method, but the PATCH method used by the Set-PnPAzureADAppSitePermission allow them.

This allows the Azure Application on Graph API to create Lists and more with this 2 additionals roles .

This seems to be not documented from Microsoft, but it works. Additionnal informations here, in comments (Jonathan & Joel's answer): https://ashiqf.com/2021/03/15/how-to-use-microsoft-graph-sharepoint-sites-selected-application-permission-in-a-azure-ad-application-for-more-granular-control/
