### PR TITLE
Update AddTeamsUser.cs

### DIFF
--- a/src/Commands/Teams/AddTeamsUser.cs
+++ b/src/Commands/Teams/AddTeamsUser.cs
@@ -18,7 +18,7 @@ namespace PnP.PowerShell.Commands.Graph
         [Parameter(Mandatory = true, ParameterSetName = ParamSet_ByMultipleUsers)]
         public TeamsTeamPipeBind Team;
 
-        [Parameter(Mandatory = true, ParameterSetName = ParamSet_ByUser)]
+        [Parameter(Mandatory = false, ParameterSetName = ParamSet_ByUser)]
         public TeamsChannelPipeBind Channel;
 
         [Parameter(Mandatory = true, ParameterSetName = ParamSet_ByUser)]


### PR DESCRIPTION
Add-PnPTeamUser should treat Channel param as optional

Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #1952 

## What is in this Pull Request ? ##
Changed the setting for `Channel` parameter so that `Add-PnPTeamUser` considers it as optional

### Guidance ###
* You can delete this section when you are submitting the pull request.* 
* *Please update this PR information accordingly. We use this as part of our release notes in monthly communications.*
* **Please target your PR to Dev branch. If you do not target the Dev branch we will not accept this PR.**
