### PR TITLE
Allowing output of Get-PnPUPABulkImportStatus to be piped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed issue with `Remove-PnPSiteDesign -Identity` not accepting a site design name, only a GUID
 - Added `Sync-PnPSharePointUserProfilesFromAzureActiveDirectory` cmdlet which allows direct synchronization of user profile properties of choice between user profiles in Azure Active Directory and their SharePoint Online User Profile Service user profile equivallents
 - Fixed issue with `Remove-PnPSiteDesign -Identity` not accepting a site design name, only a GUID.
-
+- Fixed issue with `Get-PnPUPABulkImportStatus` where it did not allow you to pipe its output to i.e. get the most recent one using `Select -Latest 1` or the ones that failed using `? State -ne "Succeeded"`
+  
 ### Contributors
 
 - Koen Zomers [koenzomers]

--- a/src/Commands/UserProfiles/GetUPABulkImportStatus.cs
+++ b/src/Commands/UserProfiles/GetUPABulkImportStatus.cs
@@ -26,7 +26,7 @@ namespace PnP.PowerShell.Commands.UserProfiles
                 ClientContext.ExecuteQueryRetry();
 
                 GetErrorInfo(job);
-                WriteObject(job);
+                WriteObject(job, true);
             }
             else
             {
@@ -37,7 +37,7 @@ namespace PnP.PowerShell.Commands.UserProfiles
                 {
                     GetErrorInfo(job);
                 }
-                WriteObject(jobs);
+                WriteObject(jobs, true);
             }
         }
 


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Fixed issue with `Get-PnPUPABulkImportStatus` where it did not allow you to pipe its output to i.e. get the most recent one using `Select -Latest 1` or the ones that failed using `? State -ne "Succeeded"`