### PR TITLE
Adding Set\Get-PnPTenant -ViewInFileExplorerEnabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Added option which allows the Explorer View for Microsoft Edge to be enabled tenant wide by using `Set-PnPTenant -ViewInFileExplorerEnabled` and requesting its current setting using `Get-PnPTenant | Select ViewInFileExplorerEnabled`. It can be that this option is not enabled yet on your tenant in which case trying to set it results in to `Set-PnPTenant: The requested operation is part of an experimental feature that is not supported in the current environment.`. In that case try again later.
 
 ### Contributors
 

--- a/src/Commands/Admin/SetTenant.cs
+++ b/src/Commands/Admin/SetTenant.cs
@@ -212,6 +212,10 @@ namespace PnP.PowerShell.Commands.Admin
 
         [Parameter(Mandatory = false)]
         public bool? DisableBackToClassic;
+
+        [Parameter(Mandatory = false)]
+        public bool? ViewInFileExplorerEnabled;
+
         protected override void ExecuteCmdlet()
         {
             ClientContext.Load(Tenant);
@@ -811,6 +815,11 @@ namespace PnP.PowerShell.Commands.Admin
                 Tenant.MarkNewFilesSensitiveByDefault = MarkNewFilesSensitiveByDefault.Value;
                 modified = true;
             }
+            if (ViewInFileExplorerEnabled.HasValue)
+            {
+                Tenant.ViewInFileExplorerEnabled = ViewInFileExplorerEnabled.Value;
+                modified = true;
+            }            
             if (modified)
             {
                 ClientContext.ExecuteQueryRetry();

--- a/src/Commands/Model/SPOTenant.cs
+++ b/src/Commands/Model/SPOTenant.cs
@@ -36,6 +36,7 @@ namespace PnP.PowerShell.Commands.Model
             this.provisionSharedWithEveryoneFolder = tenant.ProvisionSharedWithEveryoneFolder;
             this.signInAccelerationDomain = tenant.SignInAccelerationDomain;
             this.disabledWebPartIds = tenant.DisabledWebPartIds;
+            this.viewInFileExplorerEnabled = tenant.ViewInFileExplorerEnabled;
 
             try
             {
@@ -483,6 +484,8 @@ namespace PnP.PowerShell.Commands.Model
 
         public SensitiveByDefaultState MarkNewFilesSensitiveByDefault => markNewFilesSensitiveByDefault;
 
+        public bool ViewInFileExplorerEnabled => viewInFileExplorerEnabled;
+
         private bool hideDefaultThemes;
 
         private long storageQuota;
@@ -616,5 +619,7 @@ namespace PnP.PowerShell.Commands.Model
         private bool disableCustomAppAuthentication;
 
         private SensitiveByDefaultState markNewFilesSensitiveByDefault;
+
+        private bool viewInFileExplorerEnabled;
     }
 }


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Adding Set\Get-PnPTenant -ViewInFileExplorerEnabled to allow for Explorer View in Microsoft Edge to be used