### PR TITLE
Various fixes when using specific Connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Invoke-PnPSPRestMethod` invalid parsing for SharePoint number columns. [#1877](https://github.com/pnp/powershell/pull/1879)
 - Fix issue with `Add/Set-PnPListItem` not throwing correct exception for invalid taxonomy values. [#1870](https://github.com/pnp/powershell/pull/1870)
 - Fixed `Sync-PnPSharePointUserProfilesFromAzureActiveDirectory` throwing an "Object reference not set to an instance of an object" exception when providing an empty users collection or incorrect user mapping [#1896](https://github.com/pnp/powershell/pull/1896)
+- Fixed `Connect-PnPOnline -ReturnConnection` also setting the current connection instead of just the returned connection
+- Fixed `Disconnect-PnPOnline -Connection` also disconnecting other connections next to the provided connection
 
 ### Removed
 - Removed `Get-PnPAvailableClientSideComponents`. Use `Get-PnPPageComponent -Page -ListAvailable` instead.  [#1833](https://github.com/pnp/powershell/pull/1833)

--- a/documentation/Get-PnPConnection.md
+++ b/documentation/Get-PnPConnection.md
@@ -10,12 +10,12 @@ title: Get-PnPConnection
 # Get-PnPConnection
 
 ## SYNOPSIS
-Returns the current context
+Returns the current connection
 
 ## SYNTAX
 
 ```powershell
