### PR TITLE
Add OutputType Attribute - #3

### DIFF
--- a/src/Commands/Graph/GetGraphAccessToken.cs
+++ b/src/Commands/Graph/GetGraphAccessToken.cs
@@ -1,19 +1,25 @@
 ﻿
+using System.IdentityModel.Tokens.Jwt;
 using System.Management.Automation;
 
 namespace PnP.PowerShell.Commands.Base
 {
-    [Cmdlet(VerbsCommon.Get, "PnPGraphAccessToken")]
+    [Cmdlet(VerbsCommon.Get, "PnPGraphAccessToken", DefaultParameterSetName = ParameterSet_Encoded)]
+    [OutputType(typeof(string), ParameterSetName = new[] { ParameterSet_Encoded })]
+    [OutputType(typeof(JwtSecurityToken), ParameterSetName = new[] { ParameterSet_Decoded })]
     public class GetGraphAccessToken : PnPGraphCmdlet
     {
-        [Parameter(Mandatory = false)]
+        public const string ParameterSet_Decoded = "Decoded (JwtSecurityToken)";
+        public const string ParameterSet_Encoded = "Encoded (string)";
+
+        [Parameter(Mandatory = true, ParameterSetName = ParameterSet_Decoded)]
         public SwitchParameter Decoded;
 
         protected override void ExecuteCmdlet()
         {
             if (Decoded.IsPresent)
             {
-                WriteObject(new System.IdentityModel.Tokens.Jwt.JwtSecurityToken(AccessToken));
+                WriteObject(new JwtSecurityToken(AccessToken));
             }
             else
             {

--- a/src/Commands/Graph/GetGraphSubscription.cs
+++ b/src/Commands/Graph/GetGraphSubscription.cs
@@ -6,7 +6,8 @@ using System.Management.Automation;
 namespace PnP.PowerShell.Commands.Graph
 {
     [Cmdlet(VerbsCommon.Get, "PnPGraphSubscription", DefaultParameterSetName = ParameterSet_LIST)]
-  
+    [OutputType(typeof(Framework.Graph.Model.Subscription))]
+
     // Deliberately omitting the CmdletMicrosoftGraphApiPermission attribute as permissions vary largely by the subscription type being used
     public class GetGraphSubscription : PnPGraphCmdlet
     {

--- a/src/Commands/Graph/NewGraphSubscription.cs
+++ b/src/Commands/Graph/NewGraphSubscription.cs
@@ -7,7 +7,8 @@ using System.Management.Automation;
 namespace PnP.PowerShell.Commands.Graph
 {
     [Cmdlet(VerbsCommon.New, "PnPGraphSubscription")]
-    
+    [OutputType(typeof(Framework.Graph.Model.Subscription))]
+
     // Deliberately omitting the CmdletMicrosoftGraphApiPermission attribute as permissions vary largely by the subscription type being used. This means it will not work with an app-only token.
     public class NewGraphSubscription : PnPGraphCmdlet
     {

--- a/src/Commands/Graph/RemoveGraphSubscription.cs
+++ b/src/Commands/Graph/RemoveGraphSubscription.cs
@@ -7,6 +7,7 @@ using System.Management.Automation;
 namespace PnP.PowerShell.Commands.Graph
 {
     [Cmdlet(VerbsCommon.Remove, "PnPGraphSubscription")]
+    [OutputType(typeof(void))]
     // Deliberately omitting the CmdletMicrosoftGraphApiPermission attribute as permissions vary largely by the subscription type being used
     public class RemoveGraphSubscription : PnPGraphCmdlet
     {

--- a/src/Commands/Graph/RemoveSiteClassification.cs
+++ b/src/Commands/Graph/RemoveSiteClassification.cs
@@ -10,6 +10,7 @@ namespace PnP.PowerShell.Commands.Graph
 {
     [Cmdlet(VerbsCommon.Remove, "PnPSiteClassification")]
     [RequiredMinimalApiPermissions("Directory.ReadWrite.All")]
+    [OutputType(typeof(void))]
     public class RemoveSiteClassification : PnPGraphCmdlet
     {
 

--- a/src/Commands/Graph/SetGraphSubscription.cs
+++ b/src/Commands/Graph/SetGraphSubscription.cs
@@ -8,6 +8,7 @@ using System.Management.Automation;
 namespace PnP.PowerShell.Commands.Graph
 {
     [Cmdlet(VerbsCommon.Set, "PnPGraphSubscription")]
+    [OutputType(typeof(Framework.Graph.Model.Subscription))]
     public class SetGraphSubscription : PnPGraphCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true)]

--- a/src/Commands/ListDesign/AddListDesign.cs
+++ b/src/Commands/ListDesign/AddListDesign.cs
@@ -7,6 +7,7 @@ using System.Management.Automation;
 namespace PnP.PowerShell.Commands
 {
     [Cmdlet(VerbsCommon.Add, "PnPListDesign")]
+    [OutputType(typeof(TenantListDesign))]
     public class AddListDesign : PnPAdminCmdlet
     {
         [Parameter(Mandatory = true)]

--- a/src/Commands/ListDesign/GetListDesign.cs
+++ b/src/Commands/ListDesign/GetListDesign.cs
@@ -7,6 +7,7 @@ using System.Management.Automation;
 namespace PnP.PowerShell.Commands
 {
     [Cmdlet(VerbsCommon.Get, "PnPListDesign")]
+    [OutputType(typeof(TenantListDesign))]
     public class GetListDesign : PnPAdminCmdlet
     {
         [Parameter(Mandatory = false, Position = 0, ValueFromPipeline = true)]

--- a/src/Commands/ListDesign/InvokeListDesign.cs
+++ b/src/Commands/ListDesign/InvokeListDesign.cs
@@ -7,6 +7,7 @@ using System.Management.Automation;
 namespace PnP.PowerShell.Commands
 {
     [Cmdlet(VerbsLifecycle.Invoke, "PnPListDesign")]
+    [OutputType(typeof(TenantSiteScriptActionResult))]
     public class InvokeListDesign : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]

--- a/src/Commands/ListDesign/RemoveListDesign.cs
+++ b/src/Commands/ListDesign/RemoveListDesign.cs
@@ -7,6 +7,7 @@ using System.Management.Automation;
 namespace PnP.PowerShell.Commands
 {
     [Cmdlet(VerbsCommon.Remove, "PnPListDesign")]
+    [OutputType(typeof(void))]
     public class RemoveListDesign : PnPAdminCmdlet
     {
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]

--- a/src/Commands/ManagementApi/GetUnifiedAuditLog.cs
+++ b/src/Commands/ManagementApi/GetUnifiedAuditLog.cs
@@ -12,6 +12,7 @@ namespace PnP.PowerShell.Commands.ManagementApi
 {
     [Cmdlet(VerbsCommon.Get, "PnPUnifiedAuditLog")]
     [RequiredMinimalApiPermissions("https://manage.office.com/ActivityFeed.Read")]
+    [OutputType(typeof(ManagementApiUnifiedLogRecord))]
     public class GetUnifiedAuditLog : PnPOfficeManagementApiCmdlet
     {
         private const string ParameterSet_LogsByDate = "Logs by date";

--- a/src/Commands/Navigation/AddNavigationNode.cs
+++ b/src/Commands/Navigation/AddNavigationNode.cs
@@ -7,6 +7,7 @@ using PnP.Framework.Enums;
 namespace PnP.PowerShell.Commands.Branding
 {
     [Cmdlet(VerbsCommon.Add, "PnPNavigationNode")]
+    [OutputType(typeof(NavigationNode))]
     public class AddNavigationNode : PnPWebCmdlet
     {
         [Parameter(Mandatory = true)]

--- a/src/Commands/Navigation/GetStructuralNavigationCacheSiteState.cs
+++ b/src/Commands/Navigation/GetStructuralNavigationCacheSiteState.cs
@@ -5,6 +5,7 @@ using Microsoft.SharePoint.Client;
 namespace PnP.PowerShell.Commands.Site
 {
     [Cmdlet(VerbsCommon.Get, "PnPStructuralNavigationCacheSiteState")]
+    [OutputType(typeof(bool))]
     public class GetStructuralNavigationCacheSiteState : PnPAdminCmdlet
     {
         [Parameter(Mandatory = false, ValueFromPipeline = true)]

--- a/src/Commands/Navigation/GetStructuralNavigationCacheWebState.cs
+++ b/src/Commands/Navigation/GetStructuralNavigationCacheWebState.cs
@@ -5,6 +5,7 @@ using Microsoft.SharePoint.Client;
 namespace PnP.PowerShell.Commands.Site
 {
     [Cmdlet(VerbsCommon.Get, "PnPStructuralNavigationCacheWebState")]
+    [OutputType(typeof(bool))]
     public class GetStructuralNavigationCacheWebState : PnPAdminCmdlet
     {
         [Parameter(Mandatory = false, ValueFromPipeline = true)]

--- a/src/Commands/Navigation/RemoveNavigationNode.cs
+++ b/src/Commands/Navigation/RemoveNavigationNode.cs
@@ -9,6 +9,7 @@ using Resources = PnP.PowerShell.Commands.Properties.Resources;
 namespace PnP.PowerShell.Commands.Branding
 {
     [Cmdlet(VerbsCommon.Remove, "PnPNavigationNode", DefaultParameterSetName = ParameterSet_BYID)]
+    [OutputType(typeof(void))]
     public class RemoveNavigationNode : PnPWebCmdlet
     {
         private const string ParameterSet_BYNAME = "Remove node by Title";

--- a/src/Commands/Navigation/SetStructuralNavigationCacheSiteState.cs
+++ b/src/Commands/Navigation/SetStructuralNavigationCacheSiteState.cs
@@ -5,6 +5,7 @@ using Microsoft.SharePoint.Client;
 namespace PnP.PowerShell.Commands.Site
 {
     [Cmdlet(VerbsCommon.Set, "PnPStructuralNavigationCacheSiteState")]
+    [OutputType(typeof(void))]
     public class SetStructuralNavigationCacheSiteState : PnPAdminCmdlet
     {
         [Parameter(Mandatory = false, ValueFromPipeline = true)]

--- a/src/Commands/Navigation/SetStructuralNavigationCacheWebState.cs
+++ b/src/Commands/Navigation/SetStructuralNavigationCacheWebState.cs
@@ -5,6 +5,7 @@ using Microsoft.SharePoint.Client;
 namespace PnP.PowerShell.Commands.Site
 {
     [Cmdlet(VerbsCommon.Set, "PnPStructuralNavigationCacheWebState")]
+    [OutputType(typeof(void))]
     public class SetStructuralNavigationCacheWebState : PnPAdminCmdlet
     {
         [Parameter(Mandatory = false, ValueFromPipeline = true)]

--- a/src/Commands/Syntex/GetSyntexModel.cs
+++ b/src/Commands/Syntex/GetSyntexModel.cs
@@ -7,6 +7,7 @@ using System.Management.Automation;
 namespace PnP.PowerShell.Commands.Syntex
 {
     [Cmdlet(VerbsCommon.Get, "PnPSyntexModel")]
+    [OutputType(typeof(SyntexModel))]
     public class GetSyntexModel : PnPWebCmdlet
     {
 

--- a/src/Commands/Syntex/GetSyntexModelPublication.cs
+++ b/src/Commands/Syntex/GetSyntexModelPublication.cs
@@ -7,6 +7,7 @@ using System.Management.Automation;
 namespace PnP.PowerShell.Commands.Syntex
 {
     [Cmdlet(VerbsCommon.Get, "PnPSyntexModelPublication")]
+    [OutputType(typeof(Model.Syntex.SyntexModelPublication))]
     public class GetSyntexModelPublication : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]

--- a/src/Commands/Syntex/PublishSyntexModel.cs
+++ b/src/Commands/Syntex/PublishSyntexModel.cs
@@ -9,6 +9,7 @@ using System.Management.Automation;
 namespace PnP.PowerShell.Commands.Syntex
 {
     [Cmdlet(VerbsData.Publish, "PnPSyntexModel")]
+    [OutputType(typeof(SyntexPublicationResult))]
     public class PublishSyntexModel : PnPWebCmdlet
     {
         const string ParameterSet_SINGLE = "Single";

--- a/src/Commands/Syntex/RequestSyntexClassifyAndExtract.cs
+++ b/src/Commands/Syntex/RequestSyntexClassifyAndExtract.cs
@@ -3,6 +3,8 @@ using PnP.Framework.Utilities;
 using PnP.PowerShell.Commands.Base;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 using PnP.PowerShell.Commands.Model;
+using PnP.PowerShell.Commands.Model.Syntex;
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
@@ -10,6 +12,7 @@ using System.Management.Automation;
 namespace PnP.PowerShell.Commands.Syntex
 {
     [Cmdlet(VerbsLifecycle.Request, "PnPSyntexClassifyAndExtract")]
+    [OutputType(typeof(SyntexClassifyAndExtractResult))]
     public class RequestSyntexClassifyAndExtract : PnPWebCmdlet
     {
         const string ParameterSet_LIST = "List";
@@ -53,7 +56,7 @@ namespace PnP.PowerShell.Commands.Syntex
                 if (OffPeak)
                 {
                     var classifyAndExtractResult = list.ClassifyAndExtractOffPeak();
-                    WriteObject(new Model.Syntex.SyntexClassifyAndExtractResult()
+                    WriteObject(new SyntexClassifyAndExtractResult()
                     {
                         Created = classifyAndExtractResult.Created,
                         DeliverDate = classifyAndExtractResult.DeliverDate,
@@ -76,7 +79,7 @@ namespace PnP.PowerShell.Commands.Syntex
                     {
                         foreach (var classifyAndExtractResult in classifyAndExtractResults)
                         {
-                            classifyAndExtractResultsOutput.Add(new Model.Syntex.SyntexClassifyAndExtractResult()
+                            classifyAndExtractResultsOutput.Add(new SyntexClassifyAndExtractResult()
                             {
                                 Created = classifyAndExtractResult.Created,
                                 DeliverDate = classifyAndExtractResult.DeliverDate,
@@ -99,7 +102,7 @@ namespace PnP.PowerShell.Commands.Syntex
             {
                 IFolder folder = Folder.GetFolder(ctx);
                 var classifyAndExtractResult = folder.ClassifyAndExtractOffPeak();
-                WriteObject(new Model.Syntex.SyntexClassifyAndExtractResult()
+                WriteObject(new SyntexClassifyAndExtractResult()
                 {
                     Created = classifyAndExtractResult.Created,
                     DeliverDate = classifyAndExtractResult.DeliverDate,
@@ -138,7 +141,7 @@ namespace PnP.PowerShell.Commands.Syntex
 
                     if (classifyAndExtractResult != null)
                     {
-                        WriteObject(new Model.Syntex.SyntexClassifyAndExtractResult()
+                        WriteObject(new SyntexClassifyAndExtractResult()
                         {
                             Created = classifyAndExtractResult.Created,
                             DeliverDate = classifyAndExtractResult.DeliverDate,

--- a/src/Commands/Syntex/UnPublishSyntexModel.cs
+++ b/src/Commands/Syntex/UnPublishSyntexModel.cs
@@ -9,6 +9,7 @@ using System.Management.Automation;
 namespace PnP.PowerShell.Commands.Syntex
 {
     [Cmdlet(VerbsData.Unpublish, "PnPSyntexModel")]
+    [OutputType(typeof(SyntexPublicationResult))]
     public class UnPublishSyntexModel : PnPWebCmdlet
     {
         const string ParameterSet_SINGLE = "Single";

--- a/src/Commands/Webhooks/AddWebhookSubscription.cs
+++ b/src/Commands/Webhooks/AddWebhookSubscription.cs
@@ -8,6 +8,7 @@ using System.Management.Automation;
 namespace PnP.PowerShell.Commands.Webhooks
 {
     [Cmdlet(VerbsCommon.Add, "PnPWebhookSubscription")]
+    [OutputType(typeof(WebhookSubscription))]
     public class AddWebhookSubscription : PnPWebCmdlet
     {
         public const int DefaultValidityInDays = 180; // Note: the max is 180 days not 6 months - https://docs.microsoft.com/sharepoint/dev/apis/webhooks/overview-sharepoint-webhooks

--- a/src/Commands/Webhooks/GetWebhookSubscriptions.cs
+++ b/src/Commands/Webhooks/GetWebhookSubscriptions.cs
@@ -8,6 +8,7 @@ using Resources = PnP.PowerShell.Commands.Properties.Resources;
 namespace PnP.PowerShell.Commands.Webhooks
 {
     [Cmdlet(VerbsCommon.Get, "PnPWebhookSubscriptions")]
+    [OutputType(typeof(WebhookSubscription))]
     public class GetWebhookSubscriptions : PnPWebCmdlet
     {
         [Parameter(Mandatory = false, ValueFromPipeline = true)]

--- a/src/Commands/Webhooks/RemoveWebhookSubscription.cs
+++ b/src/Commands/Webhooks/RemoveWebhookSubscription.cs
@@ -8,6 +8,7 @@ using System.Management.Automation;
 namespace PnP.PowerShell.Commands.Webhooks
 {
     [Cmdlet(VerbsCommon.Remove, "PnPWebhookSubscription")]
+    [OutputType(typeof(void))]
     public class RemoveWebhookSubscription : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]

--- a/src/Commands/Webhooks/SetWebhookSubscription.cs
+++ b/src/Commands/Webhooks/SetWebhookSubscription.cs
@@ -8,6 +8,7 @@ using System.Management.Automation;
 namespace PnP.PowerShell.Commands.Webhooks
 {
     [Cmdlet(VerbsCommon.Set, "PnPWebhookSubscription")]
+    [OutputType(typeof(WebhookSubscription))]
     public class SetWebhookSubscription : PnPWebCmdlet
     {
         public const int DefaultValidityInMonths = 6;


### PR DESCRIPTION
Adds OutputType Attribute to the next 26 cmdlets, for better command completion:
* Graph
* ListDesign
* Webhook
* Syntex
* NavigationNode (partially)
* `Get-PnPUnifedAuditLog`


Follow up to [PR #1763](https://github.com/pnp/powershell/pull/1763#issuecomment-1099695169)