### PR TITLE
Updated correct odata-type Private Teams-channel

### DIFF
--- a/src/Commands/Utilities/TeamsUtility.cs
+++ b/src/Commands/Utilities/TeamsUtility.cs
@@ -484,7 +484,7 @@ namespace PnP.PowerShell.Commands.Utilities
             }
             if (isPrivate)
             {
-                channel.Type = "#Microsoft.Teams.Core.channel";
+                channel.Type = "#Microsoft.Graph.channel";
                 var user = await GraphHelper.GetAsync<User>(httpClient, $"v1.0/users/{ownerUPN}", accessToken);
                 channel.Members = new List<TeamChannelMember>();
                 channel.Members.Add(new TeamChannelMember() { Roles = new List<string> { "owner" }, UserIdentifier = $"https://{PnPConnection.Current.GraphEndPoint}/v1.0/users('{user.Id}')" });


### PR DESCRIPTION
Updated the correct odata-type for private Teams channels

Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Related issue: https://github.com/microsoftgraph/microsoft-graph-docs/issues/7881#issue-605357756

## What is in this Pull Request ? ##
Updated the correct odata-type for private Teams channels
