### PR TITLE
Consistency when retrieving Site Group by name (Closes #1721)

### DIFF
--- a/documentation/Get-PnPGroup.md
+++ b/documentation/Get-PnPGroup.md
@@ -59,7 +59,7 @@ Returns all SharePoint groups in the current site
 Get-PnPGroup -Identity 'My Site Users'
 ```
 
-This will return the group called 'My Site Users' if available in the current site
+This will return the group called 'My Site Users' if available in the current site. The name is case sensitive, so a group called 'My site users' would not be found.
 
 ### EXAMPLE 3
 ```powershell
@@ -127,7 +127,7 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Get a specific group by its name or id
+Get a specific group by its name or id. The name case sensitive.
 
 ```yaml
 Type: GroupPipeBind

--- a/src/Commands/Principals/GetGroupPermissions.cs
+++ b/src/Commands/Principals/GetGroupPermissions.cs
@@ -15,11 +15,15 @@ namespace PnP.PowerShell.Commands.Principals
 
         protected override void ExecuteCmdlet()
         {
-            var g = Identity.GetGroup(PnPContext);
-            var r = g.GetRoleDefinitions();
-            if (r != null)
+            var group = Identity.GetGroup(PnPContext);
+
+            if (group == null)
+                throw new PSArgumentException("Site group not found", nameof(Identity));
+
+            var roleDefinitions = group.GetRoleDefinitions();
+            if (roleDefinitions != null)
             {
-                WriteObject(r.RequestedItems, true);
+                WriteObject(roleDefinitions.RequestedItems, true);
             }
         }
     }

--- a/src/Commands/Principals/SetGroupPermissions.cs
+++ b/src/Commands/Principals/SetGroupPermissions.cs
@@ -24,6 +24,10 @@ namespace PnP.PowerShell.Commands.Principals
         protected override void ExecuteCmdlet()
         {
             var group = Identity.GetGroup(PnPContext);
+
+            if (group == null)
+                throw new PSArgumentException("Site group not found", nameof(Identity));
+
             PnP.Core.Model.SharePoint.IList list = null;
             if (ParameterSpecified(nameof(List)))
             {


### PR DESCRIPTION
Consistency when retrieving Site Group by name.

## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #1721

## What is in this Pull Request ? ##
Added some consistency between `Get-PnPGroup`, `Get-PnPGroupPermissions` and `Set-PnPGroupPermissions` commandlets. When using the name parameter, the group is queried through the PnP Core SDK, which is case sensitive. Also added consistent `null` checks with `PSArgumentExceptions` when group was not found.