### PR TITLE
Fixing `Get-PnPTenant` not returning actual values of `AllowFilesWithKeepLabelToBeDeletedSPO\ODB`

### DIFF
--- a/src/Commands/Model/SPOTenant.cs
+++ b/src/Commands/Model/SPOTenant.cs
@@ -348,23 +348,7 @@ namespace PnP.PowerShell.Commands.Model
             catch
             {
                 this.disableCustomAppAuthentication = false;
-            } 
-            try
-            {
-                this.allowFilesWithKeepLabelToBeDeletedSPO = Microsoft.SharePoint.Client.CompliancePolicy.SPPolicyStoreProxy.GetAllowFilesWithKeepLabelToBeDeletedSPO(clientContext).Value;
-            }
-            catch
-            {
-                this.allowFilesWithKeepLabelToBeDeletedSPO = true;
-            }    
-            try
-            {
-                this.allowFilesWithKeepLabelToBeDeletedODB = Microsoft.SharePoint.Client.CompliancePolicy.SPPolicyStoreProxy.GetAllowFilesWithKeepLabelToBeDeletedODB(clientContext).Value;
-            }
-            catch
-            {
-                this.allowFilesWithKeepLabelToBeDeletedODB = true;
-            }                                 
+            }                               
             this.markNewFilesSensitiveByDefault = tenant.MarkNewFilesSensitiveByDefault;
             try
             {
@@ -382,6 +366,16 @@ namespace PnP.PowerShell.Commands.Model
             {
                 this.disableAddToOneDrive = false;
             }
+            try
+            {
+                var getAllowFilesWithKeepLabelToBeDeletedSPO = Microsoft.SharePoint.Client.CompliancePolicy.SPPolicyStoreProxy.GetAllowFilesWithKeepLabelToBeDeletedSPO(clientContext);
+                var getAllowFilesWithKeepLabelToBeDeletedODB = Microsoft.SharePoint.Client.CompliancePolicy.SPPolicyStoreProxy.GetAllowFilesWithKeepLabelToBeDeletedODB(clientContext);                
+                clientContext.ExecuteQueryRetry();
+
+                this.allowFilesWithKeepLabelToBeDeletedSPO = getAllowFilesWithKeepLabelToBeDeletedSPO.Value;
+                this.allowFilesWithKeepLabelToBeDeletedODB = getAllowFilesWithKeepLabelToBeDeletedODB.Value;
+            }
+            catch { }
         }
 
         public bool HideDefaultThemes => hideDefaultThemes;
@@ -524,12 +518,11 @@ namespace PnP.PowerShell.Commands.Model
 
         public bool DisableSpacesActivation => disableSpacesActivation;
 
-        public bool AllowFilesWithKeepLabelToBeDeletedSPO => allowFilesWithKeepLabelToBeDeletedSPO;
+        public bool? AllowFilesWithKeepLabelToBeDeletedSPO => allowFilesWithKeepLabelToBeDeletedSPO;
 
-        public bool AllowFilesWithKeepLabelToBeDeletedODB => allowFilesWithKeepLabelToBeDeletedODB;
+        public bool? AllowFilesWithKeepLabelToBeDeletedODB => allowFilesWithKeepLabelToBeDeletedODB;
 
         public bool DisableAddToOneDrive => disableAddToOneDrive;
-
 
         private bool hideDefaultThemes;
 
@@ -672,9 +665,9 @@ namespace PnP.PowerShell.Commands.Model
 
         private bool disableSpacesActivation;
 
-        private bool allowFilesWithKeepLabelToBeDeletedSPO;
+        private bool? allowFilesWithKeepLabelToBeDeletedSPO;
 
-        private bool allowFilesWithKeepLabelToBeDeletedODB;
+        private bool? allowFilesWithKeepLabelToBeDeletedODB;
 
         private bool disableAddToOneDrive;
 


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Fixing issue with PR #1366 where Get-PnPTenant didn't return the proper values for AllowFilesWithKeepLabelToBeDeletedSPO and AllowFilesWithKeepLabelToBeDeletedODB