### PR TITLE
Added `-IsDefault` option to `Get-PnPPowerPlatformEnvironment` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `-DisableAddToOneDrive` to `Set-PnPTenant` cmdlet to enable/disable users from adding shortcuts to OneDrive.
 - Added `Set-PnPBuiltInSiteTemplateSettings` and `Get-PnPBuiltInSiteTemplateSettings` to allow making the built in SharePoint Online site templates visible or hidden and getting their current settings
 - Added support for Channel sites (ID 69) to `Add-PnPSiteDesign`, `Set-PnPSiteDesign` and `Add-PnPSiteDesignFromWeb`
-  
+- Added optional `-IsDefault` option to `Get-PnPPowerPlatformEnvironment` which allows just the default or non default environments to be returned. If not provided, all environments will be returned as was the case before this addition.
+
 ### Changed
 - Improved `Get-PnPFile` cmdlet to handle large file downloads
 - Updated `Sync-PnPSharePointUserProfilesFromAzureActiveDirectory` to also allow results from `Get-PnPAzureADUser -Delta` to be provided through `-Users`

--- a/documentation/Export-PnPFlow.md
+++ b/documentation/Export-PnPFlow.md
@@ -40,11 +40,18 @@ Many times exporting a Microsoft Power Automate Flow will not be possible due to
 
 ### Example 1
 ```powershell
-$environment = Get-PnPFlowEnvironment
+$environment = Get-PnPPowerPlatformEnvironment -IsDefault $true
 Export-PnPFlow -Environment $environment -Identity fba63225-baf9-4d76-86a1-1b42c917a182
 ```
 
-This will export the specified Microsoft Power Automate Flow as an output to the current output of PowerShell
+This will export the specified Microsoft Power Automate Flow from the default Power Platform environment as an output to the current output of PowerShell
+
+### Example 2
+```powershell
+Get-PnPPowerPlatformEnvironment | foreach { Get-PnPFlow -Environment $_.Name } | foreach { Export-PnPFlow -Environment $_.Properties.EnvironmentDetails.Name -Identity $_ -OutPath "c:\flows\$($_.Name).zip" -AsZipPackage }
+```
+
+This will export all the Microsoft Power Automate Flows available within the tenant from all users from all the available Power Platform environments as a ZIP package for each of them to a local folder c:\flows
 
 ## PARAMETERS
 

--- a/documentation/Get-PnPPowerPlatformEnvironment.md
+++ b/documentation/Get-PnPPowerPlatformEnvironment.md
@@ -33,7 +33,29 @@ Get-PnPPowerPlatformEnvironment
 
 This cmdlets returns the Power Platform environments for the current tenant.
 
+### Example 2
+```powershell
+Get-PnPPowerPlatformEnvironment -IsDefault $true
+```
+
+This cmdlets returns the default Power Platform environment for the current tenant.
+
 ## PARAMETERS
+
+### -IsDefault
+Allows retrieval of the default Power Platform environment by passing in `-IsDefault $true`. When passing in `-IsDefault $false` you will get all non default environments. If not provided at all, all available environments, both default and non-default, will be returned.
+
+```yaml
+Type: bool
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Connection
 Optional connection to be used by the cmdlet.

--- a/src/Commands/PowerPlatform/Environment/GetPowerPlatformEnvironment.cs
+++ b/src/Commands/PowerPlatform/Environment/GetPowerPlatformEnvironment.cs
@@ -2,6 +2,7 @@
 using PnP.PowerShell.Commands.Base;
 using PnP.PowerShell.Commands.Utilities.REST;
 using System.Management.Automation;
+using System.Linq;
 
 namespace PnP.PowerShell.Commands.PowerPlatform.Environment
 {
@@ -11,9 +12,18 @@ namespace PnP.PowerShell.Commands.PowerPlatform.Environment
     [RequiredMinimalApiPermissions("https://management.azure.com/.default")]
     public class GetPowerPlatformEnvironment : PnPGraphCmdlet
     {
+        [Parameter(Mandatory = false)]
+        public bool? IsDefault;
+
         protected override void ExecuteCmdlet()
         {
-            var environments = GraphHelper.GetResultCollectionAsync<Model.PowerPlatform.Environment.Environment>(HttpClient, "https://management.azure.com/providers/Microsoft.ProcessSimple/environments?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();           
+            var environments = GraphHelper.GetResultCollectionAsync<Model.PowerPlatform.Environment.Environment>(HttpClient, "https://management.azure.com/providers/Microsoft.ProcessSimple/environments?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
+
+            if(ParameterSpecified(nameof(IsDefault)) && IsDefault.HasValue)
+            {
+                environments = environments.Where(e => e.Properties.IsDefault.HasValue && e.Properties.IsDefault == IsDefault.Value);
+            }
+
             WriteObject(environments, true);
         }
     }


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Added optional `-IsDefault` option to `Get-PnPPowerPlatformEnvironment` which allows just the default or non default environments to be returned. If not provided, all environments will be returned as was the case before this addition.