### PR TITLE
Updated example of the query parameter

### DIFF
--- a/documentation/Add-PnPDataRowsToSiteTemplate.md
+++ b/documentation/Add-PnPDataRowsToSiteTemplate.md
@@ -26,17 +26,17 @@ Add-PnPDataRowsToSiteTemplate [-Path] <String> -List <ListPipeBind> [-Query <Str
 
 ### EXAMPLE 1
 ```powershell
-Add-PnPDataRowsToSiteTemplate -Path template.pnp -List 'PnPTestList' -Query '<View></View>' -Fields 'Title','Choice'
+Add-PnPDataRowsToSiteTemplate -Path template.pnp -List 'PnPTestList' -Fields 'Title','Choice'
 ```
 
 Adds datarows from the provided list to the PnP Provisioning Template at the provided location
 
 ### EXAMPLE 2
 ```powershell
-Add-PnPDataRowsToSiteTemplate -Path template.pnp -List 'PnPTestList' -Query '<View></View>' -Fields 'Title','Choice' -IncludeSecurity
+Add-PnPDataRowsToSiteTemplate -Path template.pnp -List 'PnPTestList' -Query '<Query><Where><Geq><FieldRef Name="Modified"/><Value Type="DateTime"><Today OffsetDays="-7" /></Value></Eq></Where></Query>' -Fields 'Title','Choice' -IncludeSecurity
 ```
 
-Adds datarows from the provided list to the PnP Provisioning Template at the provided location
+Adds datarows from the provided list to the PnP Provisioning Template at the provided location, only the items that have changed since a week ago
 
 ## PARAMETERS
 

--- a/documentation/Add-PnPDataRowsToSiteTemplate.md
+++ b/documentation/Add-PnPDataRowsToSiteTemplate.md
@@ -33,7 +33,7 @@ Adds datarows from the provided list to the PnP Provisioning Template at the pro
 
 ### EXAMPLE 2
 ```powershell
-Add-PnPDataRowsToSiteTemplate -Path template.pnp -List 'PnPTestList' -Query '<Query><Where><Geq><FieldRef Name="Modified"/><Value Type="DateTime"><Today OffsetDays="-7" /></Value></Eq></Where></Query>' -Fields 'Title','Choice' -IncludeSecurity
+Add-PnPDataRowsToSiteTemplate -Path template.pnp -List 'PnPTestList' -Query '<Query><Where><Geq><FieldRef Name="Modified"/><Value Type="DateTime"><Today OffsetDays="-7" /></Value></Geq></Where></Query>' -Fields 'Title','Choice' -IncludeSecurity
 ```
 
 Adds datarows from the provided list to the PnP Provisioning Template at the provided location, only the items that have changed since a week ago


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [x] Sample

## What is in this Pull Request ? ##
The two examples of the Add-PnPDataRowsToSiteTemplate cmdlet contained a value for the Query parameter that caused confusion. At line 98 in the cmdlet, the query is merged with the value of the fields list inside a <View></View> element:
`query.ViewXml = string.Format("<View>{0}{1}</View>", Query, viewFieldsStringBuilder);`

So in order for this to work, the Query parameter should contain a <Query> element. I removed the Query parameter from the first example since it does not do anything, it's only confusing and added a more meaningful and working example to the second example. 

