### PR TITLE
Removed 200 mb limit from `Copy-PnPFile` documentation

### DIFF
--- a/documentation/Copy-PnPFile.md
+++ b/documentation/Copy-PnPFile.md
@@ -21,7 +21,7 @@ Copy-PnPFile [-SourceUrl] <String> [-TargetUrl] <String> [-Overwrite] [-Force] [
 
 ## DESCRIPTION
 
-Copies a file or folder to a different location. This location can be within the same document library, same site, same site collection or even to another site collection on the same tenant. Currently there is a 200MB file size limit for the file or folder to be copied. Notice that if copying between sites or to a subsite you cannot specify a target filename, only a folder name.
+Copies a file or folder to a different location. This location can be within the same document library, same site, same site collection or even to another site collection on the same tenant. Notice that if copying between sites or to a subsite you cannot specify a target filename, only a folder name. It is currently not possible to copy files between a OneDrive for Business site to SharePoint or vice versa.
 
 Copying files and folders is bound to some restrictions. You can find more on it here: https://docs.microsoft.com/office365/servicedescriptions/sharepoint-online-service-description/sharepoint-online-limits#moving-and-copying-across-sites
 


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample
- [X] Docfix

## Related Issues? ##
Resolves #1913 

## What is in this Pull Request ? ##
Removed the text that mentioned there to be a 200 mb limit on copying files. The actual limits are written in the official documentation to which is being linked.