### PR TITLE
Lists cmdlets: Add missing OutputType attributes for better autocompletion

### DIFF
--- a/src/Commands/Lists/AddListItem.cs
+++ b/src/Commands/Lists/AddListItem.cs
@@ -13,6 +13,7 @@ using PnP.PowerShell.Commands.Utilities;
 namespace PnP.PowerShell.Commands.Lists
 {
     [Cmdlet(VerbsCommon.Add, "PnPListItem", DefaultParameterSetName = ParameterSet_SINGLE)]
+    [OutputType(typeof(ListItem))]
     public class AddListItem : PnPWebCmdlet
     {
         private const string ParameterSet_SINGLE = "Single";

--- a/src/Commands/Lists/AddView.cs
+++ b/src/Commands/Lists/AddView.cs
@@ -6,6 +6,7 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 namespace PnP.PowerShell.Commands.Lists
 {
     [Cmdlet(VerbsCommon.Add, "PnPView")]
+    [OutputType(typeof(View))]
     public class AddView : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]

--- a/src/Commands/Lists/ClearDefaultColumnValues.cs
+++ b/src/Commands/Lists/ClearDefaultColumnValues.cs
@@ -11,6 +11,7 @@ namespace PnP.PowerShell.Commands.Lists
     //TODO: Create Test
 
     [Cmdlet(VerbsCommon.Clear, "PnPDefaultColumnValues")]
+    [OutputType(typeof(void))]
     public class ClearDefaultColumnValues : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]

--- a/src/Commands/Lists/CopyList.cs
+++ b/src/Commands/Lists/CopyList.cs
@@ -10,6 +10,7 @@ using System.Linq;
 namespace PnP.PowerShell.Commands.Lists
 {
     [Cmdlet(VerbsCommon.Copy, "PnPList", DefaultParameterSetName = ParameterSet_TOCURRENTSITEBYPIPE)]
+    [OutputType(typeof(List))]
     public class CopyList : PnPWebCmdlet
     {
         private const string ParameterSet_LISTBYPIPE = "By piping in a list";

--- a/src/Commands/Lists/GetDefaultColumnValues.cs
+++ b/src/Commands/Lists/GetDefaultColumnValues.cs
@@ -1,13 +1,17 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation;
+using System.Linq;
+
 using Microsoft.SharePoint.Client;
 
 using PnP.PowerShell.Commands.Base.PipeBinds;
+using PnP.PowerShell.Commands.Model.SharePoint;
 
 namespace PnP.PowerShell.Commands.Lists
 {
     [Cmdlet(VerbsCommon.Get, "PnPDefaultColumnValues")]
+    [OutputType(typeof(ListDefaultColumnValue))]
     public class GetDefaultColumnValues : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
@@ -25,27 +29,24 @@ namespace PnP.PowerShell.Commands.Lists
                 if (list.BaseTemplate == (int)ListTemplateType.DocumentLibrary || list.BaseTemplate == (int)ListTemplateType.WebPageLibrary || list.BaseTemplate == (int)ListTemplateType.PictureLibrary)
                 {
                     var defaultValues = list.GetDefaultColumnValues();
-                    var dynamicList = new List<dynamic>();
                     if (defaultValues != null)
                     {
                         foreach (var dict in defaultValues)
                         {
-                            dynamicList.Add(
-                                new
-                                {
-                                    Path = dict["Path"],
-                                    Field = dict["Field"],
-                                    Value = dict["Value"]
-                                });
+                            WriteObject(new ListDefaultColumnValue()
+                            {
+                                Path = dict["Path"],
+                                Field = dict["Field"],
+                                Value = dict["Value"]
+                            });
 
                         }
-                        WriteObject(dynamicList, true);
                     }
                 }
-            }
-            else
-            {
-                WriteWarning("List is not a document library");
+                else
+                {
+                    WriteWarning("List is not a document library");
+                }
             }
         }
     }

--- a/src/Commands/Lists/GetList.cs
+++ b/src/Commands/Lists/GetList.cs
@@ -10,6 +10,7 @@ using PnP.PowerShell.Commands.Base;
 namespace PnP.PowerShell.Commands.Lists
 {
     [Cmdlet(VerbsCommon.Get, "PnPList")]
+    [OutputType(typeof(List))]
     public class GetList : PnPWebRetrievalsCmdlet<List>
     {
         [Parameter(Mandatory = false, ValueFromPipeline = true, Position = 0)]

--- a/src/Commands/Lists/GetListItem.cs
+++ b/src/Commands/Lists/GetListItem.cs
@@ -10,6 +10,7 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 namespace PnP.PowerShell.Commands.Lists
 {
     [Cmdlet(VerbsCommon.Get, "PnPListItem", DefaultParameterSetName = ParameterSet_ALLITEMS)]
+    [OutputType(typeof(ListItem))]
     public class GetListItem : PnPWebCmdlet
     {
         private const string ParameterSet_BYID = "By Id";

--- a/src/Commands/Lists/GetListItemComment.cs
+++ b/src/Commands/Lists/GetListItemComment.cs
@@ -7,6 +7,7 @@ using PnP.Core.QueryModel;
 namespace PnP.PowerShell.Commands.Lists
 {
     [Cmdlet(VerbsCommon.Get, "PnPListItemComment")]
+    [OutputType(typeof(ListItemComments))]
     public class GetListItemComments : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
@@ -53,7 +54,7 @@ namespace PnP.PowerShell.Commands.Lists
                         ListId = comment.ListId,
                         ParentId = comment.ParentId,
                         ReplyCount = comment.ReplyCount,
-                        Text = comment.Text                        
+                        Text = comment.Text
                     };
 
                     commentsList.Add(commentValue);

--- a/src/Commands/Lists/GetListPermissions.cs
+++ b/src/Commands/Lists/GetListPermissions.cs
@@ -1,11 +1,13 @@
 ﻿using System.Management.Automation;
 using Microsoft.SharePoint.Client;
 
+using PnP.Core.Model.Security;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 
 namespace PnP.PowerShell.Commands.Principals
 {
     [Cmdlet(VerbsCommon.Get, "PnPListPermissions")]
+    [OutputType(typeof(IRoleDefinition))]
     public class GetListPermissions : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = "ByName")]

--- a/src/Commands/Lists/GetView.cs
+++ b/src/Commands/Lists/GetView.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Management.Automation;
+
 using Microsoft.SharePoint.Client;
 
 using PnP.PowerShell.Commands.Base;
@@ -11,6 +12,7 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 namespace PnP.PowerShell.Commands.Lists
 {
     [Cmdlet(VerbsCommon.Get, "PnPView")]
+    [OutputType(typeof(View))]
     public class GetView : PnPWebRetrievalsCmdlet<View>
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]

--- a/src/Commands/Lists/NewList.cs
+++ b/src/Commands/Lists/NewList.cs
@@ -6,6 +6,7 @@ using Microsoft.SharePoint.Client;
 namespace PnP.PowerShell.Commands.Lists
 {
     [Cmdlet(VerbsCommon.New, "PnPList")]
+    [OutputType(typeof(List))]
     public class NewList : PnPWebCmdlet
     {
         [Parameter(Mandatory = true)]

--- a/src/Commands/Lists/RemoveListItemComment.cs
+++ b/src/Commands/Lists/RemoveListItemComment.cs
@@ -7,6 +7,7 @@ using System.Management.Automation;
 namespace PnP.PowerShell.Commands.Lists
 {
     [Cmdlet(VerbsCommon.Remove, "PnPListItemComment")]
+    [OutputType(typeof(void))]
     public class RemoveListItemComment : PnPWebCmdlet
     {
         private const string ParameterSet_SINGLE = "Single";

--- a/src/Commands/Lists/RemoveView.cs
+++ b/src/Commands/Lists/RemoveView.cs
@@ -7,6 +7,7 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 namespace PnP.PowerShell.Commands.Lists
 {
     [Cmdlet(VerbsCommon.Remove, "PnPView")]
+    [OutputType(typeof(void))]
     public class RemoveView : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]

--- a/src/Commands/Lists/RequestReIndexList.cs
+++ b/src/Commands/Lists/RequestReIndexList.cs
@@ -6,6 +6,7 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 namespace PnP.PowerShell.Commands.Lists
 {
     [Cmdlet(VerbsLifecycle.Request, "PnPReIndexList")]
+    [OutputType(typeof(void))]
     public class RequestReIndexList : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]

--- a/src/Commands/Lists/SetDefaultColumnValues.cs
+++ b/src/Commands/Lists/SetDefaultColumnValues.cs
@@ -9,6 +9,7 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 namespace PnP.PowerShell.Commands.Lists
 {
     [Cmdlet(VerbsCommon.Set, "PnPDefaultColumnValues")]
+    [OutputType(typeof(void))]
     public class SetDefaultColumnValues : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]

--- a/src/Commands/Lists/SetList.cs
+++ b/src/Commands/Lists/SetList.cs
@@ -7,6 +7,7 @@ using PnP.PowerShell.Commands.Enums;
 namespace PnP.PowerShell.Commands.Lists
 {
     [Cmdlet(VerbsCommon.Set, "PnPList")]
+    [OutputType(typeof(List))]
     public class SetList : PnPWebCmdlet
     {
         [Parameter(Mandatory = true)]
@@ -228,6 +229,8 @@ namespace PnP.PowerShell.Commands.Lists
                     list.Update();
                     ClientContext.ExecuteQueryRetry();
                 }
+
+                WriteObject(list);
             }
         }
     }

--- a/src/Commands/Lists/SetListItem.cs
+++ b/src/Commands/Lists/SetListItem.cs
@@ -14,6 +14,7 @@ using PnP.PowerShell.Commands.Utilities;
 namespace PnP.PowerShell.Commands.Lists
 {
     [Cmdlet(VerbsCommon.Set, "PnPListItem", DefaultParameterSetName = ParameterSet_SINGLE)]
+    [OutputType(typeof(ListItem))]
     public class SetListItem : PnPWebCmdlet
     {
         const string ParameterSet_SINGLE = "Single";

--- a/src/Commands/Lists/SetListItemPermission.cs
+++ b/src/Commands/Lists/SetListItemPermission.cs
@@ -7,6 +7,7 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 namespace PnP.PowerShell.Commands.Lists
 {
     [Cmdlet(VerbsCommon.Set, "PnPListItemPermission", DefaultParameterSetName = ParameterSet_USER)]
+    [OutputType(typeof(void))]
     public class SetListItemPermission : PnPWebCmdlet
     {
         private const string ParameterSet_GROUP = "Group";

--- a/src/Commands/Lists/SetListPermission.cs
+++ b/src/Commands/Lists/SetListPermission.cs
@@ -9,6 +9,7 @@ namespace PnP.PowerShell.Commands.Lists
 {
     //TODO: Create Test
     [Cmdlet(VerbsCommon.Set, "PnPListPermission")]
+    [OutputType(typeof(void))]
     public class SetListPermission : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, ParameterSetName = ParameterAttribute.AllParameterSets)]

--- a/src/Commands/Lists/SetView.cs
+++ b/src/Commands/Lists/SetView.cs
@@ -8,6 +8,7 @@ using System.Collections;
 namespace PnP.PowerShell.Commands.Fields
 {
     [Cmdlet(VerbsCommon.Set, "PnPView")]
+    [OutputType(typeof(View))]
     public class SetView : PnPWebCmdlet
     {
         [Parameter(Mandatory = false, Position = 0)]

--- a/src/Commands/Model/SharePoint/ListDefaultColumnValue.cs
+++ b/src/Commands/Model/SharePoint/ListDefaultColumnValue.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PnP.PowerShell.Commands.Model.SharePoint
+{
+    public sealed class ListDefaultColumnValue
+    {
+        public string Path { get; set; }
+        public string Field { get; set; }
+        public string Value { get; set; }
+    }
+}


### PR DESCRIPTION
Adds the `OutputType` attribute for improved autocompletion on the cmdlets in the Lists folder.

There's a few in here that seem to be missing outputs (created comment, updated list, recycle bin item, etc.) I'll do those in separate PRs as they might need some discussion.

Follow up to [PR #1763](https://github.com/pnp/powershell/pull/1763#issuecomment-1099695169)