### PR TITLE
Improve Find-PnPFile error message

### DIFF
--- a/src/Commands/Base/PipeBinds/FolderPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/FolderPipeBind.cs
@@ -40,27 +40,37 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
 
         public string ServerRelativeUrl => _name;
 
-        internal Folder GetFolder(Web web)
+        internal Folder GetFolder(Web web, bool throwError = true)
         {
-            Folder folder = null;
-            if (Folder != null)
+            try
             {
-                folder = Folder;
+                Folder folder = null;
+                if (Folder != null)
+                {
+                    folder = Folder;
+                }
+                else if (Id != Guid.Empty)
+                {
+                    folder = web.GetFolderById(Id);
+                }
+                else if (!string.IsNullOrEmpty(ServerRelativeUrl))
+                {
+                    folder = web.GetFolderByServerRelativePath(ResourcePath.FromDecodedUrl(ServerRelativeUrl));
+                }
+                if (folder != null)
+                {
+                    web.Context.Load(folder);
+                    web.Context.ExecuteQueryRetry();
+                }
+                return folder;
             }
-            else if (Id != Guid.Empty)
+            catch
             {
-                folder = web.GetFolderById(Id);
+                if (throwError)
+                    throw;
+                else
+                    return null;
             }
-            else if (!string.IsNullOrEmpty(ServerRelativeUrl))
-            {
-                folder = web.GetFolderByServerRelativePath(ResourcePath.FromDecodedUrl(ServerRelativeUrl));
-            }
-            if (folder != null)
-            {
-                web.Context.Load(folder);
-                web.Context.ExecuteQueryRetry();
-            }
-            return folder;
         }
     }
 }

--- a/src/Commands/Files/FindFile.cs
+++ b/src/Commands/Files/FindFile.cs
@@ -34,7 +34,7 @@ namespace PnP.PowerShell.Commands.Files
                 }
                 case "Folder":
                 {
-                    var folder = Folder.GetFolder(CurrentWeb);
+                    var folder = Folder.GetFolder(CurrentWeb, false);
                     if (folder == null)
                         throw new ArgumentException("The specified folder was not found");
                     WriteObject(folder.FindFiles(Match));


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Mentioned in #731 

## What is in this Pull Request ? ##
Show "The specified folder was not found" error message when Find-PnPFile is invoked with -Folder pointing to a folder that doesn't exist. `FolderPipeBind.GetFolder()` now accepts an optional parameter to specify if null should be returned in case of error (or if the exception should be re-thrown).
The previous error message was a generic "File not found".
