### PR TITLE
Bugfix in errors being swallowed for `Get-PnPUnifiedAuditLog`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,7 +206,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Changed `Get-PnPSiteDesign` and `Invoke-PnPSiteDesign` to when providing a name through `-Identity` to be able to work with all site designs having that same name instead of just the first one
 - Changed `Set-PnPListItemPermission` to support piping in a roledefinition for `-AddRole` and `-RemoveRole`
 - Changed that `Get-PnPSiteScript -Identity` now also works with the site script name instead of just the site script Id
-- Changed that `Get-PnPUnifiedAuditLog` returns the error being returned by the Office Management API service, in case something goes wrong
+- Changed that `Get-PnPUnifiedAuditLog` returns the error being returned by the Office Management API service, in case something goes wrong [#1631](https://github.com/pnp/powershell/pull/1631)
 
 ### Fixed
 - Fixed `Get-PnPChangeLog -Nightly` not returning anything

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Changed `Get-PnPSiteDesign` and `Invoke-PnPSiteDesign` to when providing a name through `-Identity` to be able to work with all site designs having that same name instead of just the first one
 - Changed `Set-PnPListItemPermission` to support piping in a roledefinition for `-AddRole` and `-RemoveRole`
 - Changed that `Get-PnPSiteScript -Identity` now also works with the site script name instead of just the site script Id
+- Changed that `Get-PnPUnifiedAuditLog` returns the error being returned by the Office Management API service, in case something goes wrong
 
 ### Fixed
 - Fixed `Get-PnPChangeLog -Nightly` not returning anything


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Currently when the audit log service returns an error, it does not get returned to the output in your console. There is no way unless using Fiddler to know what's going or if the request even succeeded. With this update, if an error occurs, it will be returned as an exception so you can anticipate on it in your scripts and know what went wrong.