### PR TITLE
#1641- added ResourceBehaviorOptions to M365 Group creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added `-Wait` and `-Verbose` optional paramarers to `New-PnPUPABulkImportJob` [#1752](https://github.com/pnp/powershell/pull/1752)
 - Added `Add-PnpTeamsChannelUser` which allows members and owners to be added to private channels in Teams [#1735](https://github.com/pnp/powershell/pull/1735)
-
+- Added `ResourceBehaviorOptions` option in `New-PnPMicrosoft365Group` cmdlet to set `ResourceBehaviorOptions` while provisioning a Microsoft 365 Group.
 ### Changed
 - Changed `Sync-PnPSharePointUserProfilesFromAzureActiveDirectory` to map users based on their Ids instead which should resolve some issues around user identities reporting not to exist. You can use the new `-IdType` option to switch it back to `PrincipalName` if needed.  [#1752](https://github.com/pnp/powershell/pull/1752)
 

--- a/documentation/New-PnPMicrosoft365Group.md
+++ b/documentation/New-PnPMicrosoft365Group.md
@@ -21,7 +21,7 @@ Creates a new Microsoft 365 Group
 
 ```powershell
 New-PnPMicrosoft365Group -DisplayName <String> -Description <String> -MailNickname <String>
- [-Owners <String[]>] [-Members <String[]>] [-IsPrivate] [-LogoPath <String>] [-CreateTeam] [-HideFromAddressLists <Boolean>] [-HideFromOutlookClients <Boolean>] [-Force]
+ [-Owners <String[]>] [-Members <String[]>] [-IsPrivate] [-LogoPath <String>] [-CreateTeam] [-HideFromAddressLists <Boolean>] [-HideFromOutlookClients <Boolean>] [-ResourceBehaviorOptions <TeamResourceBehaviorOptions>] [-Force]
   [<CommonParameters>]
 ```
 
@@ -56,6 +56,13 @@ New-PnPMicrosoft365Group -DisplayName $displayName -Description $description -Ma
 ```
 
 Creates a private Microsoft 365 Group with all the required properties, and with a custom list of Owners and a custom list of Members
+
+### EXAMPLE 5
+```powershell
+New-PnPMicrosoft365Group -DisplayName "myPnPDemo1" -Description $description -MailNickname $nickname -Owners $arrayOfOwners -Members $arrayOfMembers -IsPrivate -ResourceBehaviorOptions WelcomeEmailDisabled, HideGroupInOutlook
+```
+
+This will create a new Microsoft 365 Group called "myPnPDemo1" and sets the privacy to Private. Welcome Email will not be sent when the Group is created. The M365 Group will also not be visible in Outlook.
 
 ## PARAMETERS
 
@@ -205,6 +212,22 @@ Controls whether the group shows in the Outlook left-hand navigation.
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResourceBehaviorOptions
+
+Allows providing ResourceBehaviorOptions which accepts multiple values that specify group behaviors for a Microsoft 365 Group.
+
+```yaml
+Type: TeamResourceBehaviorOptions
+Parameter Sets: (All)
+Accepted values: AllowOnlyMembersToPost, HideGroupInOutlook, SubscribeNewGroupMembers, WelcomeEmailDisabled
 
 Required: False
 Position: Named

--- a/src/Commands/Microsoft365Groups/NewMicrosoft365Group.cs
+++ b/src/Commands/Microsoft365Groups/NewMicrosoft365Group.cs
@@ -1,10 +1,12 @@
 ﻿using PnP.Framework.Graph;
 using PnP.PowerShell.Commands.Attributes;
 using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Enums;
 using PnP.PowerShell.Commands.Model;
 using PnP.PowerShell.Commands.Properties;
 using PnP.PowerShell.Commands.Utilities;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
 
@@ -48,6 +50,9 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
         [Parameter(Mandatory = false)]
         public SwitchParameter Force;
 
+        [Parameter(Mandatory = false)]
+        public TeamResourceBehaviorOptions?[] ResourceBehaviorOptions;
+
         protected override void ExecuteCmdlet()
         {
             if (MailNickname.Contains(" "))
@@ -89,6 +94,17 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
                     SecurityEnabled = false,
                     GroupTypes = new string[] { "Unified" }
                 };
+                
+                if (ResourceBehaviorOptions != null && ResourceBehaviorOptions.Length > 0)
+                {
+                    var teamResourceBehaviorOptionsValue = new List<string>();
+                    for (int i = 0; i < ResourceBehaviorOptions.Length; i++)
+                    {
+                        teamResourceBehaviorOptionsValue.Add(ResourceBehaviorOptions[i].ToString());
+                    }
+                    newGroup.ResourceBehaviorOptions = teamResourceBehaviorOptionsValue.ToArray();
+                }
+
                 var group = Microsoft365GroupsUtility.CreateAsync(HttpClient, AccessToken, newGroup, CreateTeam, LogoPath, Owners, Members, HideFromAddressLists, HideFromOutlookClients).GetAwaiter().GetResult();
                 
                 if (ParameterSpecified(nameof(HideFromAddressLists)) || ParameterSpecified(nameof(HideFromOutlookClients)))


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #1641 

## What is in this Pull Request ? ##
- Added `ResourceBehaviorOptions` option in `New-PnPMicrosoft365Group` cmdlet to set `ResourceBehaviorOptions` while provisioning a Microsoft 365 Group.