### PR TITLE
Allow force beta for get azure ad user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added `Add\Remove\Invoke-PnPListDesign` cmdlets to add a list design, remove a list design and apply the list design.
 - Added the ability to set the title of a new modern page in SharePoint Online using `Add-PnPPage` to be different from its filename by using `-Title`
- 
+- Added `-Content` option to `Add-PnPFile` which allows textual content to be directly uploaded to SharePoint without having to save it as a file first
+-  
 ### Changed
 
 - Changed `Add-PnPDataRowsToSiteTemplate`, it will return a warning if user(s) are not found during list item extraction. Earlier it used to throw error and stop extraction of list items.
+
+### Changed
+
+- Introduced optional `-UseBeta` parameter to `Get-PnPAzureADUser` to force it to use the Microsoft Graph beta endpoint. This can be necessary when i.e. using `-Select "PreferredDataLocation"` to query for users with a specific multi geo location as this property is only available through the beta endpoint.
+- Changed the return type of `Sync-PnPSharePointUserProfilesFromAzureActiveDirectory` to return our own entity instead of the one returned by CSOM to decouple it and also allow for it to return the location where the import file has been uploaded to on SharePoint when using `-WhatIf`. This allows for the scenario where you would use `-WhatIf` to create the mapping JSON file, but not actually start the import yet because i.e. you want to modify the data in the mapping file first before you trigger the import process to start.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `Add\Remove\Invoke-PnPListDesign` cmdlets to add a list design, remove a list design and apply the list design.
 - Added the ability to set the title of a new modern page in SharePoint Online using `Add-PnPPage` to be different from its filename by using `-Title`
 - Added `-Content` option to `Add-PnPFile` which allows textual content to be directly uploaded to SharePoint without having to save it as a file first
+- Added optional `-UseBeta` parameter to `Get-PnPAzureADUser` to force it to use the Microsoft Graph beta endpoint. This can be necessary when i.e. using `-Select "PreferredDataLocation"` to query for users with a specific multi geo location as this property is only available through the beta endpoint.
   
 ### Changed
 
 - Changed `Add-PnPDataRowsToSiteTemplate`, it will return a warning if user(s) are not found during list item extraction. Earlier it used to throw error and stop extraction of list items.
-
-### Changed
-
-- Introduced optional `-UseBeta` parameter to `Get-PnPAzureADUser` to force it to use the Microsoft Graph beta endpoint. This can be necessary when i.e. using `-Select "PreferredDataLocation"` to query for users with a specific multi geo location as this property is only available through the beta endpoint.
 - Changed the return type of `Sync-PnPSharePointUserProfilesFromAzureActiveDirectory` to return our own entity instead of the one returned by CSOM to decouple it and also allow for it to return the location where the import file has been uploaded to on SharePoint when using `-WhatIf`. This allows for the scenario where you would use `-WhatIf` to create the mapping JSON file, but not actually start the import yet because i.e. you want to modify the data in the mapping file first before you trigger the import process to start.
 
 ### Fixed

--- a/src/Commands/AzureAD/GetAzureADUser.cs
+++ b/src/Commands/AzureAD/GetAzureADUser.cs
@@ -46,6 +46,11 @@ namespace PnP.PowerShell.Commands.Principals
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_DELTA)]
         public int? EndIndex = 999;
 
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_BYID)]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_LIST)]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_DELTA)]
+        public SwitchParameter UseBeta;        
+
         protected override void ExecuteCmdlet()
         {
             if(MyInvocation.InvocationName.ToLower().Equals("get-pnpaaduser"))
@@ -62,22 +67,22 @@ namespace PnP.PowerShell.Commands.Principals
                 PnP.PowerShell.Commands.Model.AzureAD.User user;
                 if (Guid.TryParse(Identity, out Guid identityGuid))
                 {
-                    user = PnP.PowerShell.Commands.Utilities.AzureAdUtility.GetUser(AccessToken, identityGuid);
+                    user = PnP.PowerShell.Commands.Utilities.AzureAdUtility.GetUser(AccessToken, identityGuid, useBetaEndPoint: UseBeta.IsPresent);
                 }
                 else
                 {
-                    user = PnP.PowerShell.Commands.Utilities.AzureAdUtility.GetUser(AccessToken, WebUtility.UrlEncode(Identity), Select);
+                    user = PnP.PowerShell.Commands.Utilities.AzureAdUtility.GetUser(AccessToken, WebUtility.UrlEncode(Identity), Select, useBetaEndPoint: UseBeta.IsPresent);
                 }
                 WriteObject(user);
             }
             else if (ParameterSpecified(nameof(Delta)))
             {
-                var userDelta = PnP.PowerShell.Commands.Utilities.AzureAdUtility.ListUserDelta(AccessToken, DeltaToken, Filter, OrderBy, Select, StartIndex, EndIndex);
+                var userDelta = PnP.PowerShell.Commands.Utilities.AzureAdUtility.ListUserDelta(AccessToken, DeltaToken, Filter, OrderBy, Select, StartIndex, EndIndex, useBetaEndPoint: UseBeta.IsPresent);
                 WriteObject(userDelta);
             } 
             else
             {
-                var users = PnP.PowerShell.Commands.Utilities.AzureAdUtility.ListUsers(AccessToken, Filter, OrderBy, Select, StartIndex, EndIndex);
+                var users = PnP.PowerShell.Commands.Utilities.AzureAdUtility.ListUsers(AccessToken, Filter, OrderBy, Select, StartIndex, EndIndex, useBetaEndPoint: UseBeta.IsPresent);
                 WriteObject(users, true);
             }
         }

