### PR TITLE
Allow piping output between `PnPTenantDeletedSite` cmdlets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support to add multiple owners and members in `New-PnPTeamsTeam` cmdlet [#1241](https://github.com/pnp/powershell/pull/1241)
 - Added the ability to set the title of a new modern page in SharePoint Online using `Add-PnPPage` to be different from its filename by using `-Title`
 - Added `Get-PnPTeamsPrimaryChannel` to get the primary Teams channel, general, of a Team [#1572](https://github.com/pnp/powershell/pull/1572)
-- Added ability to pipe the output of `Get-PnPTenantDeletedSite` to either `Restore-PnPTenantDeletedSite` or `Remove-PnPTenantDeletedSite`
+- Added ability to pipe the output of `Get-PnPTenantDeletedSite` to either `Restore-PnPTenantDeletedSite` or `Remove-PnPTenantDeletedSite` [#1596](https://github.com/pnp/powershell/pull/1596)
 
 ### Changed
 
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Changed `Add-PnPDataRowsToSiteTemplate`, it will return a warning if user(s) are not found during list item extraction. Earlier it used to throw error and stop extraction of list items.
 - Disabling telemetry collection now requires either setting the environment variable or creating the telemetry file ([documentation](https://pnp.github.io/powershell/articles/configuration.html)) [#1504](https://github.com/pnp/powershell/pull/1504)
 - Changed `Get-PnPAzureADUser` to now return all the users in Azure Active Directory by default, instead of only the first 999, unless you specified `-EndIndex:$null` [#1565](https://github.com/pnp/powershell/pull/1565)
-- Changed `Get-PnPTenantDeletedSite -Identity` no longer returning an unknown exception when no site collection with the provided Url exists in the tenant recycle bin but instead returning no output to align with other cmdlets
+- Changed `Get-PnPTenantDeletedSite -Identity` no longer returning an unknown exception when no site collection with the provided Url exists in the tenant recycle bin but instead returning no output to align with other cmdlets [#1596](https://github.com/pnp/powershell/pull/1596)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support to add multiple owners and members in `New-PnPTeamsTeam` cmdlet [#1241](https://github.com/pnp/powershell/pull/1241)
 - Added the ability to set the title of a new modern page in SharePoint Online using `Add-PnPPage` to be different from its filename by using `-Title`
 - Added `Get-PnPTeamsPrimaryChannel` to get the primary Teams channel, general, of a Team [#1572](https://github.com/pnp/powershell/pull/1572)
+- Added ability to pipe the output of `Get-PnPTenantDeletedSite` to either `Restore-PnPTenantDeletedSite` or `Remove-PnPTenantDeletedSite`
 
 ### Changed
 
@@ -29,6 +30,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Changed `Add-PnPDataRowsToSiteTemplate`, it will return a warning if user(s) are not found during list item extraction. Earlier it used to throw error and stop extraction of list items.
 - Disabling telemetry collection now requires either setting the environment variable or creating the telemetry file ([documentation](https://pnp.github.io/powershell/articles/configuration.html)) [#1504](https://github.com/pnp/powershell/pull/1504)
 - Changed `Get-PnPAzureADUser` to now return all the users in Azure Active Directory by default, instead of only the first 999, unless you specified `-EndIndex:$null` [#1565](https://github.com/pnp/powershell/pull/1565)
+- Changed `Get-PnPTenantDeletedSite -Identity` no longer returning an unknown exception when no site collection with the provided Url exists in the tenant recycle bin but instead returning no output to align with other cmdlets
 
 ### Fixed
 

--- a/src/Commands/Admin/GetTenantDeletedSite.cs
+++ b/src/Commands/Admin/GetTenantDeletedSite.cs
@@ -6,7 +6,6 @@ using PnP.PowerShell.Commands.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Management.Automation;
-using System.Text;
 
 namespace PnP.PowerShell.Commands.Admin
 {
@@ -64,8 +63,16 @@ namespace PnP.PowerShell.Commands.Admin
             {
                 DeletedSiteProperties deletedSitePropertiesByUrl = Tenant.GetDeletedSitePropertiesByUrl(Identity.Url);
                 ClientContext.Load(deletedSitePropertiesByUrl);
-                ClientContext.ExecuteQueryRetry();
-                WriteObject(new Model.SPODeletedSite(deletedSitePropertiesByUrl));
+
+                try
+                {
+                    ClientContext.ExecuteQueryRetry();
+                    WriteObject(new Model.SPODeletedSite(deletedSitePropertiesByUrl));
+                }
+                catch (Microsoft.SharePoint.Client.ServerException e) when (e.ServerErrorTypeName.Equals("Microsoft.SharePoint.Client.UnknownError", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    WriteVerbose($"No sitecollection found in the tenant recycle bin with the Url {Identity.Url}");
+                }
             }
         }
 

--- a/src/Commands/Admin/RemoveTenantDeletedSite.cs
+++ b/src/Commands/Admin/RemoveTenantDeletedSite.cs
@@ -3,9 +3,7 @@ using Microsoft.SharePoint.Client;
 using PnP.PowerShell.Commands.Base;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 using System;
-using System.Collections.Generic;
 using System.Management.Automation;
-using System.Text;
 
 namespace PnP.PowerShell.Commands.Admin
 {

--- a/src/Commands/Admin/RestoreTenantSite.cs
+++ b/src/Commands/Admin/RestoreTenantSite.cs
@@ -3,9 +3,7 @@ using Microsoft.SharePoint.Client;
 using PnP.PowerShell.Commands.Base;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 using System;
-using System.Collections.Generic;
 using System.Management.Automation;
-using System.Text;
 
 namespace PnP.PowerShell.Commands.Admin
 {

--- a/src/Commands/Base/PipeBinds/SPOSitePipeBind.cs
+++ b/src/Commands/Base/PipeBinds/SPOSitePipeBind.cs
@@ -29,6 +29,13 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             _url = site.Url?.TrimEnd(new char[] { '/' });
         }
 
-        
+        public SPOSitePipeBind(Model.SPODeletedSite site)
+        {
+            if(string.IsNullOrEmpty(site.Url))
+            {
+                throw new PSArgumentException("Site Url must be specified");
+            }
+            _url = site.Url?.TrimEnd(new char[] { '/' });
+        }
     }
 }

--- a/src/Commands/Model/SPODeletedSite.cs
+++ b/src/Commands/Model/SPODeletedSite.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.Online.SharePoint.TenantAdministration;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace PnP.PowerShell.Commands.Model
 {


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
Requested through https://github.com/pnp/powershell/issues/1589

## What is in this Pull Request ? ##
- Changed `Get-PnPTenantDeletedSite -Identity` no longer returning an unknown exception when no site collection with the provided Url exists in the tenant recycle bin but instead returning no output to align with other cmdlets
- Added ability to pipe the output of `Get-PnPTenantDeletedSite` to either `Restore-PnPTenantDeletedSite` or `Remove-PnPTenantDeletedSite`