### PR TITLE
Update New-PnPSite.md

### DIFF
--- a/documentation/New-PnPSite.md
+++ b/documentation/New-PnPSite.md
@@ -242,7 +242,7 @@ Accept wildcard characters: False
 ```
 
 ### -Lcid
-The language to use for the site.
+The language to use for the site. For more information, see Locale IDs supported by SharePoint at https://github.com/pnp/PnP-PowerShell/wiki/Supported-LCIDs-by-SharePoint. To get the list of supported languages on a SharePoint environment use: Get-PnPAvailableLanguage.
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
The -Lcid parameter description does not contain an explanation about the fact that SharePoint does not support all possible IDs, while is seems to be that way. Copied the relevant text from the '**new-pnptenantsite**' page (https://docs.microsoft.com/en-us/powershell/module/sharepoint-pnp/new-pnptenantsite?view=sharepoint-ps), where it does get mentioned.

## What is in this Pull Request ? ##
Guidance about the SharePoint support for a limited number of IDs for the -Lcid parameter
