### PR TITLE
Fix null exception when mixing connections with Certificate and without

### DIFF
--- a/src/Commands/Base/ConnectOnline.cs
+++ b/src/Commands/Base/ConnectOnline.cs
@@ -418,7 +418,7 @@ namespace PnP.PowerShell.Commands.Base
                 X509Certificate2 certificate = CertificateHelper.GetCertificateFromPath(CertificatePath, CertificatePassword);
                 if (PnPConnection.Current?.ClientId == ClientId &&
                     PnPConnection.Current?.Tenant == Tenant &&
-                    PnPConnection.Current?.Certificate.Thumbprint == certificate.Thumbprint)
+                    PnPConnection.Current?.Certificate?.Thumbprint == certificate.Thumbprint)
                 {
                     ReuseAuthenticationManager();
                 }
@@ -431,7 +431,7 @@ namespace PnP.PowerShell.Commands.Base
 
                 if (PnPConnection.Current?.ClientId == ClientId &&
                     PnPConnection.Current?.Tenant == Tenant &&
-                    PnPConnection.Current?.Certificate.Thumbprint == certificate.Thumbprint)
+                    PnPConnection.Current?.Certificate?.Thumbprint == certificate.Thumbprint)
                 {
                     ReuseAuthenticationManager();
                 }
@@ -453,7 +453,7 @@ namespace PnP.PowerShell.Commands.Base
                 }
                 if (PnPConnection.Current?.ClientId == ClientId &&
                                     PnPConnection.Current?.Tenant == Tenant &&
-                                    PnPConnection.Current?.Certificate.Thumbprint == certificate.Thumbprint)
+                                    PnPConnection.Current?.Certificate?.Thumbprint == certificate.Thumbprint)
                 {
                     ReuseAuthenticationManager();
                 }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
No linked issues

## What is in this Pull Request ? ##
When mixing `Connect-PnPOnline` calls with `ClientSecret` and with `CertificatePath` parameters, a null-exception is currently thrown when trying to access the certificate in the current connect.
This PR adds null checks where required to avoid the exception.

Here's a screenshot from a debugging session in Visual Studio showing that `PnPConnection.Current?.Certificate` is null, so accessing `Thumbprint` triggers the exception:
![image](https://user-images.githubusercontent.com/1153754/132826514-5eca60dc-51af-4f6b-8569-91d043430c2d.png)


### Guidance ###
* You can delete this section when you are submitting the pull request.* 
* *Please update this PR information accordingly. We use this as part of our release notes in monthly communications.*
* **Please target your PR to Dev branch. If you do not target the Dev branch we will not accept this PR.**