--- a/src/Commands/Enums/SharePointUserProfileImportProfilePropertiesJobError.cs
+++ b/src/Commands/Enums/SharePointUserProfileImportProfilePropertiesJobError.cs
@@ -1,0 +1,16 @@
+namespace PnP.PowerShell.Commands.Enums
+{
+    /// <summary>
+    /// Types of errors that can occur while performing a SharePoint Online User Profile Import
+    /// </summary>
+    public enum SharePointUserProfileImportProfilePropertiesJobError
+    {
+        NoError = 0,
+        InternalError = 1,
+        DataFileNotExist = 20,
+        DataFileNotInTenant = 21,
+        DataFileTooBig = 22,
+        InvalidDataFile = 23,
+        ImportCompleteWithError = 30
+    }
+}

--- a/src/Commands/Enums/SharePointUserProfileImportProfilePropertiesJobState.cs
+++ b/src/Commands/Enums/SharePointUserProfileImportProfilePropertiesJobState.cs
@@ -1,0 +1,43 @@
+namespace PnP.PowerShell.Commands.Enums
+{
+    /// <summary>
+    /// The states a SharePoint Online User Profile import job can be in
+    /// </summary>
+    public enum SharePointUserProfileImportProfilePropertiesJobState
+    {
+        /// <summary>
+        /// State is unknown
+        /// </summary>
+        Unknown = 0,
+
+        /// <summary>
+        /// The file has been submitted to SharePoint Online for processing
+        /// </summary>
+        Submitted = 1,
+
+        /// <summary>
+        /// The file is currently being processed to validate if it can be used
+        /// </summary>
+        Processing = 2,
+
+        /// <summary>
+        /// The file is queued and being executed
+        /// </summary>
+        Queued = 3,
+
+        /// <summary>
+        /// The import process has completed successfully
+        /// </summary>
+        Succeeded = 4,
+
+        /// <summary>
+        /// The import process has failed to complete
+        /// </summary>
+        Error = 5,
+
+        /// <summary>
+        /// The import process will not start
+        /// </summary>
+        WontStart = 99
+    }
+}

