### PR TITLE
Fixed Set-PnPSite not working with OneDrive for Business sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added lots of extra information getting returned when using `Get-PnPFlow`.
 - Removed `ConvertTo-PnPClientSidePage` cmdlet as it has been replaced by `ConvertTo-PnPPage`
 - Added option which allows the Explorer View for Microsoft Edge to be enabled tenant wide by using `Set-PnPTenant -ViewInFileExplorerEnabled` and requesting its current setting using `Get-PnPTenant | Select ViewInFileExplorerEnabled`. It can be that this option is not enabled yet on your tenant in which case trying to set it results in to `Set-PnPTenant: The requested operation is part of an experimental feature that is not supported in the current environment.`. In that case try again later.
+- Fixed an issue with `Set-PnPSite -Identity <url> -Owner <upn>` not working if the URL would be a OneDrive for Business site
 
 ### Contributors
 

--- a/src/Commands/Site/SetSite.cs
+++ b/src/Commands/Site/SetSite.cs
@@ -3,8 +3,6 @@ using Microsoft.Online.SharePoint.TenantManagement;
 using Microsoft.SharePoint.Client;
 using PnP.Framework;
 using PnP.Framework.Entities;
-
-using PnP.PowerShell.Commands.Base;
 using PnP.PowerShell.Commands.Utilities;
 using System;
 using System.Collections.Generic;
@@ -15,7 +13,6 @@ namespace PnP.PowerShell.Commands.Site
     [Cmdlet(VerbsCommon.Set, "PnPSite")]
     public class SetSite : PnPSharePointCmdlet
     {
-
         private const string ParameterSet_LOCKSTATE = "Set Lock State";
         private const string ParameterSet_PROPERTIES = "Set Properties";
 
@@ -172,7 +169,6 @@ namespace PnP.PowerShell.Commands.Site
 
             if (IsTenantProperty())
             {
-
                 var tenantAdminUrl = UrlUtilities.GetTenantAdministrationUrl(context.Url);
                 context = context.Clone(tenantAdminUrl);
 

--- a/src/Commands/Utilities/UrlUtilities.cs
+++ b/src/Commands/Utilities/UrlUtilities.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Text.Encodings.Web;
 #if !NETFRAMEWORK
 using System.Web;
 #endif
@@ -13,8 +12,8 @@ namespace PnP.PowerShell.Commands.Utilities
         {
             var uriParts = uri.Host.Split('.');
             if (uriParts[0].EndsWith("-admin")) return uri.OriginalString;
-            if (!uriParts[0].EndsWith("-admin"))
-                return $"https://{uriParts[0]}-admin.{string.Join(".", uriParts.Skip(1))}";
+            if (uriParts[0].EndsWith("-my")) return $"https://{uriParts[0].Remove(uriParts[0].Length - 3, 3)}-admin.{string.Join(".", uriParts.Skip(1))}";
+            if (!uriParts[0].EndsWith("-admin")) return $"https://{uriParts[0]}-admin.{string.Join(".", uriParts.Skip(1))}";
             return null;
         }
 


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Issue #770 

## What is in this Pull Request ? ##
Fixed an issue with `Set-PnPSite -Identity <url> -Owner <upn>` not working if the URL would be a OneDrive for Business site