### PR TITLE
Fix #1427 - issue with missing TeamsApp object value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Get-PnPTeamsTeam -Identity` throwing an exception if the name of the team would contain special characters
 - Fixed `Get-PnPTerm` throwing an exception when used in combination with `-Includes` [#1384](https://github.com/pnp/powershell/pull/1384)
 - Fixed `Get-PnPDiagnostics` throwing an unable to cast exception under some circumstances [#1380](https://github.com/pnp/powershell/pull/1380)
-- Fixed `Get-PnPTeamsTab` issue with missing TeamsApp object values. It will now populate TeamsApp object with Id ,DisplayName , ExternalId and DistributionMethod properties if available.
+- Fixed `Get-PnPTeamsTab` issue with missing TeamsApp object values. It will now populate TeamsApp object with Id, DisplayName, ExternalId and DistributionMethod properties if available. [#1459](https://github.com/pnp/powershell/pull/1459)
 
 ### Removed
 - Removed `Add-PnPClientSidePage` as that was marked deprecated. Use `Add-PnPPage` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Get-PnPTeamsTeam -Identity` throwing an exception if the name of the team would contain special characters
 - Fixed `Get-PnPTerm` throwing an exception when used in combination with `-Includes` [#1384](https://github.com/pnp/powershell/pull/1384)
 - Fixed `Get-PnPDiagnostics` throwing an unable to cast exception under some circumstances [#1380](https://github.com/pnp/powershell/pull/1380)
+- Fixed `Get-PnPTeamsTab` issue with missing TeamsApp object values. It will now populate TeamsApp object with Id ,DisplayName , ExternalId and DistributionMethod properties if available.
 
 ### Removed
 - Removed `Add-PnPClientSidePage` as that was marked deprecated. Use `Add-PnPPage` instead.

--- a/src/Commands/Base/PipeBinds/TeamsChannelPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/TeamsChannelPipeBind.cs
@@ -45,7 +45,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             else
             {
                 var channels = TeamsUtility.GetChannelsAsync(accessToken, httpClient, groupId).GetAwaiter().GetResult();
-                return channels.FirstOrDefault(c => c.DisplayName.Equals(_displayName, StringComparison.OrdinalIgnoreCase)).Id;
+                return channels.FirstOrDefault(c => c.DisplayName.Equals(_displayName, StringComparison.OrdinalIgnoreCase))?.Id;
             }
         }
 

--- a/src/Commands/Model/Teams/TeamTab.cs
+++ b/src/Commands/Model/Teams/TeamTab.cs
@@ -22,9 +22,11 @@ namespace PnP.PowerShell.Commands.Model.Teams
                 _displayName = System.Net.WebUtility.UrlDecode(value);
             }
         }
+        
+        public TeamApp TeamsApp { get; set; }
 
         [JsonPropertyName("teamsApp@odata.bind")]
-        public string TeamsApp { get; set; }
+        public string TeamsAppOdataBind { get; set; }
         /// <summary>
         /// App definition identifier of the tab
         /// </summary>

--- a/src/Commands/Utilities/TeamsUtility.cs
+++ b/src/Commands/Utilities/TeamsUtility.cs
@@ -532,7 +532,7 @@ namespace PnP.PowerShell.Commands.Utilities
 
         public static async Task<TeamTab> GetTabAsync(string accessToken, HttpClient httpClient, string groupId, string channelId, string tabId)
         {
-            return await GraphHelper.GetAsync<TeamTab>(httpClient, $"v1.0/teams/{groupId}/channels/{channelId}/tabs/{tabId}", accessToken);
+            return await GraphHelper.GetAsync<TeamTab>(httpClient, $"v1.0/teams/{groupId}/channels/{channelId}/tabs/{tabId}?$expand=teamsApp", accessToken, propertyNameCaseInsensitive: true);
         }
 
         public static async Task<HttpResponseMessage> DeleteTabAsync(string accessToken, HttpClient httpClient, string groupId, string channelId, string tabId)
@@ -658,7 +658,7 @@ namespace PnP.PowerShell.Commands.Utilities
                     }
             }
             tab.DisplayName = displayName;
-            tab.TeamsApp = $"https://{PnPConnection.Current.GraphEndPoint}/v1.0/appCatalogs/teamsApps/{tab.TeamsAppId}";
+            tab.TeamsAppOdataBind = $"https://{PnPConnection.Current.GraphEndPoint}/v1.0/appCatalogs/teamsApps/{tab.TeamsAppId}";
             return await GraphHelper.PostAsync<TeamTab>(httpClient, $"v1.0/teams/{groupId}/channels/{channelId}/tabs", tab, accessToken);
         }
         #endregion


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #1427 

## What is in this Pull Request ? ##

Fixed `Get-PnPTeamsTab` issue with missing TeamsApp object values. It will now populate TeamsApp object with Id ,DisplayName , ExternalId and DistributionMethod properties if available.