### PR TITLE
New cmdlet `Get-PnPTeamsChannelUser`

### DIFF
--- a/documentation/Get-PnPTeamsChannelUser.md
+++ b/documentation/Get-PnPTeamsChannelUser.md
@@ -1,0 +1,123 @@
+---
+Module Name: PnP.PowerShell
+title: Get-PnPTeamsChannelUser
+schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/Get-PnPTeamsChannelUser.html
+---
+ 
+# Get-PnPTeamsChannelUser
+
+## SYNOPSIS
+
+**Required Permissions**
+
+  * Microsoft Graph API: ChannelMember.Read.All
+
+Returns members from the specified Microsoft Teams private Channel.
+
+## SYNTAX
+
+```powershell
+Get-PnPTeamsChannelUser -Team <TeamsTeamPipeBind> -Channel <TeamsChannelPipeBind> [-Identity <TeamsChannelMemberPipeBind>] [-Role <String>]
+  [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-PnPTeamsChannelUser -Team "My Team" -Channel "My Channel"
+```
+
+Returns all owners, members and guests from the specified channel.
+
+### EXAMPLE 2
+
+```powershell
+Get-PnPTeamsChannelUser -Team "My Team" -Channel "My Channel" -Role Member
+```
+
+Returns all members from the specified channel.
+
+### EXAMPLE 3
+
+```powershell
+Get-PnPTeamsChannelUser -Team "My Team" -Channel "My Channel" -Identity john.doe@contoso.com
+```
+
+Returns membership of the user "john.doe@contoso.com" for the specified channel.
+
+### EXAMPLE 4
+
+```powershell
+Get-PnPTeamsChannelUser -Team "My Team" -Channel "My Channel" -Identity 00000000-0000-0000-0000-000000000000
+```
+
+Returns membership of the user with ID "00000000-0000-0000-0000-000000000000" for the specified channel.
+
+## PARAMETERS
+
+### -Identity
+Specify membership id, UPN or user ID of the channel member.
+
+```yaml
+Type: TeamsChannelMemberPipeBind
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Channel
+Specify id or name of the channel to use.
+
+```yaml
+Type: TeamsChannelPipeBind
+Parameter Sets: (All)
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Team
+Specify the group id, mailNickname or display name of the team to use.
+
+```yaml
+Type: TeamsTeamPipeBind
+Parameter Sets: (All)
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Role
+Specify to filter on the role of the user.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Accepted values: Owner, Member, Guest
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/src/Commands/Base/PipeBinds/TeamsChannelMemberPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/TeamsChannelMemberPipeBind.cs
@@ -1,0 +1,85 @@
+﻿using PnP.PowerShell.Commands.Model.Teams;
+using PnP.PowerShell.Commands.Utilities;
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace PnP.PowerShell.Commands.Base.PipeBinds
+{
+    public sealed class TeamsChannelMemberPipeBind
+    {
+        private readonly string _id;
+        private readonly string _userId;
+        private readonly string _userUpn;
+        private readonly TeamChannelMember _membership;
+
+        public TeamsChannelMemberPipeBind()
+        {
+            
+        }
+
+        public TeamsChannelMemberPipeBind(string input)
+        {
+            if (Guid.TryParse(input, out var userId))
+            {
+                _userId = userId.ToString();
+            }
+            else if (input.Contains('@') && input.Contains('.'))
+            {
+                _userUpn = input;
+            }
+            else
+            {
+                _id = input;
+            }
+        }
+
+        public TeamsChannelMemberPipeBind(TeamChannelMember membership)
+        {
+            _membership = membership;
+        }
+
+        public async Task<string> GetIdAsync(HttpClient httpClient, string accessToken, string groupId, string channelId)
+        {
+            if (!string.IsNullOrEmpty(_id))
+            {
+                return _id;
+            }
+             
+            if (_membership != null)
+            {
+                return _membership.Id;
+            }
+
+            var memberships = await TeamsUtility.GetChannelMembersAsync(httpClient, accessToken, groupId, channelId);
+            if (!string.IsNullOrEmpty(_userUpn))
+            {
+                return memberships.FirstOrDefault(m => _userUpn.Equals(m.Email, StringComparison.OrdinalIgnoreCase))?.Id;
+            }
+
+            return memberships.FirstOrDefault(m => !string.IsNullOrEmpty(m.UserId) && _userId.Equals(m.UserId, StringComparison.OrdinalIgnoreCase))?.Id;
+        }
+
+        public async Task<TeamChannelMember> GetMembershipAsync(HttpClient httpClient, string accessToken, string groupId, string channelId)
+        {
+            if (_membership != null)
+            {
+                return _membership;
+            }
+
+            if (!string.IsNullOrEmpty(_id))
+            {
+                return await TeamsUtility.GetChannelMemberAsync(httpClient, accessToken, groupId, channelId, _id);
+            }
+
+            var memberships = await TeamsUtility.GetChannelMembersAsync(httpClient, accessToken, groupId, channelId);
+            if (!string.IsNullOrEmpty(_userUpn))
+            {
+                return memberships.FirstOrDefault(m => _userUpn.Equals(m.Email, StringComparison.OrdinalIgnoreCase));
+            }
+
+            return memberships.FirstOrDefault(m => !string.IsNullOrEmpty(m.UserId) && _userId.Equals(m.UserId, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/src/Commands/Model/Teams/TeamChannelMember.cs
+++ b/src/Commands/Model/Teams/TeamChannelMember.cs
@@ -24,6 +24,6 @@ namespace PnP.PowerShell.Commands.Model.Teams
         public string UserId { get; set; }
 
         [JsonPropertyName("email")]
-        public string email { get; set; }
+        public string Email { get; set; }
     }
 }

--- a/src/Commands/Teams/GetTeamsChannelUser.cs
+++ b/src/Commands/Teams/GetTeamsChannelUser.cs
@@ -1,0 +1,50 @@
+﻿using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Base.PipeBinds;
+using PnP.PowerShell.Commands.Utilities;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Teams
+{
+    [Cmdlet(VerbsCommon.Get, "PnPTeamsChannelUser")]
+    [RequiredMinimalApiPermissions("ChannelMember.Read.All")]
+    public class GetTeamsChannelUser : PnPGraphCmdlet
+    {
+        [Parameter(Mandatory = true)]
+        public TeamsTeamPipeBind Team;
+
+        [Parameter(Mandatory = true)]
+        public TeamsChannelPipeBind Channel;
+
+        [Parameter(Mandatory = false)]
+        public TeamsChannelMemberPipeBind Identity;
+
+        [Parameter(Mandatory = false)]
+        [ValidateSet("Owner", "Member", "Guest")]
+        public string Role;
+
+        protected override void ExecuteCmdlet()
+        {
+            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            if (groupId == null)
+            {
+                throw new PSArgumentException("Group not found");
+            }
+
+            var channelId = Channel.GetId(HttpClient, AccessToken, groupId);
+            if (channelId == null)
+            {
+                throw new PSArgumentException("Channel not found");
+            }
+
+            if (ParameterSpecified(nameof(Identity)))
+            {
+                WriteObject(Identity.GetMembershipAsync(HttpClient, AccessToken, groupId, channelId).GetAwaiter().GetResult());
+            }
+            else
+            {
+                WriteObject(TeamsUtility.GetChannelMembersAsync(HttpClient, AccessToken, groupId, channelId, Role).GetAwaiter().GetResult(), true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #1790

## What is in this Pull Request ? ##
New cmdlet to get and list users from a private teams channel. If you specify the `-Identity` option you will get a specific membership of the channel. If you don't specify the `-Identity` option, all memberships will be listed. It is possible to filter out only Owners, Members or Guests using the `-Role` option.

**Examples:**
`Get-PnPTeamsChannelUser -Team "My Team" -Channel "My Channel"`
`Get-PnPTeamsChannelUser -Team "My Team" -Channel "My Channel" -Role Owner`
`Get-PnPTeamsChannelUser -Team "My Team" -Channel "My Channel" -Identity john.doe@contoso.com`