### PR TITLE
Added `Copy-PnPFolder` alias on `Copy-PnPFile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support for Channel sites (ID 69) to `Add-PnPSiteDesign`, `Set-PnPSiteDesign` and `Add-PnPSiteDesignFromWeb`
 - Added optional `-IsDefault` option to `Get-PnPPowerPlatformEnvironment` which allows just the default or non default environments to be returned. If not provided, all environments will be returned as was the case before this addition.
 - Added `ResourceBehaviorOptions` option in `New-PnPTeamsTeam` cmdlet to set `ResourceBehaviorOptions` while provisioning a Team
+- Added alias on `Copy-PnPFile` for `Copy-PnPFolder`. It could already be used to copy a folder, but to make this more clear, and as we already had a `Copy/Move-PnPFolder` as well, the same cmdlet is now also available under its alternative cmdlet name.
 
 ### Changed
 - Improved `Get-PnPFile` cmdlet to handle large file downloads

--- a/documentation/Copy-PnPFolder.md
+++ b/documentation/Copy-PnPFolder.md
@@ -2,26 +2,26 @@
 Module Name: PnP.PowerShell
 schema: 2.0.0
 applicable: SharePoint Online
-online version: https://pnp.github.io/powershell/cmdlets/Copy-PnPFile.html
+online version: https://pnp.github.io/powershell/cmdlets/Copy-PnPFolder.html
 external help file: PnP.PowerShell.dll-Help.xml
-title: Copy-PnPFile
+title: Copy-PnPFolder
 ---
   
-# Copy-PnPFile
+# Copy-PnPFolder
 
 ## SYNOPSIS
-Copies a file or folder to a different location
+Copies a folder or file to a different location
 
 ## SYNTAX
 
 ```powershell
