### PR TITLE
Implicit Param positions removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Add/Set-PnPListItem` issue with managed metadata / taxonomy field value failing in a batched request.
 - Fixed `Set-PnPListItem` issue with setting `Modified` date value properly when using `-Batch` parameter.
 - Fixed `Get-PnPTeamsTeam -Identity` throwing an exception if the name of the team would contain special characters
+- Fixed `Get-PnPTerm` throwing an exception when used in combination with `-Includes` [#1384](https://github.com/pnp/powershell/pull/1384)
 
 ### Removed
 - Removed `Add-PnPClientSidePage` as that was marked deprecated. Use `Add-PnPPage` instead.
@@ -82,6 +83,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [Andy-Dawson]
 - David Aeschlimann [TashunkoWitko]
 - [outorted]
+- [dkardokas]
 
 ## [1.8.0]
 

--- a/src/Commands/Taxonomy/GetTerm.cs
+++ b/src/Commands/Taxonomy/GetTerm.cs
@@ -18,10 +18,10 @@ namespace PnP.PowerShell.Commands.Taxonomy
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_TERMNAME)]
         public TaxonomyTermPipeBind Identity;
 
-        [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, ParameterSetName = ParameterSet_TERMNAME)]
+        [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = ParameterSet_TERMNAME)]
         public TaxonomyTermSetPipeBind TermSet;
 
-        [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, ParameterSetName = ParameterSet_TERMNAME)]
+        [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = ParameterSet_TERMNAME)]
         public TaxonomyTermGroupPipeBind TermGroup;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_TERMID)]


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #1304 

## What is in this Pull Request ? ##
Positional parameter definitions interfere with dynamic params (in this case -Includes). Positional params not required in this case: both -TermSet and -TermGroup need to be named as per documentation

