### PR TITLE
Adding `-Title` to `Add-PnPPage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Added `Add\Remove\Invoke-PnPListDesign` cmdlets to add a list design, remove a list design and apply the list design.
-
+- Added the ability to set the title of a new modern page in SharePoint Online using `Add-PnPPage` to be different from its filename by using `-Title`
+ 
 ### Changed
 
 

--- a/documentation/Add-PnPPage.md
+++ b/documentation/Add-PnPPage.md
@@ -36,54 +36,61 @@ Creates a new page named 'NewPage'
 
 ### EXAMPLE 2
 ```powershell
+Add-PnPPage -Name "NewPage" -Title "Welcome to my page"
+```
+
+Creates a new page NewPage.aspx with the title as provided
+
+### EXAMPLE 3
+```powershell
 Add-PnPPage -Name "NewPage" -ContentType "MyPageContentType"
 ```
 
 Creates a new page named 'NewPage' and sets the content type to the content type specified
 
-### EXAMPLE 3
+### EXAMPLE 4
 ```powershell
 Add-PnPPage -Name "NewPageTemplate" -PromoteAs Template
 ```
 
 Creates a new page named 'NewPage' and saves as a template to the site.
 
-### EXAMPLE 4
+### EXAMPLE 5
 ```powershell
 Add-PnPPage -Name "Folder/NewPage"
 ```
 
 Creates a new page named 'NewPage' under 'Folder' folder and saves as a template to the site.
 
-### EXAMPLE 5
+### EXAMPLE 6
 ```powershell
 Add-PnPPage -Name "NewPage" -HeaderLayoutType ColorBlock
 ```
 
 Creates a new page named 'NewPage' using the ColorBlock header layout
 
-### EXAMPLE 6
+### EXAMPLE 7
 ```powershell
 Add-PnPPage -Name "NewPage" Article -ScheduledPublishDate (Get-Date).AddHours(1)
 ```
 
 Creates a new page named 'NewPage' using the article layout and schedule it to be published in 1 hour from now
 
-### EXAMPLE 7
+### EXAMPLE 8
 ```powershell
 Add-PnPPage -Name "NewPage" -Translate
 ```
 
 Creates a new page named 'NewPage' and also creates the necessary translated page for the supported languages in the site collection.
 
-### EXAMPLE 8
+### EXAMPLE 9
 ```powershell
 Add-PnPPage -Name "NewPage" -Translate -TranslationLanguageCodes 1043
 ```
 
 Creates a new page named 'NewPage' and also creates the necessary translated page for the specified language in the site collection. In this case, it will create the translated page for Dutch language. If the Dutch language is not enabled, it will enable the language and then create the translated page.
 
-### EXAMPLE 9
+### EXAMPLE 10
 ```powershell
 Add-PnPPage -Name "NewPage" -Translate -TranslationLanguageCodes 1043,1035
 ```

--- a/src/Commands/Pages/AddPage.cs
+++ b/src/Commands/Pages/AddPage.cs
@@ -41,6 +41,8 @@ namespace PnP.PowerShell.Commands.Pages
         [Parameter(Mandatory = false)]
         public int[] TranslationLanguageCodes;
 
+        [Parameter(Mandatory = false)]
+        public string Title;
         protected override void ExecuteCmdlet()
         {
             IPage clientSidePage = null;
@@ -67,6 +69,12 @@ namespace PnP.PowerShell.Commands.Pages
             // Create a page that persists immediately
             clientSidePage = PnPContext.Web.NewPage(LayoutType);
             clientSidePage.PageHeader.LayoutType = HeaderLayoutType;
+
+            if (ParameterSpecified(nameof(Title)))
+            {
+                // Set the page title that will be shown at the top of the page. If omitted, the title will be the equivallent of the name of the page which will be used as the filename as well.
+                clientSidePage.PageTitle = Title;
+            }
 
             if (PromoteAs == PagePromoteType.Template)
             {

--- a/src/Commands/Pages/AddPage.cs
+++ b/src/Commands/Pages/AddPage.cs
@@ -43,6 +43,7 @@ namespace PnP.PowerShell.Commands.Pages
 
         [Parameter(Mandatory = false)]
         public string Title;
+        
         protected override void ExecuteCmdlet()
         {
             IPage clientSidePage = null;


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Added the ability to set the title of a new modern page in SharePoint Online using `Add-PnPPage` to be different from its filename by using `-Title`