### PR TITLE
Update Remove-PnPTenantDeletedSite

### DIFF
--- a/documentation/Remove-PnPTenantDeletedSite.md
+++ b/documentation/Remove-PnPTenantDeletedSite.md
@@ -7,7 +7,7 @@ external help file: PnP.PowerShell.dll-Help.xml
 online version: https://pnp.github.io/powershell/cmdlets/Remove-PnPTenantDeletedSite.html
 ---
  
-# Remove-PnPTenantSite
+# Remove-PnPTenantDeletedSite
 
 ## SYNOPSIS
 


### PR DESCRIPTION
Page titled shows as "Remove-PnPTenantSite" and not "Remove-PnPTenantDeletedSite", although the body of the article is clearly for deleting from the recycle bin.

- [ ✔️] Bug Fix
- [ ❌] New Feature
- [❌ ] Sample

## What is in this Pull Request ? ##
Documentation update. 