### PR TITLE
Remove special characters including space from Site Alias to keep onl…

### DIFF
--- a/src/Commands/Admin/NewSite.cs
+++ b/src/Commands/Admin/NewSite.cs
@@ -115,7 +115,7 @@ namespace PnP.PowerShell.Commands
 
                 if (ParameterSpecified("SiteAlias"))
                 {
-                    creationInformation.SiteAlias = _teamSiteParameters.SiteAlias;
+                    creationInformation.SiteAlias = System.Text.RegularExpressions.Regex.Replace(_teamSiteParameters.SiteAlias, @"[^\w\._'-]", string.Empty);
                 }
 
                 if (ClientContext.GetContextSettings()?.Type != Framework.Utilities.Context.ClientContextType.SharePointACSAppOnly)


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix

## Related Issues? ##
From the user interface when a site is created only underscore, dash, single quotes, and period (_, -, ', .) are allowed.
However if a site is created with special characters in sitealias using the following cmdlet 
new-pnpsite -Type TeamSite -Title "Test site with special characters1" -Alias "TestSiteWithSpecialCharacters1" -SiteAlias " Test & _ site -%) with '¬! special ^. characters@~1"

The site is created with url .../sites/ Test & _ site --) with '¬! special ^. characters@~1

Site URL with special characters may have unpredicted behaviours like unable to delete site from SharePoint Admin Centre or restore from deleted sites.

## What is in this Pull Request ? ##
The fix is to strip any special characters and space to allow only underscore, dash, single quotes, and period (_, -, ', .) 
Running the cmdlet 
new-pnpsite -Type TeamSite -Title "Test site with special characters2" -Alias "TestSiteWithSpecialCharacters2" -SiteAlias " Test & _ site -%) with '¬! special ^. characters@~2" 
Results
../sites/Test_site-with'special.characters2
