### PR TITLE
Added error output handling for Graph calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Bumped .NET Framework version to 4.6.2 as the 4.6.1 is not supported anymore. [#1856](https://github.com/pnp/powershell/pull/1856)
 - Changed `Add-PnPDataRowsToSiteTemplate`, it will now export a datetime field value as UTC string. [#1900](https://github.com/pnp/powershell/pull/1900)
 - The cmdlets `Remove-PnPFile`, `Remove-PnPFolder`, `Move-PnPListItemToRecycleBin`, `Remove-PnPList`, `Remove-PnPListItem` and `Remove-PnPPage` will now return the corresponding recycle bin item if they get deleted to the recycle bin. Before they would not return anything. [#1783](https://github.com/pnp/powershell/pull/1783)
+- Cmdlets backed by a Microsoft Graph call will now return detailed information when the Graph call fails
 
 ### Fixed
 

--- a/src/Commands/Graph/InvokeGraphMethod.cs
+++ b/src/Commands/Graph/InvokeGraphMethod.cs
@@ -1,22 +1,12 @@
-﻿
-using Newtonsoft.Json.Linq;
-using PnP.Framework.Utilities;
-using PnP.PowerShell.Commands.Attributes;
-using PnP.PowerShell.Commands.Base;
-using PnP.PowerShell.Commands.Base.PipeBinds;
+﻿using PnP.Framework.Utilities;
 using PnP.PowerShell.Commands.Enums;
-using PnP.PowerShell.Commands.Utilities;
 using PnP.PowerShell.Commands.Utilities.REST;
-using PnP.PowerShell.Commands.Utilities.JSON;
 using System;
-using System.Linq;
 using System.Management.Automation;
 using System.Text.Json;
-using System.Collections;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using PnP.PowerShell.Commands.Model.Graph;
 
 namespace PnP.PowerShell.Commands.Base
 {
@@ -160,17 +150,6 @@ namespace PnP.PowerShell.Commands.Base
             }
         }
 
-        private void ThrowIfNoSuccess(HttpResponseMessage response)
-        {
-            if (!response.IsSuccessStatusCode)
-            {
-                var errorContent = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-                var exception = JsonSerializer.Deserialize<GraphException>(errorContent, new JsonSerializerOptions() { IgnoreNullValues = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
-                exception.AccessToken = AccessToken;
-                throw exception;
-            }
-        }
-
         private object Deserialize(string result)
         {
             var element = JsonSerializer.Deserialize<JsonElement>(result);
@@ -250,7 +229,6 @@ namespace PnP.PowerShell.Commands.Base
         private void PostRequest()
         {
             var response = GraphHelper.PostAsync(HttpClient, Url, AccessToken, GetHttpContent(), AdditionalHeaders).GetAwaiter().GetResult();
-            ThrowIfNoSuccess(response);
             var result = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
             WriteGraphResult(result);
         }
@@ -258,7 +236,6 @@ namespace PnP.PowerShell.Commands.Base
         private void PutRequest()
         {
             var response = GraphHelper.PutAsync(HttpClient, Url, AccessToken, GetHttpContent(), AdditionalHeaders).GetAwaiter().GetResult();
-            ThrowIfNoSuccess(response);
             var result = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
             WriteGraphResult(result);
         }
@@ -266,7 +243,6 @@ namespace PnP.PowerShell.Commands.Base
         private void PatchRequest()
         {
             var response = GraphHelper.PatchAsync(HttpClient, AccessToken, GetHttpContent(), Url, AdditionalHeaders).GetAwaiter().GetResult();
-            ThrowIfNoSuccess(response);
             var result = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
             WriteGraphResult(result);
         }
@@ -274,7 +250,6 @@ namespace PnP.PowerShell.Commands.Base
         private void DeleteRequest()
         {
             var response = GraphHelper.DeleteAsync(HttpClient, Url, AccessToken, AdditionalHeaders).GetAwaiter().GetResult();
-            ThrowIfNoSuccess(response);
             var result = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
             WriteGraphResult(result);
         }

--- a/src/Commands/Teams/CopyTeamsTeam.cs
+++ b/src/Commands/Teams/CopyTeamsTeam.cs
@@ -70,21 +70,7 @@ namespace PnP.PowerShell.Commands.Teams
             * but currently ignored and can't be set by user */
             teamClone.MailNickName = DisplayName;
             teamClone.Visibility = (GroupVisibility)Enum.Parse(typeof(GroupVisibility), Visibility.ToString());
-            var response = TeamsUtility.CloneTeamAsync(AccessToken, HttpClient, groupId, teamClone).GetAwaiter().GetResult();
-            if (!response.IsSuccessStatusCode)
-            {
-                if (GraphHelper.TryGetGraphException(response, out GraphException ex))
-                {
-                    if (ex.Error != null)
-                    {
-                        throw new PSInvalidOperationException(ex.Error.Message);
-                    }
-                }
-                else
-                {
-                    WriteError(new ErrorRecord(new Exception($"Team clone failed"), "CLONEFAILED", ErrorCategory.InvalidResult, this));
-                }
-            }
+            TeamsUtility.CloneTeamAsync(AccessToken, HttpClient, groupId, teamClone).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Commands/Utilities/TeamsUtility.cs
+++ b/src/Commands/Utilities/TeamsUtility.cs
@@ -913,19 +913,8 @@ namespace PnP.PowerShell.Commands.Utilities
             var byteArrayContent = new ByteArrayContent(bytes);
             byteArrayContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/zip");
             var response = await GraphHelper.PostAsync(httpClient, "v1.0/appCatalogs/teamsApps", accessToken, byteArrayContent);
-            if (!response.IsSuccessStatusCode)
-            {
-                if (GraphHelper.TryGetGraphException(response, out GraphException exception))
-                {
-                    throw exception;
-                }
-            }
-            else
-            {
-                var content = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-                return JsonSerializer.Deserialize<TeamApp>(content, new JsonSerializerOptions() { IgnoreNullValues = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
-            }
-            return null;
+            var content = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            return JsonSerializer.Deserialize<TeamApp>(content, new JsonSerializerOptions() { IgnoreNullValues = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
         }
 
         public static async Task<HttpResponseMessage> UpdateAppAsync(HttpClient httpClient, string accessToken, byte[] bytes, string appId)


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample
- [X] Improvement

## Related Issues? ##
#1875 

## What is in this Pull Request ? ##
Rewrote the Graph Helper to detect for non successful responses and return the response body as an exception so details can be seen on why it went wrong. Cleaned up various code where this was being done on a cmdlet base instead of on a general level as is now implemented.