### PR TITLE
Fix legacy authentication connection ("Realm" parameter value was not used if supplied)

### DIFF
--- a/src/Commands/Base/ConnectOnline.cs
+++ b/src/Commands/Base/ConnectOnline.cs
@@ -327,11 +327,11 @@ namespace PnP.PowerShell.Commands.Base
             CmdletMessageWriter.WriteFormattedMessage(this, new CmdletMessageWriter.Message { Text = "Connecting with Client Secret uses legacy authentication and provides limited functionality. We can for instance not execute requests towards the Microsoft Graph, which limits cmdlets related to Microsoft Teams, Microsoft Planner, Microsoft Flow and Microsoft 365 Groups. You can hide this warning by using Connect-PnPOnline [your parameters] -WarningAction Ignore", Formatted = true, Type = CmdletMessageWriter.MessageType.Warning });
             if (PnPConnection.Current?.ClientId == ClientId &&
                 PnPConnection.Current?.ClientSecret == ClientSecret &&
-                PnPConnection.Current?.Tenant == AADDomain)
+                PnPConnection.Current?.Tenant == Realm)
             {
                 ReuseAuthenticationManager();
             }
-            return PnPConnection.CreateWithACSAppOnly(new Uri(Url), AADDomain, ClientId, ClientSecret, TenantAdminUrl, AzureEnvironment);
+            return PnPConnection.CreateWithACSAppOnly(new Uri(Url), Realm, ClientId, ClientSecret, TenantAdminUrl, AzureEnvironment);
         }
 
         /// <summary>


### PR DESCRIPTION
If Connect-PnPOnline used with Url+ClientId+ClientSecret cannot resolve the realm from Url, it currently uses the value from AADDomain. But AADDomain is a parameter that cannot be set, it's Realm that should be used.

## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## What is in this Pull Request ? ##
Fix legacy authentication connection ("Realm" parameter value was not used if supplied)
