### PR TITLE
Fixing Get-PnPUser -Identity X ignoring additional attributes request…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Fixed issue with `Get-PnPUser -Identity x` ignoring additional requested attributes using `-Includes`
 
 ### Contributors
 
+- Koen Zomers [koenzomers]
 
 ## [1.7.0]
 

--- a/src/Commands/Base/PipeBinds/UserPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/UserPipeBind.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.SharePoint.Client;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -36,11 +37,10 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             _user = user;
         }
 
-
-        public User GetUser(ClientContext context, bool ensure = false)
+        public User GetUser(ClientContext context, bool ensure = false, Expression<Func<User, object>>[] retrievalOptions = null)
         {
             // note: the following code to get the user is copied from Remove-PnPUser - it could be put into a utility class
-            var retrievalExpressions = new Expression<Func<User, object>>[]
+            var additionalRetrievalOptions = new List<Expression<Func<User, object>>>()
             {
                 u => u.Id,
                 u => u.LoginName,
@@ -48,17 +48,22 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
                 u => u.Title
             };
 
+            if(retrievalOptions != null)
+            {
+                additionalRetrievalOptions.AddRange(retrievalOptions);
+            }
+
             User user = null;
             if (_user != null)
             {
                 user = _user;
-                context.Load(user, retrievalExpressions);
+                context.Load(user, additionalRetrievalOptions.ToArray());
                 context.ExecuteQueryRetry();
             }
             else if (_id > 0)
             {
                 user = context.Web.GetUserById(_id);
-                context.Load(user, retrievalExpressions);
+                context.Load(user, additionalRetrievalOptions.ToArray());
                 context.ExecuteQueryRetry();
             }
             else if (!string.IsNullOrWhiteSpace(_loginOrName))
@@ -66,12 +71,12 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
                 try
                 {
                     user = context.Web.SiteUsers.GetByLoginName(_loginOrName);
-                    context.Load(user, retrievalExpressions);
+                    context.Load(user, additionalRetrievalOptions.ToArray());
                     context.ExecuteQueryRetry();
                 }
                 catch
                 {
-                    var userQuery = context.LoadQuery(context.Web.SiteUsers.Where(u => u.Title == _loginOrName).IncludeWithDefaultProperties(retrievalExpressions));
+                    var userQuery = context.LoadQuery(context.Web.SiteUsers.Where(u => u.Title == _loginOrName).IncludeWithDefaultProperties(additionalRetrievalOptions.ToArray()));
                     context.ExecuteQueryRetry();
                     user = userQuery.FirstOrDefault();
                     if(user == null && ensure)

--- a/src/Commands/Principals/GetUser.cs
+++ b/src/Commands/Principals/GetUser.cs
@@ -279,7 +279,8 @@ namespace PnP.PowerShell.Commands.Principals
             }
             else
             {
-                WriteObject(Identity.GetUser(ClientContext));
+                var user = Identity.GetUser(ClientContext, retrievalOptions: RetrievalExpressions);
+                WriteObject(user);
             }
         }
 

--- a/src/Commands/Principals/GetUser.cs
+++ b/src/Commands/Principals/GetUser.cs
@@ -1,6 +1,5 @@
 ﻿using System.Management.Automation;
 using Microsoft.SharePoint.Client;
-
 using System.Linq.Expressions;
 using System;
 using PnP.PowerShell.Commands.Base.PipeBinds;


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Fixing Get-PnPUser -Identity X ignoring additional attributes requested through -Includes, i.e. UserPrincipalName