### PR TITLE
Feature/Invoke-PnPGraphMethod

### DIFF
--- a/documentation/Invoke-PnPGraphMethod.md
+++ b/documentation/Invoke-PnPGraphMethod.md
@@ -1,0 +1,205 @@
+---
+external help file: PnP.PowerShell.dll-Help.xml
+Module Name: PnP.PowerShell
+online version: https://pnp.github.io/powershell/cmdlets/Invoke-PnPGraphMethod.html
+schema: 2.0.0
+---
+
+# Invoke-PnPGraphMethod
+
+## SYNOPSIS
+Invokes a REST request towards the Microsoft Graph API
+
+## SYNTAX
+
+```powershell
+Invoke-PnPGraphMethod -Url <String>
+                      [-AdditionalHeaders <System.Collections.Generic.IDictionary`2[System.String,System.String]>]
+                      [[-Method] <HttpRequestMethod>] 
+                      [-Content <Object>] 
+                      [-ContentType <String>] 
+                      [-ConsistencyLevelEventual] 
+                      [-Raw]
+                      [-All] 
+                      [-Connection <PnPConnection>]
+                      [<CommonParameters>]
+```
+
+## DESCRIPTION
+Invokes a REST request towards the Microsoft Graph API
+
+## EXAMPLES
+
+### Example 1
+```powershell
+Invoke-PnPGraphMethod -Url "groups?`$filter=startsWith(displayName,'ZZ')&`$select=displayName"
+Invoke-PnPGraphMethod -Url 'groups/{id}?`$select=hideFromOutlookClients'
+```
+
+Execute a GET request to get groups by filter and select.
+
+### Example 2
+```powershell
+Invoke-PnPGraphMethod -Url "groups/{id}" -Method Delete
+```
+
+delete the group with id.
+
+### Example 3
+```powershell
+Invoke-PnPGraphMethod -Url "groups/{id}" -Method Patch -Content @{ displayName = "NewName" }
+```
+
+set the displayName of the group with a Patch request.
+
+### Example 4
+```powershell
+Invoke-PnPGraphMethod -Url "v1.0/users?$filter=accountEnabled ne true&$count=true" -Method Get -ConsistencyLevelEventual
+```
+
+get users with advanced query capabilities. use of -ConsistencyLevelEventual.
+
+## PARAMETERS
+
+### -AdditionalHeaders
+Additional request headers
+
+```yaml
+Type: System.Collections.Generic.IDictionary`2[System.String,System.String]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -All
+retrieve all pages of results. this will loop through all @odata.nextLink. this flag will only be respected if the request is a GET request.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Connection
+Optional connection to be used by the cmdlet.
+Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConsistencyLevelEventual
+set the ConsistencyLevel header to eventual for advanced query capabilities on Azure AD directory objects
+
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Content
+A string or object to send
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ContentType
+The content type of the object to send. Defaults to 'application/json'.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Method
+The Http method to execute. Defaults to GET.
+
+```yaml
+Type: HttpRequestMethod
+Parameter Sets: (All)
+Aliases:
+Accepted values: Default, Get, Head, Post, Put, Delete, Trace, Options, Merge, Patch
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Raw
+If specified the returned data will not be converted to an object but returned as a JSON string.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Url
+the graph endpoint to invoke
+
+```yaml
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/documentation/Invoke-PnPGraphMethod.md
+++ b/documentation/Invoke-PnPGraphMethod.md
@@ -1,8 +1,10 @@
 ---
-external help file: PnP.PowerShell.dll-Help.xml
 Module Name: PnP.PowerShell
-online version: https://pnp.github.io/powershell/cmdlets/Invoke-PnPGraphMethod.html
+title: Invoke-PnPGraphMethod
 schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/Invoke-PnPGraphMethod.html
 ---
 
 # Invoke-PnPGraphMethod
@@ -188,8 +190,6 @@ Accept wildcard characters: False
 the graph endpoint to invoke
 
 ```yaml
