### PR TITLE
Build-Debug.ps1: improve error message when PowerShell is too old

### DIFF
--- a/build/Build-Debug.ps1
+++ b/build/Build-Debug.ps1
@@ -1,3 +1,4 @@
+#Requires -PSEdition Core
 Param(
 	[Parameter(Mandatory = $false,
 		ValueFromPipeline = $false)]


### PR DESCRIPTION
Without this the error is
`Unable to find type [System.Management.Automation.SemanticVersion].`
