### PR TITLE
Get-PnpSiteTemplate - Example for PersistMultiLanguageResources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Lars Höög [h00g]
 - [kachihro]
 - [Andy-Dawson]
+- David Aeschlimann [TashunkoWitko]
 
 ## [1.8.0]
 

--- a/documentation/Get-PnPSiteTemplate.md
+++ b/documentation/Get-PnPSiteTemplate.md
@@ -146,6 +146,15 @@ Get-PnPSiteTemplate -Out template.pnp -ListsToExtract "Title of List One","95c4e
 
 Extracts a provisioning template in Office Open XML from the current web, including only the lists specified by title or ID.
 
+### EXAMPLE 16
+```powershell
+Get-PnPSiteTemplate -Out template.xml -Handlers Fields, ContentTypes, SupportedUILanguages -PersistMultiLanguageResources
+```
+
+Extracts a provisioning template in XML format from the current web including the fields, content types and supported ui languages.
+It will create a resource file for each supported language. The generated resource files will be named 'template.en-US.resx' etc.
+It is mandatory to include the "SupportedUILanguages" for these handlers as otherwise the resource files will not be created.
+
 ## PARAMETERS
 
 ### -Configuration


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [x] Sample

## Related Issues? ##
There was no example for a usage of PersistMultiLanguageResources in combination with handlers.
It is mandatory to add SupportedUILanguages in handlers as otherwise the multilanguage resources do not get exported properly.

## What is in this Pull Request ? ##
Change of documentation for Cmdlet