-
-```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
@@ -201,5 +201,6 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
+## RELATED LINKS
 
 [Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/src/Commands/Base/InvokeSPRestMethod.cs
+++ b/src/Commands/Base/InvokeSPRestMethod.cs
@@ -3,6 +3,8 @@ using PnP.Framework.Http;
 using PnP.Framework.Utilities;
 
 using PnP.PowerShell.Commands.Enums;
+using PnP.PowerShell.Commands.Utilities.JSON;
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -103,7 +105,7 @@ namespace PnP.PowerShell.Commands.Admin
                             }
                             if (jsonElement.TryGetProperty("value", out JsonElement valueProperty))
                             {
-                                var formattedObject = ConvertToPSObject(valueProperty, "value");
+                                var formattedObject = Utilities.JSON.Convert.ConvertToPSObject(valueProperty, "value");
                                 if (!string.IsNullOrEmpty(nextLink))
                                 {
                                     formattedObject.Properties.Add(new PSNoteProperty("odata.nextLink", nextLink));
@@ -113,7 +115,7 @@ namespace PnP.PowerShell.Commands.Admin
                             }
                             else
                             {
-                                WriteObject(ConvertToPSObject(jsonElement, null), true);
+                                WriteObject(Utilities.JSON.Convert.ConvertToPSObject(jsonElement, null), true);
                             }
                         }
                         else
@@ -159,70 +161,6 @@ namespace PnP.PowerShell.Commands.Admin
             }
             handler.CookieContainer = authCookiesContainer;
             //}
-        }
-
-        private PSObject ConvertToPSObject(JsonElement element, string jsonPropertyName)
-        {
-            var list = new List<PSObject>();
-            var pso = new PSObject();
-
-            if (element.ValueKind == JsonValueKind.Array)
-            {
-                var array = ConvertToPSObjectArray(element);
-                pso.Properties.Add(new PSNoteProperty(jsonPropertyName, array));
-            }            
-            else
-            {
-                foreach (var prop in element.EnumerateObject())
-                {
-                    object value = null;
-                    switch (prop.Value.ValueKind)
-                    {
-
-                        case JsonValueKind.Array:
-                            {
-                                value = ConvertToPSObjectArray(prop.Value);
-                                break;
-                            }
-                        case JsonValueKind.True:
-                        case JsonValueKind.False:
-                            {
-                                value = prop.Value.GetBoolean();
-                                break;
-                            }
-                        case JsonValueKind.String:
-                            {
-                                value = prop.Value.GetString();
-                                break;
-                            }
-                        case JsonValueKind.Object:
-                            {
-                                value = ConvertToPSObject(prop.Value, prop.Name);
-                                break;
-                            }
-                        case JsonValueKind.Number:
-                            {
-                                value = prop.Value.GetInt64();
-                                break;
-                            }
-                    }
-                    pso.Properties.Add(new PSNoteProperty(prop.Name, value));
-                }
-            }
-
-            return pso;
-        }
-
-        private List<PSObject> ConvertToPSObjectArray(JsonElement element)
-        {
-            var list = new List<PSObject>();
-
-            foreach (var subelement in element.EnumerateArray())
-            {
-                var value = ConvertToPSObject(subelement, null);
-                list.Add(value);
-            }
-            return list;
         }
     }
 

--- a/src/Commands/Graph/InvokeGraphMethod.cs
+++ b/src/Commands/Graph/InvokeGraphMethod.cs
@@ -41,7 +41,7 @@ namespace PnP.PowerShell.Commands.Base
                     {
                         url = url.Remove(0, 1);
                     }
-                    if (!url.StartsWith("beta", StringComparison.OrdinalIgnoreCase) || !url.StartsWith("beta", StringComparison.OrdinalIgnoreCase))
+                    if (!url.StartsWith("beta/", StringComparison.OrdinalIgnoreCase) && !url.StartsWith("v1.0/", StringComparison.OrdinalIgnoreCase))
                     {
                         url = UrlUtility.Combine("v1.0", url);
                     }

--- a/src/Commands/Graph/InvokeGraphMethod.cs
+++ b/src/Commands/Graph/InvokeGraphMethod.cs
@@ -1,0 +1,282 @@
+﻿
+using Newtonsoft.Json.Linq;
+using PnP.Framework.Utilities;
+using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Base.PipeBinds;
+using PnP.PowerShell.Commands.Enums;
+using PnP.PowerShell.Commands.Utilities;
+using PnP.PowerShell.Commands.Utilities.REST;
+using PnP.PowerShell.Commands.Utilities.JSON;
+using System;
+using System.Linq;
+using System.Management.Automation;
+using System.Text.Json;
+using System.Collections;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using PnP.PowerShell.Commands.Model.Graph;
+
+namespace PnP.PowerShell.Commands.Base
+{
+    [Cmdlet(VerbsLifecycle.Invoke, "PnPGraphMethod")]
+    public class InvokeGraphMethod : PnPGraphCmdlet
+    {
+        [Parameter(Mandatory = false, Position = 0)]
+        public HttpRequestMethod Method = HttpRequestMethod.Get;
+
+        private string _url;
+
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+        public string Url
+        {
+            get { return _url; }
+            set
+            {
+                var url = value;
+                if (!url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (url.StartsWith("/", StringComparison.OrdinalIgnoreCase))
+                    {
+                        url = url.Remove(0, 1);
+                    }
+                    if (!url.StartsWith("beta", StringComparison.OrdinalIgnoreCase) || !url.StartsWith("beta", StringComparison.OrdinalIgnoreCase))
+                    {
+                        url = UrlUtility.Combine("v1.0", url);
+                    }
+                }
+                _url = url;
+            }
+        }
+
+        [Parameter(Mandatory = false)]
+        public object Content;
+
+        [Parameter(Mandatory = false)]
+        public string ContentType = "application/json";
+
+        IDictionary<string, string> additionalHeaders = null;
+
+        [Parameter(Mandatory = false)]
+        public IDictionary<string, string> AdditionalHeaders
+        {
+            get
+            {
+                if (ConsistencyLevelEventual.IsPresent)
+                {
+                    if (additionalHeaders == null)
+                    {
+                        additionalHeaders = new Dictionary<string, string>();
+                    }
+                    additionalHeaders.Remove("ConsistencyLevel");
+                    additionalHeaders.Add("ConsistencyLevel", "eventual");
+                }
+                return additionalHeaders;
+            }
+            set
+            {
+                additionalHeaders = value;
+            }
+        }
+
+        [Parameter(Mandatory = false)]
+        public SwitchParameter ConsistencyLevelEventual;
+
+        [Parameter(Mandatory = false)]
+        public SwitchParameter Raw;
+
+        [Parameter(Mandatory = false)]
+        public SwitchParameter All;
+
+        protected override void ExecuteCmdlet()
+        {
+            try
+            {
+                SendRequest();
+            }
+            catch (Exception ex)
+            {
+                WriteError(ex, ErrorCategory.WriteError);
+            }
+        }
+
+        private HttpContent GetHttpContent()
+        {
+            if (Content != null)
+            {
+                if (Content is HttpContent)
+                {
+                    return (HttpContent)Content;
+                }
+                if (string.IsNullOrEmpty(ContentType))
+                {
+                    ContentType = "application/json";
+                }
+                var contentString = Content is string ? Content.ToString() :
+                    JsonSerializer.Serialize(Content);
+
+                HttpContent httpContent = new StringContent(contentString, System.Text.Encoding.UTF8);
+                httpContent.Headers.ContentType = MediaTypeHeaderValue.Parse(ContentType);
+                return httpContent;
+            }
+            return null;
+        }
+
+        private void SendRequest()
+        {
+            try
+            {
+                switch (Method)
+                {
+                    case HttpRequestMethod.Get:
+                        GetRequest();
+                        return;
+                    case HttpRequestMethod.Post:
+                        PostRequest();
+                        return;
+                    case HttpRequestMethod.Patch:
+                        PatchRequest();
+                        return;
+                    case HttpRequestMethod.Put:
+                        PutRequest();
+                        return;
+                    case HttpRequestMethod.Delete:
+                        DeleteRequest();
+                        return;
+                }
+                throw new NotSupportedException($"method [{Method}] not supported");
+            }
+            catch (PnP.PowerShell.Commands.Model.Graph.GraphException gex)
+            {
+                if (gex.Error.Code == "Authorization_RequestDenied")
+                {
+                    if (!string.IsNullOrEmpty(gex.AccessToken))
+                    {
+                        TokenHandler.ValidateTokenForPermissions(GetType(), gex.AccessToken);
+                    }
+                }
+                throw new PSInvalidOperationException(gex.Error.Message);
+            }
+        }
+
+        private void ThrowIfNoSuccess(HttpResponseMessage response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorContent = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                var exception = JsonSerializer.Deserialize<GraphException>(errorContent, new JsonSerializerOptions() { IgnoreNullValues = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+                exception.AccessToken = AccessToken;
+                throw exception;
+            }
+        }
+
+        private object Deserialize(string result)
+        {
+            var element = JsonSerializer.Deserialize<JsonElement>(result);
+            return Deserialize(element);
+        }
+
+        private object Deserialize(JsonElement element)
+        {
+            var obj = Utilities.JSON.Convert.ConvertToObject(element);
+            return obj;
+        }
+
+        private void WriteGraphResult(string result)
+        {
+            if (!string.IsNullOrEmpty(result))
+            {
+                if (Raw.IsPresent)
+                {
+                    WriteObject(result);
+                }
+                else
+                {
+                    WriteObject(Deserialize(result));
+                }
+            }
+        }
+
+        private void GetRequest()
+        {
+            var result = GraphHelper.GetAsync(HttpClient, Url, AccessToken, AdditionalHeaders).GetAwaiter().GetResult();
+            if (Raw.IsPresent)
+            {
+                WriteObject(result);
+            }
+            else
+            {
+                var element = JsonSerializer.Deserialize<JsonElement>(result);
+                var rootObj = Deserialize(element);
+
+                dynamic obj = rootObj;
+
+                if (All.IsPresent && obj != null && obj.value != null && (obj.value is List<object>))
+                {
+                    List<object> values = obj.value;
+                    while (true)
+                    {
+                        if (element.TryGetProperty("@odata.nextLink", out JsonElement nextLinkProperty))
+                        {
+                            if (nextLinkProperty.ValueKind != JsonValueKind.String)
+                            {
+                                break;
+                            }
+                            var nextLink = nextLinkProperty.ToString();
+                            result = GraphHelper.GetAsync(HttpClient, nextLink, AccessToken, AdditionalHeaders).GetAwaiter().GetResult();
+                            element = JsonSerializer.Deserialize<JsonElement>(result);
+                            dynamic nextObj = Deserialize(element);
+                            if (nextObj != null && nextObj.value != null && (nextObj.value is List<object>))
+                            {
+                                List<object> nextValues = nextObj.value;
+                                values.AddRange(nextValues);
+                            }
+                            else
+                            {
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                }
+                WriteObject(rootObj);
+            }
+        }
+
+        private void PostRequest()
+        {
+            var response = GraphHelper.PostAsync(HttpClient, Url, AccessToken, GetHttpContent(), AdditionalHeaders).GetAwaiter().GetResult();
+            ThrowIfNoSuccess(response);
+            var result = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            WriteGraphResult(result);
+        }
+
+        private void PutRequest()
+        {
+            var response = GraphHelper.PutAsync(HttpClient, Url, AccessToken, GetHttpContent(), AdditionalHeaders).GetAwaiter().GetResult();
+            ThrowIfNoSuccess(response);
+            var result = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            WriteGraphResult(result);
+        }
+
+        private void PatchRequest()
+        {
+            var response = GraphHelper.PatchAsync(HttpClient, AccessToken, GetHttpContent(), Url, AdditionalHeaders).GetAwaiter().GetResult();
+            ThrowIfNoSuccess(response);
+            var result = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            WriteGraphResult(result);
+        }
+
+        private void DeleteRequest()
+        {
+            var response = GraphHelper.DeleteAsync(HttpClient, Url, AccessToken, AdditionalHeaders).GetAwaiter().GetResult();
+            ThrowIfNoSuccess(response);
+            var result = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            WriteGraphResult(result);
+        }
+    }
+}

--- a/src/Commands/Utilities/Json/Convert.cs
+++ b/src/Commands/Utilities/Json/Convert.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Text;
+using System.Text.Json;
+
+namespace PnP.PowerShell.Commands.Utilities.JSON
+{
+    public static class Convert
+    {
+        public static PSObject ConvertToPSObject(string jsonString)
+        {
+            var jsonElement = JsonSerializer.Deserialize<JsonElement>(jsonString);
+            return ConvertToPSObject(jsonElement);
+        }
+
+        public static PSObject ConvertToPSObject(JsonElement element) => ConvertToPSObject(element, null);
+
+        public static PSObject ConvertToPSObject(JsonElement element, string jsonPropertyName)
+        {
+            var value = ConvertToObject(element);
+            if (!string.IsNullOrEmpty(jsonPropertyName))
+            {
+                var pso = new PSObject();
+                pso.Properties.Add(new PSNoteProperty(jsonPropertyName, value));
+                return pso;
+            }
+            if (value is PSObject)
+            {
+                return (PSObject)value;
+            }
+            throw new FormatException($"primitive type[{element.ValueKind}] can not be converted to PSObject");
+        }
+
+        public static object ConvertToObject(string jsonString)
+        {
+            var jsonElement = JsonSerializer.Deserialize<JsonElement>(jsonString);
+            return ConvertToObject(jsonElement);
+        }
+
+        public static object ConvertToObject(JsonElement element)
+        {
+            object value = null;
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.Array:
+                    {
+                        value = ConvertToPSObjectArray(element);
+                        break;
+                    }
+                case JsonValueKind.True:
+                case JsonValueKind.False:
+                    {
+                        value = element.GetBoolean();
+                        break;
+                    }
+                case JsonValueKind.String:
+                    {
+                        value = element.GetString();
+                        break;
+                    }
+                case JsonValueKind.Object:
+                    {
+                        var nestedPso = new PSObject();
+                        foreach (var prop in element.EnumerateObject())
+                        {
+                            var propValue = ConvertToObject(prop.Value);
+                            nestedPso.Properties.Add(new PSNoteProperty(prop.Name, propValue));
+                        }
+                        value = nestedPso;
+                        break;
+                    }
+                case JsonValueKind.Number:
+                    {
+                        value = element.GetInt64();
+                        break;
+                    }
+            }
+
+            return value;
+        }
+
+        private static List<object> ConvertToPSObjectArray(JsonElement element)
+        {
+            var list = new List<object>();
+
+            foreach (var subelement in element.EnumerateArray())
+            {
+                var value = ConvertToObject(subelement);
+                list.Add(value);
+            }
+            return list;
+        }
+    }
+}

--- a/src/Commands/Utilities/REST/GraphHelper.cs
+++ b/src/Commands/Utilities/REST/GraphHelper.cs
@@ -40,7 +40,7 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             }
         }
 
-        private static HttpRequestMessage GetMessage(string url, HttpMethod method, string accessToken, HttpContent content = null, Dictionary<string, string> additionalHeaders = null)
+        private static HttpRequestMessage GetMessage(string url, HttpMethod method, string accessToken, HttpContent content = null, IDictionary<string, string> additionalHeaders = null)
         {
             if (url.StartsWith("/"))
             {
@@ -67,9 +67,9 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             return message;
         }
 
-        public static async Task<string> GetAsync(HttpClient httpClient, string url, string accessToken)
+        public static async Task<string> GetAsync(HttpClient httpClient, string url, string accessToken, IDictionary<string, string> additionalHeaders = null)
         {
-            var message = GetMessage(url, HttpMethod.Get, accessToken);
+            var message = GetMessage(url, HttpMethod.Get, accessToken, null, additionalHeaders);
             return await SendMessageAsync(httpClient, message, accessToken);
         }
 
@@ -148,26 +148,26 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             return default(T);
         }
 
-        public static async Task<HttpResponseMessage> PostAsync(HttpClient httpClient, string url, string accessToken, HttpContent content)
+        public static async Task<HttpResponseMessage> PostAsync(HttpClient httpClient, string url, string accessToken, HttpContent content, IDictionary<string, string> additionalHeaders = null)
         {
-            var message = GetMessage(url, HttpMethod.Post, accessToken, content);
+            var message = GetMessage(url, HttpMethod.Post, accessToken, content, additionalHeaders);
             return await GetResponseMessageAsync(httpClient, message);
         }
 
-        public static async Task<HttpResponseMessage> PutAsync(HttpClient httpClient, string url, string accessToken, HttpContent content)
+        public static async Task<HttpResponseMessage> PutAsync(HttpClient httpClient, string url, string accessToken, HttpContent content, IDictionary<string, string> additionalHeaders = null)
         {
-            var message = GetMessage(url, HttpMethod.Put, accessToken, content);
+            var message = GetMessage(url, HttpMethod.Put, accessToken, content, additionalHeaders);
             return await GetResponseMessageAsync(httpClient, message);
         }
 
         #region DELETE
-        public static async Task<HttpResponseMessage> DeleteAsync(HttpClient httpClient, string url, string accessToken, Dictionary<string, string> additionalHeaders = null)
+        public static async Task<HttpResponseMessage> DeleteAsync(HttpClient httpClient, string url, string accessToken, IDictionary<string, string> additionalHeaders = null)
         {
             var message = GetMessage(url, HttpMethod.Delete, accessToken, null, additionalHeaders);
             return await GetResponseMessageAsync(httpClient, message);
         }
 
-        public static async Task<T> DeleteAsync<T>(HttpClient httpClient, string url, string accessToken, bool camlCasePolicy = true, Dictionary<string, string> additionalHeaders = null)
+        public static async Task<T> DeleteAsync<T>(HttpClient httpClient, string url, string accessToken, bool camlCasePolicy = true, IDictionary<string, string> additionalHeaders = null)
         {
             var response = await DeleteAsync(httpClient, url, accessToken, additionalHeaders);
             if (response.IsSuccessStatusCode)
@@ -196,7 +196,7 @@ namespace PnP.PowerShell.Commands.Utilities.REST
         #endregion
 
         #region PATCH
-        public static async Task<T> PatchAsync<T>(HttpClient httpClient, string accessToken, string url, T content, Dictionary<string, string> additionalHeaders = null, bool camlCasePolicy = true)
+        public static async Task<T> PatchAsync<T>(HttpClient httpClient, string accessToken, string url, T content, IDictionary<string, string> additionalHeaders = null, bool camlCasePolicy = true)
         {
             var serializerSettings = new JsonSerializerOptions() { IgnoreNullValues = true };
             if (camlCasePolicy)
@@ -221,7 +221,7 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             }
         }
 
-        public static async Task<T> PatchAsync<T>(HttpClient httpClient, string accessToken, string url, HttpContent content, Dictionary<string, string> additionalHeaders = null)
+        public static async Task<T> PatchAsync<T>(HttpClient httpClient, string accessToken, string url, HttpContent content, IDictionary<string, string> additionalHeaders = null)
         {
 #if NETFRAMEWORK
             var message = GetMessage(url, new HttpMethod("PATCH"), accessToken, content, additionalHeaders);
@@ -239,7 +239,7 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             }
         }
 
-        public static async Task<HttpResponseMessage> PatchAsync(HttpClient httpClient, string accessToken, HttpContent content, string url, Dictionary<string, string> additionalHeaders = null)
+        public static async Task<HttpResponseMessage> PatchAsync(HttpClient httpClient, string accessToken, HttpContent content, string url, IDictionary<string, string> additionalHeaders = null)
         {
 #if NETFRAMEWORK
             var message = GetMessage(url, new HttpMethod("PATCH"), accessToken, content, additionalHeaders);
@@ -251,7 +251,7 @@ namespace PnP.PowerShell.Commands.Utilities.REST
 
 
 
-        // public static async Task<T> PatchAsync<T>(HttpClient httpClient, string accessToken, string url, T content,Dictionary<string, string> additionalHeaders = null)
+        // public static async Task<T> PatchAsync<T>(HttpClient httpClient, string accessToken, string url, T content,IDictionary<string, string> additionalHeaders = null)
         // {
         //     var requestContent = new StringContent(JsonSerializer.Serialize(content, new JsonSerializerOptions() { IgnoreNullValues = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
         //     requestContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
@@ -269,12 +269,12 @@ namespace PnP.PowerShell.Commands.Utilities.REST
         #endregion
 
 
-        public static async Task<T> PostAsync<T>(HttpClient httpClient, string url, HttpContent content, string accessToken, Dictionary<string, string> additionalHeaders = null, bool propertyNameCaseInsensitive = false)
+        public static async Task<T> PostAsync<T>(HttpClient httpClient, string url, HttpContent content, string accessToken, IDictionary<string, string> additionalHeaders = null, bool propertyNameCaseInsensitive = false)
         {
             return await PostInternalAsync<T>(httpClient, url, accessToken, content, additionalHeaders, propertyNameCaseInsensitive);
         }
 
-        public static async Task<T> PutAsync<T>(HttpClient httpClient, string url, string accessToken, HttpContent content, Dictionary<string, string> additionalHeaders = null)
+        public static async Task<T> PutAsync<T>(HttpClient httpClient, string url, string accessToken, HttpContent content, IDictionary<string, string> additionalHeaders = null)
         {
             var message = GetMessage(url, HttpMethod.Put, accessToken, content, additionalHeaders);
             var stringContent = await SendMessageAsync(httpClient, message, accessToken);
@@ -305,7 +305,7 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             return await PostInternalAsync<T>(httpClient, url, accessToken, null);
         }
 
-        private static async Task<T> PostInternalAsync<T>(HttpClient httpClient, string url, string accessToken, HttpContent content, Dictionary<string, string> additionalHeaders = null, bool propertyNameCaseInsensitive = false)
+        private static async Task<T> PostInternalAsync<T>(HttpClient httpClient, string url, string accessToken, HttpContent content, IDictionary<string, string> additionalHeaders = null, bool propertyNameCaseInsensitive = false)
         {
             var message = GetMessage(url, HttpMethod.Post, accessToken, content, additionalHeaders);
             var stringContent = await SendMessageAsync(httpClient, message, accessToken);


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #873 

## What is in this Pull Request ? ##
Add a new command `Invoke-PnPGraphMethod` to invoke generic Microsoft Graph API Methods.
- Updated GraphHelper to support additional headers on all methods
- json utility to convert to PSObject/object
- updated src/Commands/Base/InvokeSPRestMethod.cs to use json convert utility
- implemented src/Commands/Graph/InvokeGraphMethod.cs
- docs for Invoke-PnPGraphMethod
