### PR TITLE
Add OutputType Attribute - #2

### DIFF
--- a/src/Commands/DocumentSets/AddContentTypeToDocumentSet.cs
+++ b/src/Commands/DocumentSets/AddContentTypeToDocumentSet.cs
@@ -6,6 +6,7 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 namespace PnP.PowerShell.Commands.DocumentSets
 {
     [Cmdlet(VerbsCommon.Add,"PnPContentTypeToDocumentSet")]
+    [OutputType(typeof(void))]
     public class AddContentTypeToDocumentSet : PnPWebCmdlet
     {
         [Parameter(Mandatory = true)]

--- a/src/Commands/DocumentSets/AddDocumentSet.cs
+++ b/src/Commands/DocumentSets/AddDocumentSet.cs
@@ -8,6 +8,7 @@ using System.Linq;
 namespace PnP.PowerShell.Commands.DocumentSets
 {
     [Cmdlet(VerbsCommon.Add, "PnPDocumentSet")]
+    [OutputType(typeof(string))]
     public class AddDocumentSet : PnPWebCmdlet
     {
         [Parameter(Mandatory = true)]

--- a/src/Commands/DocumentSets/GetDocumentSetTemplate.cs
+++ b/src/Commands/DocumentSets/GetDocumentSetTemplate.cs
@@ -10,6 +10,7 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 namespace PnP.PowerShell.Commands.DocumentSets
 {
     [Cmdlet(VerbsCommon.Get,"PnPDocumentSetTemplate")]
+    [OutputType(typeof(DocumentSetTemplate))]
     public class GetDocumentSetTemplate : PnPWebRetrievalsCmdlet<DocumentSetTemplate>
     {
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]

--- a/src/Commands/DocumentSets/RemoveContentTypeFromDocumentSet.cs
+++ b/src/Commands/DocumentSets/RemoveContentTypeFromDocumentSet.cs
@@ -6,6 +6,7 @@ using Microsoft.SharePoint.Client;
 namespace PnP.PowerShell.Commands.DocumentSets
 {
     [Cmdlet(VerbsCommon.Remove, "PnPContentTypeFromDocumentSet")]
+    [OutputType(typeof(void))]
     public class RemoveContentTypeFromDocumentSet : PnPWebCmdlet
     {
         [Parameter(Mandatory = true)]

--- a/src/Commands/DocumentSets/SetDocumentSetField.cs
+++ b/src/Commands/DocumentSets/SetDocumentSetField.cs
@@ -8,6 +8,7 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 namespace PnP.PowerShell.Commands.DocumentSets
 {
     [Cmdlet(VerbsCommon.Set, "PnPDocumentSetField")]
+    [OutputType(typeof(void))]
     public class SetFieldInDocumentSet : PnPWebCmdlet
     {
         [Parameter(Mandatory = true)]

--- a/src/Commands/Events/AddEventReceiver.cs
+++ b/src/Commands/Events/AddEventReceiver.cs
@@ -5,6 +5,7 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 namespace PnP.PowerShell.Commands.Events
 {
     [Cmdlet(VerbsCommon.Add, "PnPEventReceiver", DefaultParameterSetName = ParameterSet_SCOPE)]
+    [OutputType(typeof(EventReceiverDefinition))]
     public class AddEventReceiver : PnPWebCmdlet
     {
         private const string ParameterSet_LIST = "On a list";

--- a/src/Commands/Events/GetEventReceiver.cs
+++ b/src/Commands/Events/GetEventReceiver.cs
@@ -6,7 +6,8 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 namespace PnP.PowerShell.Commands.Events
 {
     [Cmdlet(VerbsCommon.Get, "PnPEventReceiver", DefaultParameterSetName = ParameterSet_SCOPE)]
-  
+    [OutputType(typeof(EventReceiverDefinition))]
+
     public class GetEventReceiver : PnPWebRetrievalsCmdlet<EventReceiverDefinition>
     {
         private const string ParameterSet_LIST = "On a list";

--- a/src/Commands/Events/RemoveEventReceiver.cs
+++ b/src/Commands/Events/RemoveEventReceiver.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 namespace PnP.PowerShell.Commands.Events
 {
     [Cmdlet(VerbsCommon.Remove, "PnPEventReceiver", DefaultParameterSetName = ParameterSet_SCOPE)]
+    [OutputType(typeof(void))]
     public class RemoveEventReceiver : PnPWebCmdlet
     {
         private const string ParameterSet_LIST = "From a list";

--- a/src/Commands/Extensibility/NewExtensibilityHandlerObject.cs
+++ b/src/Commands/Extensibility/NewExtensibilityHandlerObject.cs
@@ -1,13 +1,15 @@
 ﻿using System.Management.Automation;
+
 using PnP.Framework.Provisioning.Model;
 
 
 namespace PnP.PowerShell.Commands.Extensibility
 {
     [Cmdlet(VerbsCommon.New, "PnPExtensibilityHandlerObject")]
+    [OutputType(typeof(ExtensibilityHandler))]
     public class NewExtensibilityHandlerObject : PSCmdlet
     {
-        [Parameter(Mandatory = true, Position=0, ValueFromPipeline=true)]
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
         public string Assembly;
 
         [Parameter(Mandatory = true)]

--- a/src/Commands/Features/DisableFeature.cs
+++ b/src/Commands/Features/DisableFeature.cs
@@ -8,6 +8,7 @@ using PnP.PowerShell.Commands.Enums;
 namespace PnP.PowerShell.Commands.Features
 {
     [Cmdlet(VerbsLifecycle.Disable, "PnPFeature")]
+    [OutputType(typeof(void))]
     public class DisableFeature : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterAttribute.AllParameterSets)]

--- a/src/Commands/Features/DisablePageScheduling.cs
+++ b/src/Commands/Features/DisablePageScheduling.cs
@@ -5,6 +5,7 @@ using Microsoft.SharePoint.Client;
 namespace PnP.PowerShell.Commands.Features
 {
     [Cmdlet(VerbsLifecycle.Disable, "PnPPageScheduling")]
+    [OutputType(typeof(void))]
     public class DisablePageScheduling : PnPWebCmdlet
     {
         protected override void ExecuteCmdlet()

--- a/src/Commands/Features/EnableFeature.cs
+++ b/src/Commands/Features/EnableFeature.cs
@@ -6,6 +6,7 @@ using PnP.PowerShell.Commands.Enums;
 namespace PnP.PowerShell.Commands.Features
 {
     [Cmdlet(VerbsLifecycle.Enable, "PnPFeature")]
+    [OutputType(typeof(void))]
     public class EnableFeature : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, Position=0, ValueFromPipeline=true)]

--- a/src/Commands/Features/EnablePageScheduling.cs
+++ b/src/Commands/Features/EnablePageScheduling.cs
@@ -5,6 +5,7 @@ using Microsoft.SharePoint.Client;
 namespace PnP.PowerShell.Commands.Features
 {
     [Cmdlet(VerbsLifecycle.Enable, "PnPPageScheduling")]
+    [OutputType(typeof(void))]
     public class EnablePageScheduling : PnPWebCmdlet
     {
         protected override void ExecuteCmdlet()

--- a/src/Commands/Features/GetFeature.cs
+++ b/src/Commands/Features/GetFeature.cs
@@ -12,6 +12,7 @@ using PnP.PowerShell.Commands.Enums;
 namespace PnP.PowerShell.Commands.Features
 {
     [Cmdlet(VerbsCommon.Get, "PnPFeature")]
+    [OutputType(typeof(Feature))]
     public class GetFeature : PnPWebRetrievalsCmdlet<Feature>
     {
         [Parameter(Mandatory = false, Position = 0, ValueFromPipeline = true)]

--- a/src/Commands/Fields/AddField.cs
+++ b/src/Commands/Fields/AddField.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 namespace PnP.PowerShell.Commands.Fields
 {
     [Cmdlet(VerbsCommon.Add, "PnPField", DefaultParameterSetName = "Add field to list")]
+    [OutputType(typeof(Field))]
     public class AddField : PnPWebCmdlet, IDynamicParameters
     {
         const string ParameterSet_ADDFIELDTOLIST = "Add field to list";

--- a/src/Commands/Fields/AddFieldFromXml.cs
+++ b/src/Commands/Fields/AddFieldFromXml.cs
@@ -6,6 +6,7 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 namespace PnP.PowerShell.Commands.Fields
 {
     [Cmdlet(VerbsCommon.Add, "PnPFieldFromXml")]
+    [OutputType(typeof(Field))]
     public class AddFieldFromXml : PnPWebCmdlet
     {
         [Parameter(Mandatory = false, ValueFromPipeline = true)]

--- a/src/Commands/Fields/AddTaxonomyField.cs
+++ b/src/Commands/Fields/AddTaxonomyField.cs
@@ -9,6 +9,7 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 namespace PnP.PowerShell.Commands.Fields
 {
     [Cmdlet(VerbsCommon.Add, "PnPTaxonomyField")]
+    [OutputType(typeof(TaxonomyField))]
     public class AddTaxonomyField : PnPWebCmdlet
     {
         [Parameter(Mandatory = false, ParameterSetName = ParameterAttribute.AllParameterSets)]

--- a/src/Commands/Fields/GetField.cs
+++ b/src/Commands/Fields/GetField.cs
@@ -10,6 +10,7 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 namespace PnP.PowerShell.Commands.Fields
 {
     [Cmdlet(VerbsCommon.Get, "PnPField")]
+    [OutputType(typeof(Field))]
     public class GetField : PnPWebRetrievalsCmdlet<Field>
     {
         [Parameter(Mandatory = false, ValueFromPipeline = true)]

--- a/src/Commands/Fields/RemoveField.cs
+++ b/src/Commands/Fields/RemoveField.cs
@@ -7,6 +7,7 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 namespace PnP.PowerShell.Commands.Fields
 {
     [Cmdlet(VerbsCommon.Remove, "PnPField")]
+    [OutputType(typeof(void))]
     public class RemoveField : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]

--- a/src/Commands/Fields/SetField.cs
+++ b/src/Commands/Fields/SetField.cs
@@ -8,6 +8,7 @@ using System.Collections;
 namespace PnP.PowerShell.Commands.Fields
 {
     [Cmdlet(VerbsCommon.Set, "PnPField")]
+    [OutputType(typeof(void))]
     public class SetField : PnPWebCmdlet
     {
         [Parameter(Mandatory = false, ValueFromPipeline = true)]


### PR DESCRIPTION
Adds OutputType Attribute to the next 20 cmdlets, for better command completion:
* DocumentSets
* EventReceiver
* `New-ExtensibilityHandlerObject`
* Feature
* Fields


Follow up to [PR #1763](https://github.com/pnp/powershell/pull/1763#issuecomment-1099695169)