### PR TITLE
Fixes Add-PnPFileToSiteTemplate

### DIFF
--- a/src/Commands/Provisioning/Site/AddFileToSiteTemplate.cs
+++ b/src/Commands/Provisioning/Site/AddFileToSiteTemplate.cs
@@ -18,7 +18,7 @@ namespace PnP.PowerShell.Commands.Provisioning.Site
     public class AddFileToSiteTemplate : PnPWebCmdlet
     {
         const string parameterSet_LOCALFILE = "Local File";
-        const string parameterSet_REMOTEFILE = "Remove File";
+        const string parameterSet_REMOTEFILE = "Remote File";
 
         [Parameter(Mandatory = true, Position = 0)]
         public string Path;
@@ -113,7 +113,11 @@ namespace PnP.PowerShell.Commands.Provisioning.Site
         {
             var source = !string.IsNullOrEmpty(container) ? (container + "/" + fileName) : fileName;
 
-            template.Connector.SaveFileStream(fileName, container, fs);
+            //See if sourcefile already is in same directory as template, if so we dont need to save it again
+            if (!System.IO.File.Exists(System.IO.Path.Combine(new FileInfo(Path).DirectoryName, source)))
+            {
+                template.Connector.SaveFileStream(fileName, container, fs);
+            }
 
             if (template.Connector is ICommitableFileConnector connector)
             {


### PR DESCRIPTION
Fixes an issue where the FileStream tried to overwrite an already open filestream when a file was located in the same directory as the template file itself

Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
#1529

## What is in this Pull Request ? ##
Fixes Add-PnPFileToSiteTemplate

Fixes an issue where the FileStream tried to overwrite an already open filestream when a file was located in the same directory as the template file itself.

Add-PnPFileToSiteTemplate throwing error "The process cannot access the file 'filename' because it us being used by another process".

Also fixed an spelling mistake for the value of const parameterSet_REMOTEFILE.
