### PR TITLE
Update New-PnPSite.md

### DIFF
--- a/documentation/New-PnPSite.md
+++ b/documentation/New-PnPSite.md
@@ -226,7 +226,7 @@ Accept wildcard characters: False
 ```
 
 ### -IsPublic
-Identifies whether the corresponding Microsoft365 group type is Private or Public. If not specified, group is considered Public.
+Identifies whether the corresponding Microsoft365 group type is Private or Public. If not specified, group is considered Private.
 Content in a Public group can be seen by anybody in the organization, and anybody in the organization is able to join the group. 
 Content in a Private group can only be seen by the members of the group and people who want to join a private group have to be approved by a group owner.
 


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
No

## What is in this Pull Request ? ##
Change to the documentation of New-PnPSite: When the parameter -IsPublic is not specified the default value is false, so the group will be Private. The current documentation incorrectly says it will be Public.