### PR TITLE
Removed `Get-PnPAadUser` alias from `Get-PnPAzureAdUser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed `Add-PnPClientSidePageSection`, use `Add-PnPPageSection` instead [#1563](https://github.com/pnp/powershell/pull/1563)
 - Removed `Add-PnPClientSideWebPart`, use `Add-PnPPageWebPart` instead [#1563](https://github.com/pnp/powershell/pull/1563)
 - Removed `Add-PnPClientSideText`, use `Add-PnPPageTextPart` instead [#1563](https://github.com/pnp/powershell/pull/1563)
-- Removed `Get-PnPAADUser`, user `Get-PnPAzureADUser` instead
+- Removed `Get-PnPAADUser`, user `Get-PnPAzureADUser` instead [#1568](https://github.com/pnp/powershell/pull/1568)
 
 ### Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed `Add-PnPClientSidePageSection`, use `Add-PnPPageSection` instead [#1563](https://github.com/pnp/powershell/pull/1563)
 - Removed `Add-PnPClientSideWebPart`, use `Add-PnPPageWebPart` instead [#1563](https://github.com/pnp/powershell/pull/1563)
 - Removed `Add-PnPClientSideText`, use `Add-PnPPageTextPart` instead [#1563](https://github.com/pnp/powershell/pull/1563)
-- Removed `Get-PnPAADUser`, user `Get-PnPAzureADUser` instead [#1568](https://github.com/pnp/powershell/pull/1568)
+- Removed `Get-PnPAADUser`, use `Get-PnPAzureADUser` instead [#1568](https://github.com/pnp/powershell/pull/1568)
 
 ### Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed `Add-PnPClientSidePageSection`, use `Add-PnPPageSection` instead [#1563](https://github.com/pnp/powershell/pull/1563)
 - Removed `Add-PnPClientSideWebPart`, use `Add-PnPPageWebPart` instead [#1563](https://github.com/pnp/powershell/pull/1563)
 - Removed `Add-PnPClientSideText`, use `Add-PnPPageTextPart` instead [#1563](https://github.com/pnp/powershell/pull/1563)
+- Removed `Get-PnPAADUser`, user `Get-PnPAzureADUser` instead
 
 ### Contributors
 

--- a/src/Commands/AzureAD/GetAzureADUser.cs
+++ b/src/Commands/AzureAD/GetAzureADUser.cs
@@ -9,7 +9,6 @@ namespace PnP.PowerShell.Commands.Principals
 {
     [Cmdlet(VerbsCommon.Get, "PnPAzureADUser", DefaultParameterSetName = ParameterSet_LIST)]
     [RequiredMinimalApiPermissions("User.Read.All")]
-    [Alias("Get-PnPAADUser")]
     public class GetAzureADUser : PnPGraphCmdlet
     {
         const string ParameterSet_BYID = "Return by specific ID";
@@ -48,11 +47,6 @@ namespace PnP.PowerShell.Commands.Principals
 
         protected override void ExecuteCmdlet()
         {
-            if(MyInvocation.InvocationName.ToLower().Equals("get-pnpaaduser"))
-            {
-                WriteWarning("Get-PnPAADUser is obsolete. Use Get-PnPAzureADUser instead which has the same parameters.");
-            }
-
             if (PnPConnection.Current.ClientId == PnPConnection.PnPManagementShellClientId)
             {
                 PnPConnection.Current.Scopes = new[] { "Directory.ReadWrite.All" };


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample
- [X] Cleanup

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Removed `Get-PnPAadUser` alias from `Get-PnPAzureAdUser` as it was marked deprecated a year ago already