### PR TITLE
Update Export-PnPTermGroupToXml.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [kachihro]
 - [Andy-Dawson]
 - David Aeschlimann [TashunkoWitko]
+- [outorted]
 
 ## [1.8.0]
 

--- a/documentation/Export-PnPTermGroupToXml.md
+++ b/documentation/Export-PnPTermGroupToXml.md
@@ -46,7 +46,7 @@ Exports the term group with the specified name to the file 'output.xml' located 
 
 ### EXAMPLE 4
 ```powershell
-$termgroup = Get-PnPTermGroup -GroupName Test
+$termgroup = Get-PnPTermGroup -Identity Test
 $termgroup | Export-PnPTermGroupToXml -Out c:\output.xml
 ```
 


### PR DESCRIPTION
Example 4 should have -Identity and not -GroupName in the first line

I tested on PnP.PowerShell version 1.8.0 and got an error with -GroupName. It works fine with -Identity

Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [X ] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
None

## What is in this Pull Request ? ##
Fixes error in documentation


