### PR TITLE
Update requirements section and examples on Add-PnPSiteCollectionAppCatalog command

### DIFF
--- a/documentation/Add-PnPSiteCollectionAppCatalog.md
+++ b/documentation/Add-PnPSiteCollectionAppCatalog.md
@@ -11,9 +11,10 @@ title: Add-PnPSiteCollectionAppCatalog
 
 ## SYNOPSIS
 
-**Required Permissions**
+**Requirements**
 
-* SharePoint: Access to the SharePoint Tenant Administration site
+* The user must have access to the SharePoint Tenant Administration site,
+* An open connection to the SharePoint Tenant Administration site when invoking the command.
 
 Adds a Site Collection scoped App Catalog to a site
 
@@ -28,13 +29,6 @@ Add-PnPSiteCollectionAppCatalog [-Site <SitePipeBind>] [-Connection <PnPConnecti
 ## EXAMPLES
 
 ### EXAMPLE 1
-```powershell
-Add-PnPSiteCollectionAppCatalog
-```
-
-This will add a SiteCollection app catalog to the currently connected to site
-
-### EXAMPLE 2
 ```powershell
 Add-PnPSiteCollectionAppCatalog -Site "https://contoso.sharepoint.com/sites/FinanceTeamsite"
 ```


### PR DESCRIPTION
An open connection to the SharePoint Tenant Administration site is needed when invoking the command. In other case, you will receive a 403 error from the console. I've updated the documentation to clarify the use of the Add-PnPSiteCollectionAppCatalog command.

## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [X] Sample


## What is in this Pull Request ? ##

All changes has been done in Add-PnPSiteCollectionAppCatalog command documentation:

- Rename the section "Required permissions" to "Requirements" and update the explanation, 

- remove the example 1 provided because it was wrong, there is no way to create a site collection app catalog when connecting to that site collection,

- update the example 2 and set as "Example 1"