-Get-PnPConnection [<CommonParameters>]
+Get-PnPConnection [-Connection <PnPConnection>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -32,8 +32,22 @@ This will put the current connection for use with the -Connection parameter on o
 
 ## PARAMETERS
 
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by specifying -ReturnConnection on Connect-PnPOnline. If not provided, the connection will be retrieved from the current context.
+
+```yaml
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ## RELATED LINKS
 
 [Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)
-
-

--- a/documentation/Get-PnPContext.md
+++ b/documentation/Get-PnPContext.md
@@ -10,16 +10,16 @@ title: Get-PnPContext
 # Get-PnPContext
 
 ## SYNOPSIS
-Returns the current context
+Returns the current SharePoint Online CSOM context
 
 ## SYNTAX
 
 ```powershell
-Get-PnPContext [<CommonParameters>]
+Get-PnPContext [-Connection <PnPConnection>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Returns a Client Side Object Model context
+Returns a SharePoint Online Client Side Object Model (CSOM) context
 
 ## EXAMPLES
 
@@ -43,8 +43,20 @@ Get-PnPList # returns the lists from site A
 
 ## PARAMETERS
 
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection. If not provided, the context of the connection will be retrieved from the current connection.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ## RELATED LINKS
 
 [Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)
-
-

--- a/documentation/Get-PnPList.md
+++ b/documentation/Get-PnPList.md
@@ -53,20 +53,6 @@ This examples shows how to do wildcard searches on the list URL. It returns all 
 
 ## PARAMETERS
 
-### -Connection
-Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.
-
-```yaml
-Type: PnPConnection
-Parameter Sets: (All)
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Identity
 The ID, name or Url (Lists/MyList) of the list
 
@@ -95,10 +81,20 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.
 
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ## RELATED LINKS
 
 [Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)
-
-

--- a/src/Commands/Base/BasePSCmdlet.cs
+++ b/src/Commands/Base/BasePSCmdlet.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Management.Automation;
-using System.Reflection;
 using PnP.PowerShell.Commands.Attributes;
 
 namespace PnP.PowerShell.Commands.Base

--- a/src/Commands/Base/ConnectOnline.cs
+++ b/src/Commands/Base/ConnectOnline.cs
@@ -283,8 +283,8 @@ namespace PnP.PowerShell.Commands.Base
 #else
             WriteVerbose($"PnP PowerShell Cmdlets ({Assembly.GetExecutingAssembly().GetName().Version})");
 #endif
-            PnPConnection.Current = connection;
-            if (CreateDrive && PnPConnection.Current.Context != null)
+            
+            if (CreateDrive && connection.Context != null)
             {
                 var provider = SessionState.Provider.GetAll().FirstOrDefault(p => p.Name.Equals(SPOProvider.PSProviderName, StringComparison.InvariantCultureIgnoreCase));
                 if (provider != null)
@@ -299,9 +299,9 @@ namespace PnP.PowerShell.Commands.Base
                 }
             }
 
-            if (PnPConnection.Current.Url != null)
+            if (connection.Url != null)
             {
-                var hostUri = new Uri(PnPConnection.Current.Url);
+                var hostUri = new Uri(connection.Url);
                 Environment.SetEnvironmentVariable("PNPPSHOST", hostUri.Host);
                 Environment.SetEnvironmentVariable("PNPPSSITE", hostUri.LocalPath);
             }
@@ -315,7 +315,10 @@ namespace PnP.PowerShell.Commands.Base
             {
                 WriteObject(connection);
             }
-
+            else
+            {
+                PnPConnection.Current = connection;
+            }
         }
 
         #region Connect Types

--- a/src/Commands/Base/GetConnection.cs
+++ b/src/Commands/Base/GetConnection.cs
@@ -1,32 +1,14 @@
 ﻿using System.Management.Automation;
 
-using System;
-using PnP.PowerShell.Commands.Properties;
-
 namespace PnP.PowerShell.Commands.Base
 {
     [Cmdlet(VerbsCommon.Get, "PnPConnection")]
     [OutputType(typeof(PnPConnection))]
-    public class GetPnPConnection : PSCmdlet
+    public class GetPnPConnection : PnPSharePointCmdlet
     {
-
-        protected override void BeginProcessing()
-        {
-            base.BeginProcessing();
-
-            if (PnPConnection.Current == null)
-            {
-                throw new InvalidOperationException(Resources.NoSharePointConnection);
-            }
-            if (PnPConnection.Current.Context == null)
-            {
-                throw new InvalidOperationException(Resources.NoSharePointConnection);
-            }
-        }
-
         protected override void ProcessRecord()
         {
-            WriteObject(PnPConnection.Current);
+            WriteObject(Connection);
         }
     }
 }

--- a/src/Commands/Base/GetContext.cs
+++ b/src/Commands/Base/GetContext.cs
@@ -1,32 +1,14 @@
 ﻿using System.Management.Automation;
 
-using System;
-using PnP.PowerShell.Commands.Properties;
-
 namespace PnP.PowerShell.Commands.Base
 {
     [Cmdlet(VerbsCommon.Get, "PnPContext")]
     [OutputType(typeof(Microsoft.SharePoint.Client.ClientContext))]
-    public class GetSPOContext : PSCmdlet
+    public class GetSPOContext : PnPSharePointCmdlet
     {
-
-        protected override void BeginProcessing()
-        {
-            base.BeginProcessing();
-
-            if (PnPConnection.Current == null)
-            {
-                throw new InvalidOperationException(Resources.NoSharePointConnection);
-            }
-            if (PnPConnection.Current.Context == null)
-            {
-                throw new InvalidOperationException(Resources.NoSharePointConnection);
-            }
-        }
-
         protected override void ProcessRecord()
         {
-            WriteObject(PnPConnection.Current.Context);
+            WriteObject(Connection.Context);
         }
     }
 }

--- a/src/Commands/Base/PnPConnectedCmdlet.cs
+++ b/src/Commands/Base/PnPConnectedCmdlet.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Management.Automation;
 using System.Net.Http;
 
 namespace PnP.PowerShell.Commands.Base
@@ -11,7 +10,15 @@ namespace PnP.PowerShell.Commands.Base
     {
         protected override void BeginProcessing()
         {
+            BeginProcessing(false);
+        }
+
+        protected void BeginProcessing(bool skipConnectedValidation)
+        {
             base.BeginProcessing();
+
+            // Check if we should ensure that we are connected
+            if(skipConnectedValidation) return;
 
             // Ensure there is an active connection
             if (PnPConnection.Current == null)
@@ -21,9 +28,5 @@ namespace PnP.PowerShell.Commands.Base
         }
 
         public HttpClient HttpClient => PnP.Framework.Http.PnPHttpClient.Instance.GetHttpClient();
-
-
     }
-
-
 }

--- a/src/Commands/Base/PnPConnection.cs
+++ b/src/Commands/Base/PnPConnection.cs
@@ -611,6 +611,8 @@ namespace PnP.PowerShell.Commands.Base
 
         internal void CacheContext()
         {
+            if(Context == null) return;
+            
             var c = ContextCache.FirstOrDefault(cc => new Uri(cc.Url).AbsoluteUri == new Uri(Context.Url).AbsoluteUri);
             if (c == null)
             {

--- a/src/Commands/Base/PnPWebRetrievalsCmdlet.cs
+++ b/src/Commands/Base/PnPWebRetrievalsCmdlet.cs
@@ -4,8 +4,6 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 using System.Management.Automation;
 using Microsoft.SharePoint.Client;
 
-using PnP.PowerShell.Commands.Extensions;
-
 namespace PnP.PowerShell.Commands
 {
     /// <summary>
@@ -41,20 +39,20 @@ namespace PnP.PowerShell.Commands
             {
                 var subWeb = Web.GetWeb(ClientContext);
                 subWeb.EnsureProperty(w => w.Url);
-                PnPConnection.Current.CloneContext(subWeb.Url);
-                web = PnPConnection.Current.Context.Web;
+                Connection.CloneContext(subWeb.Url);
+                web = Connection.Context.Web;
             }
 #pragma warning restore CS0618
             else
             {
-                if (PnPConnection.Current.Context.Url != PnPConnection.Current.Url)
+                if (Connection.Context.Url != Connection.Url)
                 {
-                    PnPConnection.Current.RestoreCachedContext(PnPConnection.Current.Url);
+                    Connection.RestoreCachedContext(Connection.Url);
                 }
                 web = ClientContext.Web;
             }
 
-            PnPConnection.Current.Context.ExecuteQueryRetry();
+            Connection.Context.ExecuteQueryRetry();
 
             return web;
         }
@@ -62,16 +60,16 @@ namespace PnP.PowerShell.Commands
         protected override void EndProcessing()
         {
             base.EndProcessing();
-            if (PnPConnection.Current.Context.Url != PnPConnection.Current.Url)
+            if (Connection.Context.Url != Connection.Url)
             {
-                PnPConnection.Current.RestoreCachedContext(PnPConnection.Current.Url);
+                Connection.RestoreCachedContext(Connection.Url);
             }
         }
 
         protected override void BeginProcessing()
         {
             base.BeginProcessing();
-            PnPConnection.Current.CacheContext();
+            Connection.CacheContext();
         }
     }
 }


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #1857 

## What is in this Pull Request ? ##
Lots of cleanup and refactoring around using a specific connection retrieved by `Connect-PnPOnline -ReturnConnection` or `Get-PnPConnection`. Things were getting completely mixed up. It should now completely be separated from the current context which even would allow having multiple connections at once, each with a different authentication method or user. 