### PR TITLE
Removing obsolete notification and alias for Add-PnPUserToGroup

### DIFF
--- a/src/Commands/Base/PipeBinds/AzureADUserPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/AzureADUserPipeBind.cs
@@ -1,0 +1,75 @@
+﻿using PnP.Framework.Graph.Model;
+using System;
+using System.Net;
+
+namespace PnP.PowerShell.Commands.Base.PipeBinds
+{
+    /// <summary>
+    /// Allows passing an Azure Active Directory User from one cmdlet to another
+    /// </summary>
+    public class AzureADUserPipeBind
+    {
+        private readonly User _user;
+        private readonly string _userId;
+        private readonly string _upn;
+
+        public AzureADUserPipeBind()
+        {
+        }
+
+        public AzureADUserPipeBind(User user)
+        {
+            _user = user;
+        }
+
+        public AzureADUserPipeBind(string input)
+        {
+            Guid idValue;
+            if (Guid.TryParse(input, out idValue))
+            {
+                _userId = input;
+            }
+            else
+            {
+                _upn = input;
+            }
+        }
+
+        /// <summary>
+        /// Instance of an Azure Active Directory User
+        /// </summary>
+        public User User => _user;
+
+        /// <summary>
+        /// User Principal Name (UPN) of the user
+        /// </summary>
+        public string Upn => _upn;
+
+        /// <summary>
+        /// GUID of the user account
+        /// </summary>
+        public string UserId => _userId;
+
+        /// <summary>
+        /// Tries to return the User instace based on the information this pipe has available
+        /// </summary>
+        /// <param name="accessToken">Access Token for Microsoft Graph that can be used to fetch User data</param>
+        /// <returns>User instance or NULL if unable to define user instance based on the available information</returns>
+        public User GetUser(string accessToken)
+        {
+            if (_user != null)
+            {
+                return _user;
+            }
+            if (_userId != null)
+            {
+                return PnP.Framework.Graph.UsersUtility.GetUser(accessToken, _userId);
+            }
+            if (_upn != null)
+            {                
+                return PnP.Framework.Graph.UsersUtility.GetUser(accessToken, WebUtility.UrlEncode(_upn));
+            }
+            return null;
+        }
+    }
+}

--- a/src/Commands/UserProfiles/SyncSharePointUserProfilesFromAzureActiveDirectory.cs
+++ b/src/Commands/UserProfiles/SyncSharePointUserProfilesFromAzureActiveDirectory.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections;
+using System.ComponentModel;
+using System.Linq;
+using System.Management.Automation;
+using Microsoft.Online.SharePoint.TenantManagement;
+using Microsoft.SharePoint.Client;
+
+using PnP.PowerShell.Commands.Base;
+using PnP.Framework.Utilities;
+
+namespace PnP.PowerShell.Commands.UserProfiles
+{
+    [Cmdlet(VerbsData.Sync, "PnPSharePointUserProfilesFromAzureActiveDirectory")]
+    public class SyncSharePointUserProfilesFromAzureActiveDirectory : PnPAdminCmdlet
+    {
+        [Parameter(Mandatory = true, Position = 0)]
+        public string Folder;
+
+        [Parameter(Mandatory = true, Position = 1)]
+        public string Path = string.Empty;
+
+        [Parameter(Mandatory = true, Position = 2)]
+        public Hashtable UserProfilePropertyMapping;
+
+        [Parameter(Mandatory = true, Position = 3)]
+        public string IdProperty;
+
+        [Parameter(Mandatory = false, Position = 4)]
+        public ImportProfilePropertiesUserIdType IdType = ImportProfilePropertiesUserIdType.Email;
+
+        protected override void ExecuteCmdlet()
+        {
+            if (string.IsNullOrWhiteSpace(Path))
+            {
+                throw new InvalidEnumArgumentException(@"Path cannot be empty.");
+            }
+
+            if (string.IsNullOrWhiteSpace(IdProperty))
+            {
+                throw new InvalidEnumArgumentException(@"IdProperty cannot be empty.");
+            }
+            
+            var webCtx = ClientContext.Clone(PnPConnection.Current.Url);
+            var web = webCtx.Web;
+            var webServerRelativeUrl = web.EnsureProperty(w => w.ServerRelativeUrl);
+            if (!Folder.ToLower().StartsWith(webServerRelativeUrl))
+            {
+                Folder = UrlUtility.Combine(webServerRelativeUrl, Folder);
+            }
+            if (!web.DoesFolderExists(Folder))
+            {
+                throw new InvalidOperationException($"Folder {Folder} does not exist.");
+            }
+            var folder = web.GetFolderByServerRelativeUrl(Folder);
+
+            var fileName = System.IO.Path.GetFileName(Path);
+            File file = folder.UploadFile(fileName, Path, true);
+            
+            var o365 = new Office365Tenant(ClientContext);
+            var propDictionary = UserProfilePropertyMapping.Cast<DictionaryEntry>().ToDictionary(kvp => (string)kvp.Key, kvp => (string)kvp.Value);
+            var url = new Uri(webCtx.Url).GetLeftPart(UriPartial.Authority) + file.ServerRelativeUrl;
+            var id = o365.QueueImportProfileProperties(IdType, IdProperty, propDictionary, url);
+            ClientContext.ExecuteQueryRetry();
+
+            var job = o365.GetImportProfilePropertyJob(id.Value);
+            ClientContext.Load(job);
+            ClientContext.ExecuteQueryRetry();
+            WriteObject(job);
+        }
+    }
+}


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample
- [X] Code cleanup

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Removing obsolete notification and alias for `Add-PnPUserToGroup` as it has been replaced by `Add-PnPGroupMember`