--- a/src/Commands/Model/SharePointUserProfileSync/SharePointUserProfileSyncStatus.cs
+++ b/src/Commands/Model/SharePointUserProfileSync/SharePointUserProfileSyncStatus.cs
@@ -1,0 +1,68 @@
+using System;
+using Microsoft.Online.SharePoint.TenantManagement;
+using PnP.PowerShell.Commands.Enums;
+
+namespace PnP.PowerShell.Commands.Model.SharePoint.SharePointUserProfileSync
+{
+    /// <summary>
+    /// Contains the status of a SharePoint Online User Profile Import job
+    /// </summary>
+    public class SharePointUserProfileSyncStatus
+    {
+        #region Properties
+
+        /// <summary>
+        /// Details on the type of error that occurred, if any
+        /// </summary>
+        public SharePointUserProfileImportProfilePropertiesJobError Error { get; set; }
+
+        /// <summary>
+        /// The error message, if an error occurred
+        /// </summary>
+        public string ErrorMessage { get; set; }
+
+        /// <summary>
+        /// Unique identifier of the import job
+        /// </summary>
+        public Guid? JobId { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public string LogFolderUri { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public string SourceUri { get; set; }
+
+        /// <summary>
+        /// State the user profile import process is in
+        /// </summary>
+        public SharePointUserProfileImportProfilePropertiesJobState State { get; set; }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Takes an instance of ImportProfilePropertiesJobInfo from CSOM and maps it to a local SharePointUserProfileSyncStatus entity
+        /// </summary>
+        /// <param name="importProfilePropertiesJobInfo">Instance to map from</param>
+        public static SharePointUserProfileSyncStatus ParseFromImportProfilePropertiesJobInfo(ImportProfilePropertiesJobInfo importProfilePropertiesJobInfo)
+        {
+            var result = new SharePointUserProfileSyncStatus
+            {
+                Error = Enum.TryParse(importProfilePropertiesJobInfo.Error.ToString(), out SharePointUserProfileImportProfilePropertiesJobError sharePointUserProfileImportProfilePropertiesJobError) ? sharePointUserProfileImportProfilePropertiesJobError : SharePointUserProfileImportProfilePropertiesJobError.NoError,
+                ErrorMessage = importProfilePropertiesJobInfo.ErrorMessage,
+                JobId = importProfilePropertiesJobInfo.JobId,
+                LogFolderUri = importProfilePropertiesJobInfo.LogFolderUri,
+                SourceUri = importProfilePropertiesJobInfo.SourceUri,
+                State = Enum.TryParse(importProfilePropertiesJobInfo.State.ToString(), out SharePointUserProfileImportProfilePropertiesJobState sharePointUserProfileImportProfilePropertiesJobState) ? sharePointUserProfileImportProfilePropertiesJobState : SharePointUserProfileImportProfilePropertiesJobState.Unknown
+            };
+            return result;
+        }
+
+        #endregion
+    }
+}

--- a/src/Commands/Utilities/AzureAdUtility.cs
+++ b/src/Commands/Utilities/AzureAdUtility.cs
@@ -22,10 +22,11 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="selectProperties">Optional additional properties to fetch for the users</param>
         /// <param name="startIndex">Optional start index indicating starting from which result to start returning users</param>
         /// <param name="endIndex">Optional end index indicating up to which result to return users. By default all users will be returned.</param>
+        /// <param name="useBetaEndPoint">Indicates if the v1.0 (false) or beta (true) endpoint should be used at Microsoft Graph to query for the data</param>
         /// <returns>UserDelta instance</returns>
-        public static UserDelta ListUserDelta(string accessToken, string deltaToken, string filter, string orderby, string[] selectProperties = null, int startIndex = 0, int? endIndex = null)
+        public static UserDelta ListUserDelta(string accessToken, string deltaToken, string filter, string orderby, string[] selectProperties = null, int startIndex = 0, int? endIndex = null, bool useBetaEndPoint = false)
         {
-            var userDelta = PnP.Framework.Graph.UsersUtility.ListUserDelta(accessToken, deltaToken, filter, orderby, selectProperties, startIndex, endIndex);
+            var userDelta = PnP.Framework.Graph.UsersUtility.ListUserDelta(accessToken, deltaToken, filter, orderby, selectProperties, startIndex, endIndex, useBetaEndPoint: useBetaEndPoint);
 
             var result = new UserDelta
             {
@@ -45,28 +46,26 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="selectProperties">Allows providing the names of properties to return regarding the users. If not provided, the standard properties will be returned.</param>
         /// <param name="startIndex">First item in the results returned by Microsoft Graph to return</param>
         /// <param name="endIndex">Last item in the results returned by Microsoft Graph to return. Provide NULL to return all results that exist.</param>
-        /// <param name="retryCount">Number of times to retry the request in case of throttling</param>
-        /// <param name="delay">Milliseconds to wait before retrying the request. The delay will be increased (doubled) every retry.</param>
+        /// <param name="useBetaEndPoint">Indicates if the v1.0 (false) or beta (true) endpoint should be used at Microsoft Graph to query for the data</param>
         /// <returns>List with User objects</returns>
-        public static List<User> ListUsers(string accessToken, string filter, string orderby, string[] selectProperties = null, int startIndex = 0, int? endIndex = 999)
+        public static List<User> ListUsers(string accessToken, string filter, string orderby, string[] selectProperties = null, int startIndex = 0, int? endIndex = 999, bool useBetaEndPoint = false)
         {
-            return PnP.Framework.Graph.UsersUtility.ListUsers(accessToken, filter, orderby, selectProperties, startIndex, endIndex).Select(User.CreateFrom).ToList();
+            return PnP.Framework.Graph.UsersUtility.ListUsers(accessToken, filter, orderby, selectProperties, startIndex, endIndex, useBetaEndPoint: useBetaEndPoint).Select(User.CreateFrom).ToList();
         }
 
         /// <summary>
-        /// Returns the user with the provided userId from Azure Active Directory
+        /// Returns the user with the provided <paramref name="userId"/> from Azure Active Directory
         /// </summary>
         /// <param name="accessToken">The OAuth 2.0 Access Token to use for invoking the Microsoft Graph</param>
         /// <param name="userId">The unique identifier of the user in Azure Active Directory to return</param>    
         /// <param name="selectProperties">Allows providing the names of properties to return regarding the users. If not provided, the standard properties will be returned.</param>
         /// <param name="startIndex">First item in the results returned by Microsoft Graph to return</param>
         /// <param name="endIndex">Last item in the results returned by Microsoft Graph to return. Provide NULL to return all results that exist.</param>
-        /// <param name="retryCount">Number of times to retry the request in case of throttling</param>
-        /// <param name="delay">Milliseconds to wait before retrying the request. The delay will be increased (doubled) every retry.</param>
+        /// <param name="useBetaEndPoint">Indicates if the v1.0 (false) or beta (true) endpoint should be used at Microsoft Graph to query for the data</param>
         /// <returns>List with User objects</returns>
-        public static User GetUser(string accessToken, Guid userId, string[] selectProperties = null, int startIndex = 0, int? endIndex = 999)
+        public static User GetUser(string accessToken, Guid userId, string[] selectProperties = null, int startIndex = 0, int? endIndex = 999, bool useBetaEndPoint = false)
         {
-            return PnP.Framework.Graph.UsersUtility.ListUsers(accessToken, $"id eq '{userId}'", null, selectProperties, startIndex, endIndex).Select(User.CreateFrom).FirstOrDefault();
+            return PnP.Framework.Graph.UsersUtility.ListUsers(accessToken, $"id eq '{userId}'", null, selectProperties, startIndex, endIndex, useBetaEndPoint: useBetaEndPoint).Select(User.CreateFrom).FirstOrDefault();
         }
 
         /// <summary>
@@ -77,12 +76,11 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="selectProperties">Allows providing the names of properties to return regarding the users. If not provided, the standard properties will be returned.</param>
         /// <param name="startIndex">First item in the results returned by Microsoft Graph to return</param>
         /// <param name="endIndex">Last item in the results returned by Microsoft Graph to return. Provide NULL to return all results that exist.</param>
-        /// <param name="retryCount">Number of times to retry the request in case of throttling</param>
-        /// <param name="delay">Milliseconds to wait before retrying the request. The delay will be increased (doubled) every retry.</param>
+        /// <param name="useBetaEndPoint">Indicates if the v1.0 (false) or beta (true) endpoint should be used at Microsoft Graph to query for the data</param>
         /// <returns>User object</returns>
-        public static User GetUser(string accessToken, string userPrincipalName, string[] selectProperties = null, int startIndex = 0, int? endIndex = 999)
+        public static User GetUser(string accessToken, string userPrincipalName, string[] selectProperties = null, int startIndex = 0, int? endIndex = 999, bool useBetaEndPoint = false)
         {
-            return PnP.Framework.Graph.UsersUtility.ListUsers(accessToken, $"userPrincipalName eq '{userPrincipalName}'", null, selectProperties, startIndex, endIndex).Select(User.CreateFrom).FirstOrDefault();
+            return PnP.Framework.Graph.UsersUtility.ListUsers(accessToken, $"userPrincipalName eq '{userPrincipalName}'", null, selectProperties, startIndex, endIndex, useBetaEndPoint: useBetaEndPoint).Select(User.CreateFrom).FirstOrDefault();
         }
 
         #endregion


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
- Added optional `-UseBeta` parameter to `Get-PnPAzureADUser` to force it to use the Microsoft Graph beta endpoint. This can be necessary when i.e. using `-Select "PreferredDataLocation"` to query for users with a specific multi geo location as this property is only available through the beta endpoint.