### PR TITLE
SetList: receive list from pipeline

### DIFF
--- a/src/Commands/Lists/SetList.cs
+++ b/src/Commands/Lists/SetList.cs
@@ -10,7 +10,7 @@ namespace PnP.PowerShell.Commands.Lists
     [OutputType(typeof(List))]
     public class SetList : PnPWebCmdlet
     {
-        [Parameter(Mandatory = true)]
+        [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
         public ListPipeBind Identity;
 
         [Parameter(Mandatory = false)]


### PR DESCRIPTION
Adds the ability to do

    Get-PnPList | ? -not EnableVersioning | Set-PnPList -EnableVersioning:$true

instead of the more clumsy:

    Get-PnPList | ? -not EnableVersioning | % { Set-PnPList -Identity $_ -EnableVersioning:$true; }

Also

    Set-PnPList "MyList" -EnableVersioning:$true

Instead of

    Set-PnPList -Identity "MyList" -EnableVersioning:$true

A small improvement, but adds to the overall consistency. 