### PR TITLE
Adds cmdlet Set-PnPTeamsChannelUser

### DIFF
--- a/documentation/Set-PnpTeamsChannelUser.md
+++ b/documentation/Set-PnpTeamsChannelUser.md
@@ -2,12 +2,12 @@
 Module Name: PnP.PowerShell
 schema: 2.0.0
 applicable: SharePoint Online
-online version: https://pnp.github.io/powershell/cmdlets/Add-PnPTeamsChannelUser.html
+online version: https://pnp.github.io/powershell/cmdlets/Set-PnPTeamsChannelUser.html
 external help file: PnP.PowerShell.dll-Help.xml
-title: Add-PnPTeamsChannelUser
+title: Set-PnPTeamsChannelUser
 ---
   
-# Add-PnPTeamsChannelUser
+# Set-PnPTeamsChannelUser
 
 ## SYNOPSIS
 
@@ -15,12 +15,12 @@ title: Add-PnPTeamsChannelUser
 
   * Microsoft Graph API: ChannelMember.ReadWrite.All
 
-Adds a user to an existing Microsoft Teams private channel.
+Updates the role of a user in an existing Microsoft Teams private channel.
 
 ## SYNTAX
 
 ```powershell
-Add-PnPTeamsChannelUser -Team <TeamsTeamPipeBind> -Channel <TeamsChannelPipeBind> -User <String> -Role <String> [<CommonParameters>]
+Set-PnPTeamsChannelUser -Team <TeamsTeamPipeBind> -Channel <TeamsChannelPipeBind> -User <String> -Role <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -29,17 +29,17 @@ Add-PnPTeamsChannelUser -Team <TeamsTeamPipeBind> -Channel <TeamsChannelPipeBind
 
 ### EXAMPLE 1
 ```powershell
-Add-PnPTeamsChannelUser -Team 4efdf392-8225-4763-9e7f-4edeb7f721aa -Channel "19:796d063b63e34497aeaf092c8fb9b44e@thread.skype" -User john@doe.com -Role Owner
+Set-PnPTeamsChannelUser -Team 4efdf392-8225-4763-9e7f-4edeb7f721aa -Channel "19:796d063b63e34497aeaf092c8fb9b44e@thread.skype" -Identity MCMjMiMjMDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwIyMxOTowMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMEB0aHJlYWQuc2t5cGUjIzAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMA== -Role Owner
 ```
 
-Adds user as an owner to the private channel.
+Updates the user with specific membership ID as owner of the specified Teams private channel.
 
 ### EXAMPLE 2
 ```powershell
-Add-PnPTeamsChannelUser -Team "My Team" -Channel "My Private Channel" -User john@doe.com -Role Member
+Set-PnPTeamsChannelUser -Team "My Team" -Channel "My Private Channel" -Identity john@doe.com -Role Member
 ```
 
-Adds user as a member to the private channel.
+Updates the user john@doe.com as member of the specified Teams private channel.
 
 ## PARAMETERS
 
@@ -71,12 +71,12 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -User
-Specify the UPN (e.g. john@doe.com)
+### -Identity
+Specify membership id, UPN or user ID of the channel member.
 
 ```yaml
-Type: String
-Parameter Sets: (User)
+Type: TeamsChannelMemberPipeBind
+Parameter Sets: (All)
 
 Required: True
 Position: Named

