### PR TITLE
Tidied up Add-PnPField to add further info on choices & formula parameters and removed references to create field from XML.

### DIFF
--- a/documentation/Add-PnPField.md
+++ b/documentation/Add-PnPField.md
@@ -17,7 +17,7 @@ Add a field
 ### Add field to list (Default)
 ```powershell
 Add-PnPField [-List <ListPipeBind>] -DisplayName <String> -InternalName <String> -Type <FieldType>
- [-Id <Guid>] [-AddToDefaultView] [-Required] [-Group <String>] [-ClientSideComponentId <Guid>]
+ [-Id <Guid>] [-Formula <String>] [-AddToDefaultView] [-Required] [-Group <String>] [-ClientSideComponentId <Guid>]
  [-ClientSideComponentProperties <String>] [-AddToAllContentTypes] [-Connection <PnPConnection>]
  [<CommonParameters>]
 ```
@@ -30,14 +30,8 @@ Add-PnPField -List <ListPipeBind> -Field <FieldPipeBind> [-Connection <PnPConnec
 
 ### Add field to web
 ```powershell
-Add-PnPField -DisplayName <String> -InternalName <String> -Type <FieldType> [-Id <Guid>]
+Add-PnPField -DisplayName <String> -InternalName <String> -Type <FieldType> [-Id <Guid>] [-Formula <String>] 
  [-ClientSideComponentId <Guid>] [-ClientSideComponentProperties <String>] 
- [-Connection <PnPConnection>] [<CommonParameters>]
-```
-
-### Add field by XML to list
-```powershell
-Add-PnPField [-AddToDefaultView] [-Required] [-Group <String>] [-AddToAllContentTypes]
  [-Connection <PnPConnection>] [<CommonParameters>]
 ```
 
@@ -67,6 +61,20 @@ Add-PnPField -List "Demo list" -DisplayName "Speakers" -InternalName "SPSSpeaker
 
 This will add a field of type Multiple Choice to the list "Demo List". (you can pick several choices for the same item)
 
+### EXAMPLE 4
+```powershell
+Add-PnPField -List "TestLib" -Field "Demo List"
+```
+
+This will add an existing site column called "MyTest" to the list "Demo List".
+
+### EXAMPLE 5
+```powershell
+Add-PnPField -Type Choice -Choices "PnP","Parker","Sharing Is Caring" -DisplayName "Choice Column" -InternalName "Choice"
+```
+
+This will add a site column of type Choice along with choices and only one choice can be chosen at the same time.
+
 ## PARAMETERS
 
 ### -AddToDefaultView
@@ -74,7 +82,7 @@ Switch Parameter if this field must be added to the default view
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Add field to list, Add field by XML to list
+Parameter Sets: Add field to list, Add field to web
 
 Required: False
 Position: Named
@@ -88,7 +96,20 @@ Switch Parameter if this field must be added to all content types
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Add field to list, Add field by XML to list
+Parameter Sets: Add field to list, Add field to web
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+### -Choices
+The Choice values when field type is Choice or MultiChoice
+
+```yaml
+Type: FieldPipeBind
+Parameter Sets: Add field to list (Choice or MultiChoice Field), Add field to web (Choice or MultiChoice Field)
 
 Required: False
 Position: Named
@@ -167,6 +188,20 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Formula
+The Formula when Calculated column is chosen.
+
+```yaml
+Type: FieldPipeBind
+Parameter Sets: Add field to list (Calculated Field), Add field to web  (Calculated Field)
+
+Required: Fals
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Group
 The group name to where this field belongs to
 
@@ -239,7 +274,7 @@ Switch Parameter if the field is a required field
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Add field to list, Add field by XML to list
+Parameter Sets: Add field to list, Add field to web
 
 Required: False
 Position: Named

--- a/documentation/Add-PnPField.md
+++ b/documentation/Add-PnPField.md
@@ -17,7 +17,7 @@ Add a field
 ### Add field to list (Default)
 ```powershell
 Add-PnPField [-List <ListPipeBind>] -DisplayName <String> -InternalName <String> -Type <FieldType>
- [-Id <Guid>] [-Formula <String>] [-AddToDefaultView] [-Required] [-Group <String>] [-ClientSideComponentId <Guid>]
+ [-Id <Guid>] [-Formula <String>] [-Choices <String>] [-AddToDefaultView] [-Required] [-Group <String>] [-ClientSideComponentId <Guid>]
  [-ClientSideComponentProperties <String>] [-AddToAllContentTypes] [-Connection <PnPConnection>]
  [<CommonParameters>]
 ```
@@ -30,7 +30,7 @@ Add-PnPField -List <ListPipeBind> -Field <FieldPipeBind> [-Connection <PnPConnec
 
 ### Add field to web
 ```powershell
-Add-PnPField -DisplayName <String> -InternalName <String> -Type <FieldType> [-Id <Guid>] [-Formula <String>] 
+Add-PnPField -DisplayName <String> -InternalName <String> -Type <FieldType> [-Id <Guid>] [-Formula <String>] [-Choices <String>]
  [-ClientSideComponentId <Guid>] [-ClientSideComponentProperties <String>] 
  [-Connection <PnPConnection>] [<CommonParameters>]
 ```
@@ -63,17 +63,17 @@ This will add a field of type Multiple Choice to the list "Demo List". (you can 
 
 ### EXAMPLE 4
 ```powershell
-Add-PnPField -List "TestLib" -Field "Demo List"
+Add-PnPField -List "Demo List" -Field "MyTestCol"
 ```
 
-This will add an existing site column called "MyTest" to the list "Demo List".
+This will add an existing site column called "MyTestCol" to the list "Demo List".
 
 ### EXAMPLE 5
 ```powershell
-Add-PnPField -Type Choice -Choices "PnP","Parker","Sharing Is Caring" -DisplayName "Choice Column" -InternalName "Choice"
+Add-PnPField -Type Choice -Choices "PnP","Parker","Sharing Is Caring" -DisplayName "My Test Column" -InternalName "MyTestCol"
 ```
 
-This will add a site column of type Choice along with choices and only one choice can be chosen at the same time.
+This will add a site column of type Choice (only one choice value can be chosen at the same time) called "My Test Column" with three choice values.
 
 ## PARAMETERS
 
@@ -108,8 +108,8 @@ Accept wildcard characters: False
 The Choice values when field type is Choice or MultiChoice
 
 ```yaml
-Type: FieldPipeBind
-Parameter Sets: Add field to list (Choice or MultiChoice Field), Add field to web (Choice or MultiChoice Field)
+Type: String[]
+Parameter Sets: Add field to list (Choice or MultiChoice Field Chosen), Add field to web (Choice or MultiChoice Field Chosen)
 
 Required: False
 Position: Named
@@ -192,10 +192,10 @@ Accept wildcard characters: False
 The Formula when Calculated column is chosen.
 
 ```yaml
-Type: FieldPipeBind
+Type: String[]
 Parameter Sets: Add field to list (Calculated Field), Add field to web  (Calculated Field)
 
-Required: Fals
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample
- [X] Doc Fix

## Related Issues? ##


## What is in this Pull Request ? ##
Tidied up the Add-PnPField documentation to add further information regarding -Formula and -Choices fields. Updated documentation to remove references to creating field from XML which has branched off to a new cmdlet Add-PnPFieldFromXml and there is no longer a parameter in Add-PnPField to accept Xml (I note in the code https://github.com/pnp/powershell/blob/dev/src/Commands/Fields/AddField.cs it still references xml so not sure if I'm reading the code correctly or it needs cleaning up due to the new cmdlet Add-PnPFieldFromXml).
