### PR TITLE
Removed -Confirm from Rename-PnPFile

### DIFF
--- a/documentation/Rename-PnPFile.md
+++ b/documentation/Rename-PnPFile.md
@@ -53,21 +53,6 @@ Renames a file named company.docx located in the document library called Documen
 
 ## PARAMETERS
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Connection
 Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.
 


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [x] Documentation

## Related Issues? ##
Documentation modification following issue #1056 

## What is in this Pull Request ? ##
I've removed `-Confirm` from `Rename-PnPFile` as it doesn't exist. The `-Force` parameter should be used.