--- a/documentation/Set-PnpTeamsChannelUser.md
+++ b/documentation/Set-PnpTeamsChannelUser.md
@@ -20,7 +20,7 @@ Updates the role of a user in an existing Microsoft Teams private channel.
 ## SYNTAX
 
 ```powershell
-Set-PnPTeamsChannelUser -Team <TeamsTeamPipeBind> -Channel <TeamsChannelPipeBind> -User <String> -Role <String> [<CommonParameters>]
+Set-PnPTeamsChannelUser -Team <TeamsTeamPipeBind> -Channel <TeamsChannelPipeBind> -Identity <TeamsChannelMemberPipeBind> -Role <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/src/Commands/Teams/SetTeamsChannelUser.cs
+++ b/src/Commands/Teams/SetTeamsChannelUser.cs
@@ -1,0 +1,63 @@
+﻿using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Base.PipeBinds;
+using PnP.PowerShell.Commands.Model.Graph;
+using PnP.PowerShell.Commands.Utilities;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Teams
+{
+    [Cmdlet(VerbsCommon.Set, "PnPTeamsChannelUser")]
+    [RequiredMinimalApiPermissions("ChannelMember.ReadWrite.All")]
+    public class SetTeamsChannelUser : PnPGraphCmdlet
+    {
+        [Parameter(Mandatory = true)]
+        public TeamsTeamPipeBind Team;
+
+        [Parameter(Mandatory = true)]
+        public TeamsChannelPipeBind Channel;
+
+        [Parameter(Mandatory = true)]
+        public TeamsChannelMemberPipeBind Identity;
+
+        [Parameter(Mandatory = true)]
+        [ValidateSet("Owner", "Member")]
+        public string Role;
+
+        protected override void ExecuteCmdlet()
+        {
+            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            if (groupId == null)
+            {
+                throw new PSArgumentException("Group not found");
+            }
+
+            var channelId = Channel.GetId(HttpClient, AccessToken, groupId);
+            if (channelId == null)
+            {
+                throw new PSArgumentException("Channel not found");
+            }
+
+            var membershipId = Identity.GetIdAsync(HttpClient, AccessToken, groupId, channelId).GetAwaiter().GetResult();
+            if (string.IsNullOrEmpty(membershipId))
+            {
+                throw new PSArgumentException("User was not found in the specified Teams channel");
+            }
+
+            try
+            {
+                var updatedMember = TeamsUtility.UpdateChannelMemberAsync(HttpClient, AccessToken, groupId, channelId, membershipId, Role).GetAwaiter().GetResult();
+                WriteObject(updatedMember);
+            }
+            catch (GraphException ex)
+            {
+                if (ex.Error != null)
+                {
+                    throw new PSInvalidOperationException(ex.Error.Message);
+                }
+
+                throw;
+            }
+        }
+    }
+}

--- a/src/Commands/Utilities/TeamsUtility.cs
+++ b/src/Commands/Utilities/TeamsUtility.cs
@@ -697,6 +697,21 @@ namespace PnP.PowerShell.Commands.Utilities
             return await GraphHelper.DeleteAsync(httpClient, $"v1.0/teams/{groupId}/channels/{channelId}/members/{membershipId}", accessToken);
         }
 
+        /// <summary>
+        /// Update the role of a specific member of a Microsoft Teams channel.
+        /// </summary>
+        /// <returns>Updated membership object.</returns>
+        public static async Task<TeamChannelMember> UpdateChannelMemberAsync(HttpClient httpClient, string accessToken, string groupId, string channelId, string membershipId, string role)
+        {
+            var channelMember = new TeamChannelMember();
+
+            // User role. Empty for member, 'owner' for owner.
+            if (role.Equals("owner", StringComparison.OrdinalIgnoreCase))
+                channelMember.Roles.Add("owner");
+
+            return await GraphHelper.PatchAsync(httpClient, accessToken, $"v1.0/teams/{groupId}/channels/{channelId}/members/{membershipId}", channelMember);
+        }
+
         #endregion
 
         #region Tabs


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #1841

## What is in this Pull Request ? ##
This cmdlet can update the role of a user in a private channel. Valid roles: Owner, Member.

Usage:
```powershell
 Set-PnPTeamsChannelUser -Team "My Team" -Channel "My Channel" -Identity john.doe@contoso.com -Role Owner
```

Also updated documentation typo for the `Add-PnPTeamsChannelUser` -Channel parameter should be required.