### PR TITLE
User Profile Bulk import job improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Current Nightly]
 
 ### Added
+- Added -Wait and -Verbose optional paramarers to New-PnPUPABulkImportJob
 
 ### Changed
+- Changed Sync-PnPSharePointUserProfilesFromAzureActiveDirectory to map users based on their Ids instead which should resolve some issues around user identities reporting not to exist. You can use the new -IdType option to switch it back to PrincipalName if needed.
 
 ### Fixed
 
 ### Removed
 
 ### Contributors
+
+- Koen Zomers [koenzomers]
 
 ## [1.10.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+### Contributors
+
 ## [1.10.0]
 
 ### Added

--- a/documentation/Add-PnPFile.md
+++ b/documentation/Add-PnPFile.md
@@ -29,6 +29,7 @@ Add-PnPFile -Folder <FolderPipeBind> -FileName <String> -Stream <Stream> [-Check
 ```
 
 ## DESCRIPTION
+This cmdlet uploads a local file or a file from a stream to the specified folder.
 
 ## EXAMPLES
 

--- a/documentation/Add-PnPPage.md
+++ b/documentation/Add-PnPPage.md
@@ -10,7 +10,7 @@ title: Add-PnPPage
 # Add-PnPPage
 
 ## SYNOPSIS
-Allows creation of a new page
+Creates a new page
 
 ## SYNTAX
 
@@ -23,7 +23,7 @@ Add-PnPPage [-Name] <String> [-LayoutType <PageLayoutType>]
 ```
 
 ## DESCRIPTION
-Allows creation of a new page. The page will be located inside the Site Pages library of the cite currently connected to.
+Creates a new page. The page will be located inside the Site Pages library of the cite currently connected to.
 
 ## EXAMPLES
 
@@ -120,20 +120,6 @@ Enables or Disables the comments on the page
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: (All)
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Connection
-Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.
-
-```yaml
-Type: PnPConnection
 Parameter Sets: (All)
 
 Required: False

--- a/documentation/Add-PnPRoleDefinition.md
+++ b/documentation/Add-PnPRoleDefinition.md
@@ -98,7 +98,7 @@ Accept wildcard characters: False
 ```
 
 ### -Exclude
-Specifies permission flags(s) to disable. Please visit https://docs.microsoft.com/previous-versions/office/sharepoint-csom/ee536458(v%3Doffice.15) for the PermissionKind enum
+Specifies permission flag(s) to disable. Please visit https://docs.microsoft.com/previous-versions/office/sharepoint-csom/ee536458(v%3Doffice.15) for the PermissionKind enum
 
 ```yaml
 Type: PermissionKind[]
@@ -113,7 +113,7 @@ Accept wildcard characters: False
 ```
 
 ### -Include
-Specifies permission flags(s) to enable. Please visit https://docs.microsoft.com/previous-versions/office/sharepoint-csom/ee536458(v%3Doffice.15) for the PermissionKind enum
+Specifies permission flag(s) to enable. Please visit https://docs.microsoft.com/previous-versions/office/sharepoint-csom/ee536458(v%3Doffice.15) for the PermissionKind enum
 
 ```yaml
 Type: PermissionKind[]

--- a/documentation/New-PnPUPABulkImportJob.md
+++ b/documentation/New-PnPUPABulkImportJob.md
@@ -174,7 +174,7 @@ Accept wildcard characters: False
 ```
 
 ### -Wait
-Adding this parameter will cause the script to start the user profile sync operation and wait with proceeding with the rest of the script until the user profiles have been imported into the SharePoint Online user profile. It can take a long time for the user profile sync operation to complete. It will check every 30 seconds for the current status of the job, to avoid getting throttled. This retry value is non configurable.
+Adding this parameter will cause the script to start the user profile sync operation and wait with proceeding with the rest of the script until the user profiles have been imported into the SharePoint Online user profile. It can take a long time for the user profile sync operation to complete. It will check every 30 seconds for the current status of the job, to avoid getting throttled. The check interval is non configurable.
 
 Add `-Verbose` as well to be notified about the progress while waiting.
 

--- a/documentation/New-PnPUPABulkImportJob.md
+++ b/documentation/New-PnPUPABulkImportJob.md
@@ -175,10 +175,14 @@ Accept wildcard characters: False
 
 ### -Wait
 <<<<<<< HEAD
+<<<<<<< HEAD
 Adding this parameter will cause the script to start the user profile sync operation and wait with proceeding with the rest of the script until the user profiles have been imported into the SharePoint Online user profile. It can take a long time for the user profile sync operation to complete. It will check every 30 seconds for the current status of the job, to avoid getting throttled. The check interval is non configurable.
 =======
 Adding this parameter will cause the script to start the user profile sync operation and wait with proceeding with the rest of the script until the user profiles have been imported into the SharePoint Online user profile. It can take a long time for the user profile sync operation to complete. It will check every 30 seconds for the current status of the job, to avoid getting throttled. This retry value is non configurable.
 >>>>>>> b75bab61... Work in progress
+=======
+Adding this parameter will cause the script to start the user profile sync operation and wait with proceeding with the rest of the script until the user profiles have been imported into the SharePoint Online user profile. It can take a long time for the user profile sync operation to complete. It will check every 30 seconds for the current status of the job, to avoid getting throttled. The check interval is non configurable.
+>>>>>>> 813e9972... Minor documentatipn updates
 
 Add `-Verbose` as well to be notified about the progress while waiting.
 

--- a/documentation/New-PnPUPABulkImportJob.md
+++ b/documentation/New-PnPUPABulkImportJob.md
@@ -21,13 +21,13 @@ Submit up a new user profile bulk import job.
 
 ```powershell
 New-PnPUPABulkImportJob [-Folder] <String> [-Path] <String> [-UserProfilePropertyMapping] <Hashtable>
- [-IdProperty] <String> [[-IdType] <ImportProfilePropertiesUserIdType>] [-Connection <PnPConnection>]
+ [-IdProperty] <String> [[-IdType] <ImportProfilePropertiesUserIdType>] [-Wait] [-Verbose] [-Connection <PnPConnection>]
  [<CommonParameters>]
 ```
 
 ```powershell
 New-PnPUPABulkImportJob -Url <String> [-UserProfilePropertyMapping] <Hashtable>
- [-IdProperty] <String> [[-IdType] <ImportProfilePropertiesUserIdType>] [-Connection <PnPConnection>]
+ [-IdProperty] <String> [[-IdType] <ImportProfilePropertiesUserIdType>] [-Wait] [-Verbose] [-Connection <PnPConnection>]
  [<CommonParameters>]
 ```
 
@@ -64,6 +64,13 @@ New-PnPUPABulkImportJob -Url "https://{tenant}.sharepoint.com/Shared Documents/p
 ```
 
 This will submit a new user profile bulk import job to SharePoint Online using an already uploaded file.
+
+### EXAMPLE 3
+```powershell
+New-PnPUPABulkImportJob -Url "https://{tenant}.sharepoint.com/sites/userprofilesync/Shared Documents/profiles.json" -IdProperty "IdName" -UserProfilePropertyMapping @{"Department"="Department"} -Wait -Verbose
+```
+
+This will submit a new user profile bulk import job to SharePoint Online using an already uploaded file and will wait until the import has finished.
 
 ## PARAMETERS
 
@@ -157,6 +164,36 @@ Optional connection to be used by the cmdlet. Retrieve the value for this parame
 
 ```yaml
 Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Wait
+Adding this parameter will cause the script to start the user profile sync operation and wait with proceeding with the rest of the script until the user profiles have been imported into the SharePoint Online user profile. It can take a long time for the user profile sync operation to complete. It will check every 30 seconds for the current status of the job, to avoid getting throttled. This retry value is non configurable.
+
+Add `-Verbose` as well to be notified about the progress while waiting.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Verbose
+When provided, additional debug statements will be shown while going through the user profile sync steps.
+
+```yaml
+Type: SwitchParameter
 Parameter Sets: (All)
 
 Required: False

--- a/documentation/New-PnPUPABulkImportJob.md
+++ b/documentation/New-PnPUPABulkImportJob.md
@@ -174,7 +174,11 @@ Accept wildcard characters: False
 ```
 
 ### -Wait
+<<<<<<< HEAD
 Adding this parameter will cause the script to start the user profile sync operation and wait with proceeding with the rest of the script until the user profiles have been imported into the SharePoint Online user profile. It can take a long time for the user profile sync operation to complete. It will check every 30 seconds for the current status of the job, to avoid getting throttled. The check interval is non configurable.
+=======
+Adding this parameter will cause the script to start the user profile sync operation and wait with proceeding with the rest of the script until the user profiles have been imported into the SharePoint Online user profile. It can take a long time for the user profile sync operation to complete. It will check every 30 seconds for the current status of the job, to avoid getting throttled. This retry value is non configurable.
+>>>>>>> b75bab61... Work in progress
 
 Add `-Verbose` as well to be notified about the progress while waiting.
 

--- a/documentation/Sync-PnPSharePointUserProfilesFromAzureActiveDirectory.md
+++ b/documentation/Sync-PnPSharePointUserProfilesFromAzureActiveDirectory.md
@@ -131,7 +131,7 @@ Accept wildcard characters: False
 ```
 
 ### -IdType
-The type of profile identifier (Email/CloudId/PrincipalName). Defaults to CloudId. Ensure that if you use this in combination with `-Users` that all of the user objects you're passing in are having their Mail property populated when choosing IdType Email, Id property for CloudId or UserPrincipalName for PrincipalName.
+The type of profile identifier (Email/CloudId/PrincipalName). Defaults to CloudId. Ensure that if you use this in combination with `-Users` that all of the user objects you're passing in are having their Mail property populated when choosing IdType Email, Id property for IdType CloudId or UserPrincipalName for IdType PrincipalName.
 
 ```yaml
 Type: ImportProfilePropertiesUserIdType
@@ -160,7 +160,7 @@ Accept wildcard characters: False
 ```
 
 ### -Wait
-Adding this parameter will cause the script to start the user profile sync operation and wait with proceeding with the rest of the script until the user profiles have been imported into the SharePoint Online user profile. It can take a long time for the user profile sync operation to complete. It will check every 30 seconds for the current status of the job, to avoid getting throttled. This retry value is non configurable.
+Adding this parameter will cause the script to start the user profile sync operation and wait with proceeding with the rest of the script until the user profiles have been imported into the SharePoint Online user profile. It can take a long time for the user profile sync operation to complete. It will check every 30 seconds for the current status of the job, to avoid getting throttled. The check interval is non configurable.
 
 Add `-Verbose` as well to be notified about the progress while waiting.
 

--- a/documentation/Sync-PnPSharePointUserProfilesFromAzureActiveDirectory.md
+++ b/documentation/Sync-PnPSharePointUserProfilesFromAzureActiveDirectory.md
@@ -132,10 +132,14 @@ Accept wildcard characters: False
 
 ### -IdType
 <<<<<<< HEAD
+<<<<<<< HEAD
 The type of profile identifier (Email/CloudId/PrincipalName). Defaults to CloudId. Ensure that if you use this in combination with `-Users` that all of the user objects you're passing in are having their Mail property populated when choosing IdType Email, Id property for IdType CloudId or UserPrincipalName for IdType PrincipalName.
 =======
 The type of profile identifier (Email/CloudId/PrincipalName). Defaults to CloudId. Ensure that if you use this in combination with `-Users` that all of the user objects you're passing in are having their Mail property populated when choosing IdType Email, Id property for CloudId or UserPrincipalName for PrincipalName.
 >>>>>>> b75bab61... Work in progress
+=======
+The type of profile identifier (Email/CloudId/PrincipalName). Defaults to CloudId. Ensure that if you use this in combination with `-Users` that all of the user objects you're passing in are having their Mail property populated when choosing IdType Email, Id property for IdType CloudId or UserPrincipalName for IdType PrincipalName.
+>>>>>>> 813e9972... Minor documentatipn updates
 
 ```yaml
 Type: ImportProfilePropertiesUserIdType

--- a/documentation/Sync-PnPSharePointUserProfilesFromAzureActiveDirectory.md
+++ b/documentation/Sync-PnPSharePointUserProfilesFromAzureActiveDirectory.md
@@ -16,7 +16,7 @@ Synchronizes user profiles from Azure Active Directory into the SharePoint Onlin
 
 ### Upload file
 ```powershell
-Sync-PnPSharePointUserProfilesFromAzureActiveDirectory -UserProfilePropertyMapping <Hashtable> [-Users <Array>] [-Folder <String>] [-Wait] [-Verbose] [-Connection <PnPConnection>] [<CommonParameters>]
+Sync-PnPSharePointUserProfilesFromAzureActiveDirectory -UserProfilePropertyMapping <Hashtable> [-IdType <Enum>] [-Users <Array>] [-Folder <String>] [-Wait] [-Verbose] [-Connection <PnPConnection>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -126,6 +126,20 @@ Parameter Sets: (All)
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IdType
+The type of profile identifier (Email/CloudId/PrincipalName). Defaults to CloudId. Ensure that if you use this in combination with `-Users` that all of the user objects you're passing in are having their Mail property populated when choosing IdType Email, Id property for CloudId or UserPrincipalName for PrincipalName.
+
+```yaml
+Type: ImportProfilePropertiesUserIdType
+Parameter Sets: (All)
+Accepted values: Email, CloudId, PrincipalName
+
+Required: False
+Default value: CloudId
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/documentation/Sync-PnPSharePointUserProfilesFromAzureActiveDirectory.md
+++ b/documentation/Sync-PnPSharePointUserProfilesFromAzureActiveDirectory.md
@@ -131,7 +131,11 @@ Accept wildcard characters: False
 ```
 
 ### -IdType
+<<<<<<< HEAD
 The type of profile identifier (Email/CloudId/PrincipalName). Defaults to CloudId. Ensure that if you use this in combination with `-Users` that all of the user objects you're passing in are having their Mail property populated when choosing IdType Email, Id property for IdType CloudId or UserPrincipalName for IdType PrincipalName.
+=======
+The type of profile identifier (Email/CloudId/PrincipalName). Defaults to CloudId. Ensure that if you use this in combination with `-Users` that all of the user objects you're passing in are having their Mail property populated when choosing IdType Email, Id property for CloudId or UserPrincipalName for PrincipalName.
+>>>>>>> b75bab61... Work in progress
 
 ```yaml
 Type: ImportProfilePropertiesUserIdType

--- a/src/Commands/UserProfiles/SyncSharePointUserProfilesFromAzureActiveDirectory.cs
+++ b/src/Commands/UserProfiles/SyncSharePointUserProfilesFromAzureActiveDirectory.cs
@@ -25,6 +25,9 @@ namespace PnP.PowerShell.Commands.UserProfiles
         public SwitchParameter WhatIf;
 
         [Parameter(Mandatory = false)]
+        public ImportProfilePropertiesUserIdType IdType = ImportProfilePropertiesUserIdType.PrincipalName;
+
+        [Parameter(Mandatory = false)]
         public SwitchParameter Wait;
 
         protected override void ExecuteCmdlet()
@@ -78,7 +81,7 @@ namespace PnP.PowerShell.Commands.UserProfiles
 
             // Perform the mapping and execute the sync operation
             WriteVerbose($"Creating mapping file{(WhatIf.ToBool() ? " and" : ",")} uploading it to SharePoint Online to folder '{Folder}'{(WhatIf.ToBool() ? "" : " and executing sync job")}");
-            var job = PnP.PowerShell.Commands.Utilities.SharePointUserProfileSync.SyncFromAzureActiveDirectory(nonAdminClientContext, aadUsers, UserProfilePropertyMapping, Folder, ParameterSpecified(nameof(WhatIf))).GetAwaiter().GetResult();
+            var job = PnP.PowerShell.Commands.Utilities.SharePointUserProfileSync.SyncFromAzureActiveDirectory(nonAdminClientContext, aadUsers, IdType, UserProfilePropertyMapping, Folder, ParameterSpecified(nameof(WhatIf))).GetAwaiter().GetResult();
 
             WriteVerbose($"Job initiated with Id {job.JobId} and status {job.State} for file {job.SourceUri}");
 


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample
- [X] Optimizations

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
- Added `-Wait` and `-Verbose` optional paramarers to `New-PnPUPABulkImportJob`
- Changed `Sync-PnPSharePointUserProfilesFromAzureActiveDirectory` to map users based on their Ids instead which should resolve some issues around user identities reporting not to exist. You can use the new `-IdType` option to switch it back to `PrincipalName` if needed.