### PR TITLE
Fixing issue where connecting after disconnecting would throw an exception

### DIFF
--- a/src/Commands/Base/ConnectOnline.cs
+++ b/src/Commands/Base/ConnectOnline.cs
@@ -665,8 +665,8 @@ namespace PnP.PowerShell.Commands.Base
 
         private void ReuseAuthenticationManager()
         {
-            var contextSettings = PnPConnection.Current.Context.GetContextSettings();
-            PnPConnection.CachedAuthenticationManager = contextSettings.AuthenticationManager;
+            var contextSettings = PnPConnection.Current.Context?.GetContextSettings();
+            PnPConnection.CachedAuthenticationManager = contextSettings?.AuthenticationManager;
         }
         #endregion
     }


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
If you would run `Disconnect-PnPOnline` and then `Connect-PnPOnline` again, it would throw an exception. This regression was introduced by the changes done through #1919. This fixes it. It takes the stance that if you explicitly disconnect, all cached credentials will be wiped and connecting again will require credentials to be provided again. If this is not the desired situation, simply do not disconnect but directly connect to another sitecollection on the same tenant, and it will reuse the cached credentials.