### PR TITLE
Changed WebBrowser script errors to false for Interactive and Device login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - The cmdlets `Remove-PnPFile`, `Remove-PnPFolder`, `Move-PnPListItemToRecycleBin`, `Remove-PnPList`, `Remove-PnPListItem` and `Remove-PnPPage` will now return the corresponding recycle bin item if they get deleted to the recycle bin. Before they would not return anything. [#1783](https://github.com/pnp/powershell/pull/1783)
 - Cmdlets backed by a Microsoft Graph call will now return detailed information when the Graph call fails [#1923](https://github.com/pnp/powershell/pull/1923)
 - Changed `Get-PnPPlannerBucket` to return the buckets in the correct (reversed) order as you see them through the web interface [#1922](https://github.com/pnp/powershell/pull/1922)
+- Changed `Connect-PnPOnline -Interactive` and `Connect-PnPOnline -DeviceLogin` to no longer suppress errors which should allow for certificate logins to be used
 
 ### Fixed
 

--- a/src/Commands/Base/PnPConnection.cs
+++ b/src/Commands/Base/PnPConnection.cs
@@ -244,7 +244,7 @@ namespace PnP.PowerShell.Commands.Base
                          {
                              ClipboardService.SetText(deviceCodeResult.UserCode);
                              messageWriter.WriteWarning($"\n\nCode {deviceCodeResult.UserCode} has been copied to your clipboard\n\n");
-                             BrowserHelper.GetWebBrowserPopup(deviceCodeResult.VerificationUrl, "Please log in", cancellationTokenSource: cancellationTokenSource, cancelOnClose: false);
+                             BrowserHelper.GetWebBrowserPopup(deviceCodeResult.VerificationUrl, "Please log in", cancellationTokenSource: cancellationTokenSource, cancelOnClose: false, scriptErrorsSuppressed: false);
                          }
                          else
                          {

--- a/src/Commands/Utilities/BrowserHelper.cs
+++ b/src/Commands/Utilities/BrowserHelper.cs
@@ -172,7 +172,7 @@ namespace PnP.PowerShell.Commands.Utilities
             Contains
         }
 
-        internal static bool GetWebBrowserPopup(string siteUrl, string title, (string url, UrlMatchType matchType)[] closeUrls = null, bool noThreadJoin = false, CancellationTokenSource cancellationTokenSource = null, bool cancelOnClose = true)
+        internal static bool GetWebBrowserPopup(string siteUrl, string title, (string url, UrlMatchType matchType)[] closeUrls = null, bool noThreadJoin = false, CancellationTokenSource cancellationTokenSource = null, bool cancelOnClose = true, bool scriptErrorsSuppressed = true)
         {
             bool success = false;
 #if Windows
@@ -186,12 +186,11 @@ namespace PnP.PowerShell.Commands.Utilities
                     cancellationTokenSource?.Token.Register(() =>
                     {
                         form.Invoke((System.Windows.Forms.MethodInvoker)(() => form.Close()));
-                        //form.Close();
                     });
 
                     var browser = new System.Windows.Forms.WebBrowser
                     {
-                        ScriptErrorsSuppressed = true,
+                        ScriptErrorsSuppressed = scriptErrorsSuppressed,
                         Dock = System.Windows.Forms.DockStyle.Fill
                     };
                     var assembly = typeof(BrowserHelper).Assembly;
@@ -323,7 +322,7 @@ namespace PnP.PowerShell.Commands.Utilities
             {
                 if (OperatingSystem.IsWindows() && usePopup)
                 {
-                    BrowserHelper.GetWebBrowserPopup(url, "Please login", new[] { ($"http://localhost:{port}/?code=", BrowserHelper.UrlMatchType.StartsWith) }, noThreadJoin: true, cancellationTokenSource: cancellationTokenSource, cancelOnClose: true);
+                    BrowserHelper.GetWebBrowserPopup(url, "Please login", new[] { ($"http://localhost:{port}/?code=", BrowserHelper.UrlMatchType.StartsWith) }, noThreadJoin: true, cancellationTokenSource: cancellationTokenSource, cancelOnClose: true, scriptErrorsSuppressed: false);
                 }
                 else
                 {


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #1706 

## What is in this Pull Request ? ##
Changed the error suppression in the WebBrowser container to become false to allow for logging in using a certificate. We need to evaluate if this does not cause any side effects for other scenarios.