### PR TITLE
Fix exception in Get-PnPDiagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Add/Set-PnPListItem` issue with managed metadata / taxonomy field value failing in a batched request.
 - Fixed `Set-PnPListItem` issue with setting `Modified` date value properly when using `-Batch` parameter.
 - Fixed `Get-PnPTeamsTeam -Identity` throwing an exception if the name of the team would contain special characters
+- Fixed `Get-PnPDiagnostics` throwing an unable to cast exception under some circumstances [#1380](https://github.com/pnp/powershell/pull/1380)
 
 ### Removed
 - Removed `Add-PnPClientSidePage` as that was marked deprecated. Use `Add-PnPPage` instead.
@@ -82,6 +83,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [Andy-Dawson]
 - David Aeschlimann [TashunkoWitko]
 - [outorted]
+- Giacomo Pozzoni [jackpoz]
 
 ## [1.8.0]
 

--- a/src/Commands/Base/GetDiagnostics.cs
+++ b/src/Commands/Base/GetDiagnostics.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Management.Automation;
 using System.Reflection;
 
@@ -76,9 +77,9 @@ namespace PnP.PowerShell.Commands.Base
             // Most of this code has been copied from GetException cmdlet
             PnPException pnpException = null;
             var exceptions = (ArrayList)this.SessionState.PSVariable.Get("error").Value;
-            if (exceptions.Count > 0)
+            var exception = (ErrorRecord)(exceptions.ToArray().FirstOrDefault(e => e is ErrorRecord));
+            if (exception != null)
             {
-                var exception = (ErrorRecord)exceptions[0];
                 var correlationId = string.Empty;
                 if (exception.Exception.Data.Contains("CorrelationId"))
                 {


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
No related issues

## What is in this Pull Request ? ##
Fix an exception in Get-PnPDiagnostics happening when PowerShell $Error variable had entries of a different type than ErrorRecord, i.e. System.Management.Automation.ParameterBindingValidationException.
The checks have been copied from Get-PnPException, in particular the `FirstOrDefault(e => e is ErrorRecord)` filter.

This is how the error looked. I don't have anymore how-to-reproduce steps.
![image](https://user-images.githubusercontent.com/1153754/143223946-3021cdf0-9b79-47c4-a9b3-feb641f781ad.png)

### Guidance ###
* You can delete this section when you are submitting the pull request.* 
* *Please update this PR information accordingly. We use this as part of our release notes in monthly communications.*
* **Please target your PR to Dev branch. If you do not target the Dev branch we will not accept this PR.**
