### PR TITLE
Bugfix in `Sync-PnPSharePointUserProfilesFromAzureActiveDirectory`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Set-PnPListPermission`, it will now throw error if the list does not exist. [#1891](https://github.com/pnp/powershell/pull/1891)
 - Fixed `Invoke-PnPSPRestMethod` invalid parsing for SharePoint number columns. [#1877](https://github.com/pnp/powershell/pull/1879)
 - Fix issue with `Add/Set-PnPListItem` not throwing correct exception for invalid taxonomy values. [#1870](https://github.com/pnp/powershell/pull/1870)
+- Fixed `Sync-PnPSharePointUserProfilesFromAzureActiveDirectory` throwing an "Object reference not set to an instance of an object" exception when providing an empty users collection or incorrect user mapping [#1896](https://github.com/pnp/powershell/pull/1896)
 
 ### Removed
 - Removed `Get-PnPAvailableClientSideComponents`. Use `Get-PnPPageComponent -Page -ListAvailable` instead.  [#1833](https://github.com/pnp/powershell/pull/1833)

--- a/src/Commands/UserProfiles/SyncSharePointUserProfilesFromAzureActiveDirectory.cs
+++ b/src/Commands/UserProfiles/SyncSharePointUserProfilesFromAzureActiveDirectory.cs
@@ -89,6 +89,12 @@ namespace PnP.PowerShell.Commands.UserProfiles
             WriteVerbose($"Creating mapping file{(WhatIf.ToBool() ? " and" : ",")} uploading it to SharePoint Online to folder '{Folder}'{(WhatIf.ToBool() ? "" : " and executing sync job")}");
             var job = PnP.PowerShell.Commands.Utilities.SharePointUserProfileSync.SyncFromAzureActiveDirectory(nonAdminClientContext, aadUsers, IdType, UserProfilePropertyMapping, Folder, ParameterSpecified(nameof(WhatIf))).GetAwaiter().GetResult();
 
+            // Ensure a sync job has been created
+            if(job == null)
+            {
+                throw new PSInvalidOperationException($"Failed to create sync job. Ensure you're providing users to sync and that the mapping is correct.");
+            }
+
             WriteVerbose($"Job initiated with Id {job.JobId} and status {job.State} for file {job.SourceUri}");
 
             // Check if we should wait with finalzing this cmdlet execution until the user profile import operation has completed

--- a/src/Commands/UserProfiles/SyncSharePointUserProfilesFromAzureActiveDirectory.cs
+++ b/src/Commands/UserProfiles/SyncSharePointUserProfilesFromAzureActiveDirectory.cs
@@ -40,12 +40,18 @@ namespace PnP.PowerShell.Commands.UserProfiles
             var aadUsers = new List<PnP.PowerShell.Commands.Model.AzureAD.User>();
             if (ParameterSpecified(nameof(Users)))
             {
-                // Users to sync have been provided
+                // Ensure users have been provided
                 if(Users == null)
                 {
                     throw new PSArgumentNullException(nameof(Users), "Provided Users collection cannot be null");
                 }
+                if(Users.Count == 0)
+                {
+                    WriteVerbose("No users have been provided");
+                    return;
+                }
 
+                // Users to sync have been provided
                 WriteVerbose($"Using provided user collection containing {Users.Count} user{(Users.Count != 1 ? "s": "")}");
 
                 aadUsers = Users;


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
When passing in a collection using `-Users` which has no items (Count = 0), it would throw a mysterious "Object reference not set to an instance of an object" exception. This has now been resolved. Also, when providing a mapping using `-UserProfilePropertyMapping` which would not result in a mapping file to be created, a similar exception would be thrown. These are now correctly handled and feedback is provided back.