-Copy-PnPFile [-SourceUrl] <String> [-TargetUrl] <String> [-Overwrite] [-Force] [-IgnoreVersionHistory] [-NoWait] [-Connection <PnPConnection>]  
+Copy-PnPFolder [-SourceUrl] <String> [-TargetUrl] <String> [-Overwrite] [-Force] [-IgnoreVersionHistory] [-NoWait] [-Connection <PnPConnection>]  
   [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-Copies a file or folder to a different location. This location can be within the same document library, same site, same site collection or even to another site collection on the same tenant. Currently there is a 200MB file size limit for the file or folder to be copied. Notice that if copying between sites or to a subsite you cannot specify a target filename, only a folder name.
+Copies a folder or file to a different location. This location can be within the same document library, same site, same site collection or even to another site collection on the same tenant. Currently there is a 200MB file size limit for the file or folder to be copied. Notice that if copying between sites or to a subsite you cannot specify a target filename, only a folder name.
 
 Copying files and folders is bound to some restrictions. You can find more on it here: https://docs.microsoft.com/office365/servicedescriptions/sharepoint-online-service-description/sharepoint-online-limits#moving-and-copying-across-sites
 
@@ -29,77 +29,77 @@ Copying files and folders is bound to some restrictions. You can find more on it
 
 ### EXAMPLE 1
 ```powershell
-Copy-PnPFile -SourceUrl "Shared Documents/MyProjectfiles" -TargetUrl "/sites/otherproject/Shared Documents" -Overwrite
+Copy-PnPFolder -SourceUrl "Shared Documents/MyProjectfiles" -TargetUrl "/sites/otherproject/Shared Documents" -Overwrite
 ```
 
 Copies a folder named MyProjectFiles in the document library called Documents located in the current site to the root folder of the library named Documents in the site collection otherproject. If a folder named MyProjectFiles already exists, it will overwrite it.
 
 ### EXAMPLE 2
 ```powershell
-Copy-PnPFile -SourceUrl "/sites/project/Shared Documents/company.docx" -TargetUrl "/sites/otherproject/Shared Documents"
+Copy-PnPFolder -SourceUrl "/sites/project/Shared Documents/company.docx" -TargetUrl "/sites/otherproject/Shared Documents"
 ```
 
 Copies a file named company.docx located in a document library called Shared Documents in the site collection project to the Shared Documents library in the site collection otherproject. If a file named company.docx already exists, it won't perform the copy.
 
 ### EXAMPLE 3
 ```powershell
-Copy-PnPFile -SourceUrl "Shared Documents/company.docx" -TargetUrl "/sites/otherproject/Shared Documents" -IgnoreVersionHistory
+Copy-PnPFolder -SourceUrl "Shared Documents/company.docx" -TargetUrl "/sites/otherproject/Shared Documents" -IgnoreVersionHistory
 ```
 
 Copies a file named company.docx located in a document library called Documents in the current site to the site collection otherproject. If a file named company.docx already exists, it won't perform the copy. Only the latest version of the file will be copied and its history will be discarded.
 
 ### EXAMPLE 4
 ```powershell
-Copy-PnPFile -SourceUrl "/sites/project/Shared Documents/Archive" -TargetUrl "/sites/otherproject/Shared Documents" -Overwrite
+Copy-PnPFolder -SourceUrl "/sites/project/Shared Documents/Archive" -TargetUrl "/sites/otherproject/Shared Documents" -Overwrite
 ```
 
 Copies a folder named Archive located in a document library called Shared Documents in the site collection project to the Shared Documents library in the site collection otherproject. If a folder named Archive already exists, it will overwrite it.
 
 ### EXAMPLE 5
 ```powershell
-Copy-PnPFile -SourceUrl "Documents/company.docx" -TargetUrl "Documents/company2.docx"
+Copy-PnPFolder -SourceUrl "Documents/company.docx" -TargetUrl "Documents/company2.docx"
 ```
 
 Copies a file named company.docx located in a document library called Documents to a new document named company2.docx in the same library.
 
 ### EXAMPLE 6
 ```powershell
-Copy-PnPFile -SourceUrl "Shared Documents/company.docx" -TargetUrl "Shared Documents2/company.docx"
+Copy-PnPFolder -SourceUrl "Shared Documents/company.docx" -TargetUrl "Shared Documents2/company.docx"
 ```
 
 Copies a file named company.docx located in a document library called Documents to a document library called Documents2 in the same site. 
 
 ### EXAMPLE 7
 ```powershell
-Copy-PnPFile -SourceUrl "Shared DocuDocuments/company.docx" -TargetUrl "Subsite/Shared Documents"
+Copy-PnPFolder -SourceUrl "Shared DocuDocuments/company.docx" -TargetUrl "Subsite/Shared Documents"
 ```
 
 Copies a file named company.docx located in a document library called Documents to the document library named Documents in a subsite named Subsite keeping the file name.
 
 ### EXAMPLE 8
 ```powershell
-Copy-PnPFile -SourceUrl "Shared Documents/company.docx" -TargetUrl "/sites/otherproject/Shared Documents" -Overwrite
+Copy-PnPFolder -SourceUrl "Shared Documents/company.docx" -TargetUrl "/sites/otherproject/Shared Documents" -Overwrite
 ```
 
 Copies a file named company.docx located in a document library called Documents in the current site to the site collection otherproject. If a file named company.docx already exists, it will still perform the copy and replace the original company.docx file.
 
 ### EXAMPLE 9
 ```powershell
-Copy-PnPFile -SourceUrl "Shared Documents/MyDocs" -TargetUrl "/sites/otherproject/Documents" -Overwrite
+Copy-PnPFolder -SourceUrl "Shared Documents/MyDocs" -TargetUrl "/sites/otherproject/Documents" -Overwrite
 ```
 
 Copies a folder named MyDocs in the document library called Documents located in the current site to the site collection otherproject. If the MyDocs folder exist it will copy into it, if not it will be created.
 
 ### EXAMPLE 10
 ```powershell
-Copy-PnPFile -SourceUrl "SubSite1/Documents/company.docx" -TargetUrl "SubSite2/Documents"
+Copy-PnPFolder -SourceUrl "SubSite1/Documents/company.docx" -TargetUrl "SubSite2/Documents"
 ```
 
 Copies a file named company.docx in the library named Documents in SubSite1 to the library named Documents in SubSite2.
 
 ### EXAMPLE 11
 ```powershell
-$job = Copy-PnPFile -SourceUrl "Shared Documents/company.docx" -TargetUrl "SubSite2/Shared Documents" -NoWait
+$job = Copy-PnPFolder -SourceUrl "Shared Documents/company.docx" -TargetUrl "SubSite2/Shared Documents" -NoWait
 $jobStatus = Receive-PnPCopyMoveJobStatus -Job $result
 if($jobStatus.JobState == 0)
 {
@@ -200,5 +200,3 @@ Accept wildcard characters: False
 ## RELATED LINKS
 
 [Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)
-
-

--- a/documentation/Move-PnPFile.md
+++ b/documentation/Move-PnPFile.md
@@ -21,6 +21,8 @@ Move-PnPFile [-SourceUrl] <String> [-TargetUrl] <String> [-Overwrite] [-AllowSch
 ## DESCRIPTION
 Allows moving a file or folder to a different location inside the same document library, such as in a subfolder, to a different document library on the same site collection or to a document library on another site collection. If you move a file to a different site or subweb you cannot specify a target filename.
 
+Moving files and folders is bound to some restrictions. You can find more on it here: https://docs.microsoft.com/office365/servicedescriptions/sharepoint-online-service-description/sharepoint-online-limits#moving-and-copying-across-sites
+
 ## EXAMPLES
 
 ### EXAMPLE 1

--- a/src/Commands/Files/CopyFile.cs
+++ b/src/Commands/Files/CopyFile.cs
@@ -1,19 +1,13 @@
 ﻿using System;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Management.Automation;
-using System.Text.RegularExpressions;
 using Microsoft.SharePoint.Client;
-
 using Resources = PnP.PowerShell.Commands.Properties.Resources;
 using PnP.Framework.Utilities;
-using File = Microsoft.SharePoint.Client.File;
-using System.Net.Http;
-using System.Text.Json;
-using PnP.PowerShell.Commands.Model;
 
 namespace PnP.PowerShell.Commands.Files
 {
+    [Alias("Copy-PnPFolder")]
     [Cmdlet(VerbsCommon.Copy, "PnPFile")]
     public class CopyFile : PnPWebCmdlet
     {

--- a/src/Commands/Files/MoveFile.cs
+++ b/src/Commands/Files/MoveFile.cs
@@ -1,6 +1,5 @@
 ﻿using System.Management.Automation;
 using Microsoft.SharePoint.Client;
-
 using Resources = PnP.PowerShell.Commands.Properties.Resources;
 using PnP.Framework.Utilities;
 using System;

--- a/src/Commands/Properties/Resources.resx
+++ b/src/Commands/Properties/Resources.resx
@@ -232,10 +232,10 @@
     <value>The Unified Group with MailNickname of {0} already exists. Do you want to create another one?</value>
   </data>
   <data name="CopyFile0To1" xml:space="preserve">
-    <value>Copy file '{0}' to '{1}'?</value>
+    <value>Copy file or folder '{0}' to '{1}'?</value>
   </data>
   <data name="MoveFile0To1" xml:space="preserve">
-    <value>Move file '{0}' to '{1}'?</value>
+    <value>Move file or folder '{0}' to '{1}'?</value>
   </data>
   <data name="MoveListItemWithId0ToRecycleBin" xml:space="preserve">
     <value>Move list item with ID {0} to Recycle Bin?</value>


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Added alias on `Copy-PnPFile` for `Copy-PnPFolder`. It could already be used to copy a folder, but to make this more clear, and as we already had a `Copy/Move-PnPFolder` as well, the same cmdlet is now also available under its alternative cmdlet name. Also done some minor code cleanup in related files.