### PR TITLE
Changing `Get-PnPAzureADUser` to return all users by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - The `Move\Remove\Rename-PnPFolder` cmdlets now support pipebinds.
 - Changed `Add-PnPDataRowsToSiteTemplate`, it will return a warning if user(s) are not found during list item extraction. Earlier it used to throw error and stop extraction of list items.
 - Disabling telemetry collection now requires either setting the environment variable or creating the telemetry file ([documentation](https://pnp.github.io/powershell/articles/configuration.html)) [#1504](https://github.com/pnp/powershell/pull/1504)
-- Changed `Get-PnPAzureADUser` to now return all the users in Azure Active Directory by default, instead of only the first 999, unless you specified `-EndIndex:$null`
+- Changed `Get-PnPAzureADUser` to now return all the users in Azure Active Directory by default, instead of only the first 999, unless you specified `-EndIndex:$null` [#1565](https://github.com/pnp/powershell/pull/1565)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - The `Move\Remove\Rename-PnPFolder` cmdlets now support pipebinds.
 - Changed `Add-PnPDataRowsToSiteTemplate`, it will return a warning if user(s) are not found during list item extraction. Earlier it used to throw error and stop extraction of list items.
 - Disabling telemetry collection now requires either setting the environment variable or creating the telemetry file ([documentation](https://pnp.github.io/powershell/articles/configuration.html)) [#1504](https://github.com/pnp/powershell/pull/1504)
+- Changed `Get-PnPAzureADUser` to now return all the users in Azure Active Directory by default, instead of only the first 999, unless you specified `-EndIndex:$null`
 
 ### Fixed
 

--- a/documentation/Get-PnPAzureADUser.md
+++ b/documentation/Get-PnPAzureADUser.md
@@ -43,14 +43,14 @@ Get-PnPAzureADUser [-Filter <String>] [-OrderBy <String>] [-Select <String[]>] [
 Get-PnPAzureADUser
 ```
 
-Retrieves the first 1000 users from Azure Active Directory
+Retrieves all users from Azure Active Directory
 
 ### EXAMPLE 2
 ```powershell
-Get-PnPAzureADUser -EndIndex $null
+Get-PnPAzureADUser -EndIndex 50
 ```
 
-Retrieves all users from Azure Active Directory
+Retrieves the first 50 users from Azure Active Directory. Notice that you have no control over who will be in this batch of 50 unless you combine it with the `-Filter` and/or `-OrderBy` parameters.
 
 ### EXAMPLE 3
 ```powershell
@@ -106,7 +106,7 @@ Retrieves all the users from Azure Active Directory which have had changes since
 Get-PnPAzureADUser -StartIndex 10 -EndIndex 20
 ```
 
-Retrieves the 10th through the 20th user from Azure Active Directory
+Retrieves the 10th through the 20th user from Azure Active Directory. Notice that you have no control over which users will be in this batch of 10 users.
 
 ## PARAMETERS
 
@@ -195,7 +195,7 @@ Accept wildcard characters: False
 ```
 
 ### -StartIndex
-Allows defining the first result to return. Useful for i.e. paging.
+Allows defining the first result to return. Useful for i.e. pagination.
 
 ```yaml
 Type: Int32
@@ -209,7 +209,7 @@ Accept wildcard characters: False
 ```
 
 ### -EndIndex
-Allows defining the last result to return. Useful for i.e. pagina. If omitted, it will use 999. If set to $null, it will return all users from Azure Active Directory.
+Allows defining the last result to return. Useful for i.e. pagination. If omitted, it will return all available users from Azure Active Directory.
 
 ```yaml
 Type: Int32
@@ -217,7 +217,7 @@ Parameter Sets: (All)
 
 Required: False
 Position: Named
-Default value: 999
+Default value: $null
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/src/Commands/AzureAD/GetAzureADUser.cs
+++ b/src/Commands/AzureAD/GetAzureADUser.cs
@@ -44,7 +44,7 @@ namespace PnP.PowerShell.Commands.Principals
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_LIST)]
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_DELTA)]
-        public int? EndIndex = 999;
+        public int? EndIndex = null;
 
         protected override void ExecuteCmdlet()
         {


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Changing `Get-PnPAzureADUser` to by default return all available user objects not needing `-EndIndex:$null` to be explicitly specified anymore