### PR TITLE
Allow connection param on all cmdlets

### DIFF
--- a/documentation/Disconnect-PnPOnline.md
+++ b/documentation/Disconnect-PnPOnline.md
@@ -10,19 +10,19 @@ title: Disconnect-PnPOnline
 # Disconnect-PnPOnline
 
 ## SYNOPSIS
-Disconnects the context.
+Disconnects the current connection and clears its token cache.
 
 ## SYNTAX
 
 ```powershell
-Disconnect-PnPOnline [-Connection <PnPConnection>] [<CommonParameters>]
+Disconnect-PnPOnline [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
->Note: in general it is not recommended nor needed to use this cmdlet.
+Disconnects the current connection and clears its token cache. It will require you to build up a new connection again using [Connect-PnPOnline](Connect-PnPOnline.html) in order to use any of the PnP PowerShell cmdlets. You will have to reauthenticate. If instead you simply want to connect to another site collection within the same tenant using the same credentials you used previously, do not use this cmdlet but instead use `Connect-PnPOnline -Url https://tenant.sharepoint.com/sites/othersite` instead without disconnecting. It will try to reuse the existing authentication method and cached credentials.
 
-Disconnects the current context and requires you to build up a new connection in order to use the Cmdlets again. Using Connect-PnPOnline to connect to a different site has the same effect and it's rarely needed to use Disconnect-PnPOnline. Notice that if you use Disconnect-PnPOnline the internal access token cache will be cleared too. This means that if you loop through many Connect-PnPOnline and subsequent Disconnect-PnPOnline statements a full request to the Azure AD is being made to acquire a token. This will cause throttling to occur and the script will stop. 
+Note that this cmdlet does not support passing in a specific connection to disconnect. If you wish to dispose a specific connection you have set up in a variable using `$variable = Connect-PnPOnline -ReturnConnection`, just dispose that variable using `$variable = $null` and it will be cleared from memory.
 
 ## EXAMPLES
 
@@ -31,26 +31,12 @@ Disconnects the current context and requires you to build up a new connection in
 Disconnect-PnPOnline
 ```
 
-This will clear out all active tokens
+This will clear out all active tokens from the current connection
 
 ## PARAMETERS
 
-### -Connection
-Connection to be used by cmdlet
-
-```yaml
-Type: PnPConnection
-Parameter Sets: (All)
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
+None
 
 ## RELATED LINKS
 
 [Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)
-
-

--- a/src/Commands/Admin/PublishCompanyApp.cs
+++ b/src/Commands/Admin/PublishCompanyApp.cs
@@ -184,7 +184,7 @@ namespace PnP.PowerShell.Commands.Admin
             if (!NoUpload)
             {
                 var bytes = System.IO.File.ReadAllBytes(System.IO.Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, $"{AppName}.zip"));
-                TeamsUtility.AddAppAsync(HttpClient, GraphAccessToken, bytes).GetAwaiter().GetResult();
+                TeamsUtility.AddAppAsync(Connection, GraphAccessToken, bytes).GetAwaiter().GetResult();
                 WriteObject($"Teams app uploaded to teams app Store.");
             }
         }

--- a/src/Commands/Apps/GetAzureADAppSitePermission.cs
+++ b/src/Commands/Apps/GetAzureADAppSitePermission.cs
@@ -35,7 +35,7 @@ namespace PnP.PowerShell.Commands.Apps
             Guid siteId = Guid.Empty;
             if (ParameterSpecified(nameof(Site)))
             {
-                siteId = Site.GetSiteIdThroughGraph(HttpClient, AccessToken);
+                siteId = Site.GetSiteIdThroughGraph(Connection, AccessToken);
             }
             else
             {
@@ -47,7 +47,7 @@ namespace PnP.PowerShell.Commands.Apps
                 if (!ParameterSpecified(nameof(PermissionId)))
                 {
                     // all permissions
-                    var results = GraphHelper.GetResultCollectionAsync<AzureADAppPermissionInternal>(HttpClient, $"https://{PnPConnection.Current.GraphEndPoint}/v1.0/sites/{siteId}/permissions", AccessToken).GetAwaiter().GetResult();
+                    var results = GraphHelper.GetResultCollectionAsync<AzureADAppPermissionInternal>(Connection, $"https://{PnPConnection.Current.GraphEndPoint}/v1.0/sites/{siteId}/permissions", AccessToken).GetAwaiter().GetResult();
                     if (results.Any())
                     {
                         var convertedResults = results.Select(i => i.Convert());
@@ -64,7 +64,7 @@ namespace PnP.PowerShell.Commands.Apps
                 }
                 else
                 {
-                    var results = GraphHelper.GetAsync<AzureADAppPermissionInternal>(HttpClient, $"https://{PnPConnection.Current.GraphEndPoint}/v1.0/sites/{siteId}/permissions/{PermissionId}", AccessToken).GetAwaiter().GetResult();
+                    var results = GraphHelper.GetAsync<AzureADAppPermissionInternal>(Connection, $"https://{PnPConnection.Current.GraphEndPoint}/v1.0/sites/{siteId}/permissions/{PermissionId}", AccessToken).GetAwaiter().GetResult();
                     WriteObject(results.Convert());
                 }
             }

--- a/src/Commands/Apps/GrantAzureADAppSitePermission.cs
+++ b/src/Commands/Apps/GrantAzureADAppSitePermission.cs
@@ -34,7 +34,7 @@ namespace PnP.PowerShell.Commands.Apps
             Guid siteId = Guid.Empty;
             if (ParameterSpecified(nameof(Site)))
             {
-                siteId = Site.GetSiteIdThroughGraph(HttpClient, AccessToken);
+                siteId = Site.GetSiteIdThroughGraph(Connection, AccessToken);
             }
             else
             {
@@ -56,7 +56,7 @@ namespace PnP.PowerShell.Commands.Apps
                         }
                 };
 
-                var results = PnP.PowerShell.Commands.Utilities.REST.RestHelper.PostAsync<AzureADAppPermissionInternal>(HttpClient, $"https://{PnPConnection.Current.GraphEndPoint}/v1.0/sites/{siteId}/permissions", AccessToken, payload).GetAwaiter().GetResult();
+                var results = PnP.PowerShell.Commands.Utilities.REST.RestHelper.PostAsync<AzureADAppPermissionInternal>(Connection.HttpClient, $"https://{PnPConnection.Current.GraphEndPoint}/v1.0/sites/{siteId}/permissions", AccessToken, payload).GetAwaiter().GetResult();
                 WriteObject(results.Convert());
             }
         }

--- a/src/Commands/Apps/GrantTenantServicePrincipalPermission.cs
+++ b/src/Commands/Apps/GrantTenantServicePrincipalPermission.cs
@@ -1,11 +1,7 @@
 ﻿using Microsoft.Online.SharePoint.TenantAdministration.Internal;
 using Microsoft.SharePoint.Client;
-using PnP.Framework.ALM;
-using PnP.Framework.Enums;
 using PnP.PowerShell.Commands.Attributes;
 using PnP.PowerShell.Commands.Base;
-using PnP.PowerShell.Commands.Enums;
-using PnP.PowerShell.Commands.Model;
 using PnP.PowerShell.Commands.Utilities;
 using PnP.PowerShell.Commands.Utilities.REST;
 using System.Linq;
@@ -30,7 +26,7 @@ namespace PnP.PowerShell.Commands.Apps
             {
                 var spoWebAppServicePrincipal = new SPOWebAppServicePrincipal(tenantContext);
                 var appId = spoWebAppServicePrincipal.EnsureProperty(a => a.AppId);
-                var results = GraphHelper.GetAsync<RestResultCollection<ServicePrincipal>>(this.HttpClient, $"/v1.0/servicePrincipals?$filter=appId eq '{appId}'&$select=id", AccessToken).GetAwaiter().GetResult();
+                var results = GraphHelper.GetAsync<RestResultCollection<ServicePrincipal>>(Connection, $"/v1.0/servicePrincipals?$filter=appId eq '{appId}'&$select=id", AccessToken).GetAwaiter().GetResult();
                 if (results.Items.Any())
                 {
                     var servicePrincipal = results.Items.First();

--- a/src/Commands/Apps/RevokeAzureADAppSitePermission.cs
+++ b/src/Commands/Apps/RevokeAzureADAppSitePermission.cs
@@ -26,7 +26,7 @@ namespace PnP.PowerShell.Commands.Apps
             Guid siteId = Guid.Empty;
             if (ParameterSpecified(nameof(Site)))
             {
-                siteId = Site.GetSiteIdThroughGraph(HttpClient, AccessToken);
+                siteId = Site.GetSiteIdThroughGraph(Connection, AccessToken);
             }
             else
             {
@@ -37,7 +37,7 @@ namespace PnP.PowerShell.Commands.Apps
             {
                 if (Force || ShouldContinue("Are you sure you want to revoke the permissions?", string.Empty))
                 {
-                    var results = PnP.PowerShell.Commands.Utilities.REST.RestHelper.DeleteAsync(HttpClient, $"https://{PnPConnection.Current.GraphEndPoint}/v1.0/sites/{siteId}/permissions/{PermissionId}", AccessToken).GetAwaiter().GetResult();
+                    var results = PnP.PowerShell.Commands.Utilities.REST.RestHelper.DeleteAsync(Connection.HttpClient, $"https://{PnPConnection.Current.GraphEndPoint}/v1.0/sites/{siteId}/permissions/{PermissionId}", AccessToken).GetAwaiter().GetResult();
                 }
             }
         }

--- a/src/Commands/Apps/RevokeTenantServicePrincipalPermission.cs
+++ b/src/Commands/Apps/RevokeTenantServicePrincipalPermission.cs
@@ -31,7 +31,7 @@ namespace PnP.PowerShell.Commands.Apps
             {
                 var spoWebAppServicePrincipal = new SPOWebAppServicePrincipal(tenantContext);
                 var appId = spoWebAppServicePrincipal.EnsureProperty(a => a.AppId);
-                var results = GraphHelper.GetAsync<RestResultCollection<ServicePrincipal>>(this.HttpClient, $"/v1.0/servicePrincipals?$filter=appId eq '{appId}'&$select=id", AccessToken).GetAwaiter().GetResult();
+                var results = GraphHelper.GetAsync<RestResultCollection<ServicePrincipal>>(Connection, $"/v1.0/servicePrincipals?$filter=appId eq '{appId}'&$select=id", AccessToken).GetAwaiter().GetResult();
                 if (results.Items.Any())
                 {
                     if (Force || ShouldContinue($"Revoke permission {Scope}?", "Continue"))
@@ -53,6 +53,4 @@ namespace PnP.PowerShell.Commands.Apps
             public string Id { get; set; }
         }
     }
-
-
 }

--- a/src/Commands/Apps/SetAzureADAppSitePermission.cs
+++ b/src/Commands/Apps/SetAzureADAppSitePermission.cs
@@ -29,7 +29,7 @@ namespace PnP.PowerShell.Commands.Apps
             Guid siteId = Guid.Empty;
             if (ParameterSpecified(nameof(Site)))
             {
-                siteId = Site.GetSiteIdThroughGraph(HttpClient, AccessToken);
+                siteId = Site.GetSiteIdThroughGraph(Connection, AccessToken);
             }
             else
             {
@@ -44,7 +44,7 @@ namespace PnP.PowerShell.Commands.Apps
                     roles = Permissions.Select(p => p.ToLower()).ToArray()
                 };
 
-                var results = PnP.PowerShell.Commands.Utilities.REST.RestHelper.PatchAsync<AzureADAppPermissionInternal>(HttpClient, $"https://{PnPConnection.Current.GraphEndPoint}/v1.0/sites/{siteId}/permissions/{PermissionId}", AccessToken, payload).GetAwaiter().GetResult();
+                var results = PnP.PowerShell.Commands.Utilities.REST.RestHelper.PatchAsync<AzureADAppPermissionInternal>(Connection.HttpClient, $"https://{PnPConnection.Current.GraphEndPoint}/v1.0/sites/{siteId}/permissions/{PermissionId}", AccessToken, payload).GetAwaiter().GetResult();
                 WriteObject(results.Convert());
             }
         }

--- a/src/Commands/AzureAD/GetAzureADApp.cs
+++ b/src/Commands/AzureAD/GetAzureADApp.cs
@@ -20,12 +20,12 @@ namespace PnP.PowerShell.Commands.AzureAD
         {
             if (ParameterSpecified(nameof(Identity)))
             {
-                WriteObject(Identity.GetApp(this, HttpClient, AccessToken));
+                WriteObject(Identity.GetApp(this, Connection, AccessToken));
             }
             else
             {
                 List<AzureADApp> apps = new List<AzureADApp>();
-                var result = GraphHelper.GetResultCollectionAsync<AzureADApp>(HttpClient, "/v1.0/applications", AccessToken).GetAwaiter().GetResult();
+                var result = GraphHelper.GetResultCollectionAsync<AzureADApp>(Connection, "/v1.0/applications", AccessToken).GetAwaiter().GetResult();
                 WriteObject(result, true);
             }
         }

--- a/src/Commands/AzureAD/GetAzureADAppPermission.cs
+++ b/src/Commands/AzureAD/GetAzureADAppPermission.cs
@@ -20,12 +20,12 @@ namespace PnP.PowerShell.Commands.AzureAD
         {
             if (ParameterSpecified(nameof(Identity)))
             {
-                WriteObject(ConvertToPSObject(Identity.GetApp(this, HttpClient, AccessToken)));
+                WriteObject(ConvertToPSObject(Identity.GetApp(this, Connection, AccessToken)));
             }
             else
             {
                 List<PSObject> apps = new List<PSObject>();
-                var result = GraphHelper.GetResultCollectionAsync<AzureADApp>(HttpClient, "/v1.0/applications", AccessToken).GetAwaiter().GetResult();
+                var result = GraphHelper.GetResultCollectionAsync<AzureADApp>(Connection, "/v1.0/applications", AccessToken).GetAwaiter().GetResult();
                 if (result != null && result.Any())
                 {
                     apps.AddRange(result.Select(p => ConvertToPSObject(p)));

--- a/src/Commands/AzureAD/GetAzureADUser.cs
+++ b/src/Commands/AzureAD/GetAzureADUser.cs
@@ -54,9 +54,9 @@ namespace PnP.PowerShell.Commands.Principals
 
         protected override void ExecuteCmdlet()
         {
-            if (PnPConnection.Current.ClientId == PnPConnection.PnPManagementShellClientId)
+            if (Connection.ClientId == PnPConnection.PnPManagementShellClientId)
             {
-                PnPConnection.Current.Scopes = new[] { "Directory.ReadWrite.All" };
+                Connection.Scopes = new[] { "Directory.ReadWrite.All" };
             }
             
             if(ParameterSpecified(nameof(IgnoreDefaultProperties)) && !ParameterSpecified(nameof(Select)))

--- a/src/Commands/AzureAD/RegisterAzureADApp.cs
+++ b/src/Commands/AzureAD/RegisterAzureADApp.cs
@@ -551,7 +551,7 @@ namespace PnP.PowerShell.Commands.AzureAD
         private bool AppExists(string appName, HttpClient httpClient, string token)
         {
             Host.UI.Write(ConsoleColor.Yellow, Host.UI.RawUI.BackgroundColor, $"Checking if application '{appName}' does not exist yet...");
-            var azureApps = GraphHelper.GetAsync<RestResultCollection<AzureADApp>>(httpClient, $@"https://{PnP.Framework.AuthenticationManager.GetGraphEndPoint(AzureEnvironment)}/v1.0/applications?$filter=displayName eq '{appName}'&$select=Id", token).GetAwaiter().GetResult();
+            var azureApps = RestHelper.GetAsync<RestResultCollection<AzureADApp>>(httpClient, $@"https://{PnP.Framework.AuthenticationManager.GetGraphEndPoint(AzureEnvironment)}/v1.0/applications?$filter=displayName eq '{appName}'&$select=Id", token).GetAwaiter().GetResult();
             if (azureApps != null && azureApps.Items.Any())
             {
                 Host.UI.WriteLine();
@@ -597,7 +597,7 @@ namespace PnP.PowerShell.Commands.AzureAD
             var requestContent = new StringContent(JsonSerializer.Serialize(payload));
             requestContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
 
-            var azureApp = GraphHelper.PostAsync<AzureADApp>(httpClient, $"https://{AuthenticationManager.GetGraphEndPoint(AzureEnvironment)}/v1.0/applications", requestContent, token).GetAwaiter().GetResult();
+            var azureApp = RestHelper.PostAsync<AzureADApp>(httpClient, $"https://{AuthenticationManager.GetGraphEndPoint(AzureEnvironment)}/v1.0/applications", token, requestContent).GetAwaiter().GetResult();
             if (azureApp != null)
             {
                 Host.UI.WriteLine(ConsoleColor.Yellow, Host.UI.RawUI.BackgroundColor, $"App {azureApp.DisplayName} with id {azureApp.AppId} created.");

--- a/src/Commands/AzureAD/RemoveAzureADApp.cs
+++ b/src/Commands/AzureAD/RemoveAzureADApp.cs
@@ -1,11 +1,7 @@
-using System.Collections.Generic;
-using System.Linq;
 using System.Management.Automation;
 using PnP.PowerShell.Commands.Attributes;
 using PnP.PowerShell.Commands.Base;
 using PnP.PowerShell.Commands.Base.PipeBinds;
-using PnP.PowerShell.Commands.Model;
-using PnP.PowerShell.Commands.Utilities.REST;
 
 namespace PnP.PowerShell.Commands.AzureAD
 {
@@ -21,11 +17,11 @@ namespace PnP.PowerShell.Commands.AzureAD
 
         protected override void ExecuteCmdlet()
         {
-            var app = Identity.GetApp(this, HttpClient, AccessToken);
+            var app = Identity.GetApp(this, Connection, AccessToken);
 
             if (Force || ShouldContinue($"Remove app '{app.DisplayName}' with id '{app.Id}'", string.Empty))
             {
-                Utilities.REST.GraphHelper.DeleteAsync(HttpClient, $"/v1.0/applications/{app.Id}", AccessToken).GetAwaiter().GetResult();
+                Utilities.REST.GraphHelper.DeleteAsync(Connection, $"/v1.0/applications/{app.Id}", AccessToken).GetAwaiter().GetResult();
             }
         }
     }

--- a/src/Commands/AzureAD/SetAzureADGroup.cs
+++ b/src/Commands/AzureAD/SetAzureADGroup.cs
@@ -68,7 +68,7 @@ namespace PnP.PowerShell.Commands.Graph
                     if (ParameterSpecified(nameof(HideFromAddressLists)) || ParameterSpecified(nameof(HideFromOutlookClients)))
                     {
                         // For this scenario a separate call needs to be made
-                        Utilities.Microsoft365GroupsUtility.SetVisibilityAsync(HttpClient, AccessToken, new Guid(group.Id), HideFromAddressLists, HideFromOutlookClients).GetAwaiter().GetResult();
+                        Utilities.Microsoft365GroupsUtility.SetVisibilityAsync(Connection, AccessToken, new Guid(group.Id), HideFromAddressLists, HideFromOutlookClients).GetAwaiter().GetResult();
                     }
                 }
                 catch(Exception e)

--- a/src/Commands/Base/DisconnectOnline.cs
+++ b/src/Commands/Base/DisconnectOnline.cs
@@ -28,9 +28,18 @@ namespace PnP.PowerShell.Commands.Base
                 connection.Certificate = null;
             }
 
-            var success = DisconnectProvidedService(ref connection);
-            
-            if (!success)
+            if(Connection != null)
+            {
+                Connection = null;
+                GetType().GetProperty(nameof(Connection)).SetValue(this, null);
+            }
+            else if(PnPConnection.Current != null)
+            {
+                Environment.SetEnvironmentVariable("PNPPSHOST", string.Empty);
+                Environment.SetEnvironmentVariable("PNPPSSITE", string.Empty);
+                PnPConnection.Current = null;
+            }
+            else
             {
                 throw new InvalidOperationException(Properties.Resources.NoConnectionToDisconnect);
             }
@@ -45,19 +54,6 @@ namespace PnP.PowerShell.Commands.Base
                     SessionState.Drive.Remove(drive.Name, true, "Global");
                 }
             }
-        }
-
-        internal static bool DisconnectProvidedService(ref PnPConnection connection)
-        {
-            Environment.SetEnvironmentVariable("PNPPSHOST", string.Empty);
-            Environment.SetEnvironmentVariable("PNPPSSITE", string.Empty);
-            if (connection == null)
-            {
-                return false;
-            }
-            connection.Context = null;
-            connection = null;
-            return true;
         }
     }
 }

--- a/src/Commands/Base/DisconnectOnline.cs
+++ b/src/Commands/Base/DisconnectOnline.cs
@@ -11,38 +11,26 @@ namespace PnP.PowerShell.Commands.Base
     [OutputType(typeof(void))]
     public class DisconnectOnline : PSCmdlet
     {
-        [Parameter(Mandatory = false)]
-        public PnPConnection Connection = null;
-
         protected override void ProcessRecord()
         {
-            // If no specific connection has been passed in, take the connection from the current context
-            var connection = Connection ?? PnPConnection.Current;
-
-            if (connection?.Certificate != null)
-            {
-                if (connection != null && connection.DeleteCertificateFromCacheOnDisconnect)
-                {
-                    PnPConnection.CleanupCryptoMachineKey(connection.Certificate);
-                }
-                connection.Certificate = null;
-            }
-
-            if(Connection != null)
-            {
-                Connection = null;
-                GetType().GetProperty(nameof(Connection)).SetValue(this, null);
-            }
-            else if(PnPConnection.Current != null)
-            {
-                Environment.SetEnvironmentVariable("PNPPSHOST", string.Empty);
-                Environment.SetEnvironmentVariable("PNPPSSITE", string.Empty);
-                PnPConnection.Current = null;
-            }
-            else
+            if(PnPConnection.Current == null)
             {
                 throw new InvalidOperationException(Properties.Resources.NoConnectionToDisconnect);
             }
+
+            Environment.SetEnvironmentVariable("PNPPSHOST", string.Empty);
+            Environment.SetEnvironmentVariable("PNPPSSITE", string.Empty);            
+
+            if (PnPConnection.Current.Certificate != null)
+            {
+                if (PnPConnection.Current.DeleteCertificateFromCacheOnDisconnect)
+                {
+                    PnPConnection.CleanupCryptoMachineKey(PnPConnection.Current.Certificate);
+                }
+                PnPConnection.Current.Certificate = null;
+            }
+
+            PnPConnection.Current = null;
 
             var provider = SessionState.Provider.GetAll().FirstOrDefault(p => p.Name.Equals(SPOProvider.PSProviderName, StringComparison.InvariantCultureIgnoreCase));
             if (provider != null)

--- a/src/Commands/Base/GetAccessToken.cs
+++ b/src/Commands/Base/GetAccessToken.cs
@@ -46,16 +46,16 @@ namespace PnP.PowerShell.Commands.Base
                         accessTokenValue = AccessToken;
                         break;
                     case ResourceTypeName.SharePoint:
-                        accessTokenValue = TokenHandler.GetAccessToken(null, PnPConnection.Current?.Context?.Url?.TrimEnd('/') + "/.default");
+                        accessTokenValue = TokenHandler.GetAccessToken(null, PnPConnection.Current?.Context?.Url?.TrimEnd('/') + "/.default", Connection);
                         break;
                     case ResourceTypeName.ARM:
-                        accessTokenValue = TokenHandler.GetAccessToken(null, "https://management.azure.com/.default");
+                        accessTokenValue = TokenHandler.GetAccessToken(null, "https://management.azure.com/.default", Connection);
                         break;
                 }
             }
             else if (ParameterSetName == ResourceUrlParam)
             {
-                accessTokenValue = TokenHandler.GetAccessToken(null, ResourceUrl);
+                accessTokenValue = TokenHandler.GetAccessToken(null, ResourceUrl, Connection);
             }
 
             if (Decoded.IsPresent)

--- a/src/Commands/Base/PipeBinds/AzureADAppPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/AzureADAppPipeBind.cs
@@ -29,24 +29,24 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             }
         }
 
-        public AzureADApp GetApp(BasePSCmdlet cmdlet, HttpClient httpClient, string accessToken)
+        public AzureADApp GetApp(BasePSCmdlet cmdlet, PnPConnection connection, string accessToken)
         {
             if (_id != Guid.Empty)
             {
-                var results = Utilities.REST.GraphHelper.GetAsync<RestResultCollection<AzureADApp>>(httpClient, $"/v1.0/applications?$filter=appId eq '{_id}'", accessToken).GetAwaiter().GetResult();
+                var results = Utilities.REST.GraphHelper.GetAsync<RestResultCollection<AzureADApp>>(connection, $"/v1.0/applications?$filter=appId eq '{_id}'", accessToken).GetAwaiter().GetResult();
                 if (results != null && results.Items.Any())
                 {
                     return results.Items.First();
                 }
                 else
                 {
-                    return Utilities.REST.GraphHelper.GetAsync<AzureADApp>(httpClient, $"/v1.0/applications/{_id}", accessToken).GetAwaiter().GetResult();
+                    return Utilities.REST.GraphHelper.GetAsync<AzureADApp>(connection, $"/v1.0/applications/{_id}", accessToken).GetAwaiter().GetResult();
                 }
 
             }
             if (!string.IsNullOrEmpty(_name))
             {
-                var results = Utilities.REST.GraphHelper.GetAsync<RestResultCollection<AzureADApp>>(httpClient, $"/v1.0/applications?$filter=displayName eq '{_name}'", accessToken).GetAwaiter().GetResult();
+                var results = Utilities.REST.GraphHelper.GetAsync<RestResultCollection<AzureADApp>>(connection, $"/v1.0/applications?$filter=displayName eq '{_name}'", accessToken).GetAwaiter().GetResult();
                 if (results != null && results.Items.Any())
                 {
                     return results.Items.First();

--- a/src/Commands/Base/PipeBinds/Microsoft365GroupPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/Microsoft365GroupPipeBind.cs
@@ -48,25 +48,25 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
 
         public Guid GroupId => _groupId;
 
-        public Microsoft365Group GetGroup(HttpClient httpClient, string accessToken, bool includeSite, bool includeOwners)
+        public Microsoft365Group GetGroup(PnPConnection connection, string accessToken, bool includeSite, bool includeOwners)
         {
             Microsoft365Group group = null;
             if (Group != null)
             {
-                group = Microsoft365GroupsUtility.GetGroupAsync(httpClient, _group.Id.Value, accessToken, includeSite, includeOwners).GetAwaiter().GetResult();
+                group = Microsoft365GroupsUtility.GetGroupAsync(connection, _group.Id.Value, accessToken, includeSite, includeOwners).GetAwaiter().GetResult();
             }
             else if (_groupId != Guid.Empty)
             {
-                group = Microsoft365GroupsUtility.GetGroupAsync(httpClient, _groupId, accessToken, includeSite, includeOwners).GetAwaiter().GetResult();
+                group = Microsoft365GroupsUtility.GetGroupAsync(connection, _groupId, accessToken, includeSite, includeOwners).GetAwaiter().GetResult();
             }
             else if (!string.IsNullOrEmpty(DisplayName))
             {
-                group = Microsoft365GroupsUtility.GetGroupAsync(httpClient, DisplayName, accessToken, includeSite, includeOwners).GetAwaiter().GetResult();
+                group = Microsoft365GroupsUtility.GetGroupAsync(connection, DisplayName, accessToken, includeSite, includeOwners).GetAwaiter().GetResult();
             }
             return group;
         }
 
-        public Guid GetGroupId(HttpClient httpClient, string accessToken)
+        public Guid GetGroupId(PnPConnection connection, string accessToken)
         {
             if (Group != null)
             {
@@ -78,7 +78,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             }
             else if (!string.IsNullOrEmpty(DisplayName))
             {
-                var group = Microsoft365GroupsUtility.GetGroupAsync(httpClient, DisplayName, accessToken, false, false).GetAwaiter().GetResult();
+                var group = Microsoft365GroupsUtility.GetGroupAsync(connection, DisplayName, accessToken, false, false).GetAwaiter().GetResult();
                 if (group != null)
                 {
                     return group.Id.Value;
@@ -88,24 +88,24 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             //return Guid.Empty;
         }
 
-        public Microsoft365Group GetDeletedGroup(HttpClient httpClient, string accessToken)
+        public Microsoft365Group GetDeletedGroup(PnPConnection connection, string accessToken)
         {
             if (_group != null)
             {
-                return Microsoft365GroupsUtility.GetDeletedGroupAsync(httpClient, _group.Id.Value, accessToken).GetAwaiter().GetResult();
+                return Microsoft365GroupsUtility.GetDeletedGroupAsync(connection, _group.Id.Value, accessToken).GetAwaiter().GetResult();
             }
             else if (_groupId != Guid.Empty)
             {
-                return Microsoft365GroupsUtility.GetDeletedGroupAsync(httpClient, _groupId, accessToken).GetAwaiter().GetResult();
+                return Microsoft365GroupsUtility.GetDeletedGroupAsync(connection, _groupId, accessToken).GetAwaiter().GetResult();
             }
             else if (!string.IsNullOrEmpty(_displayName))
             {
-                return Microsoft365GroupsUtility.GetDeletedGroupAsync(httpClient, _displayName, accessToken).GetAwaiter().GetResult();
+                return Microsoft365GroupsUtility.GetDeletedGroupAsync(connection, _displayName, accessToken).GetAwaiter().GetResult();
             }
             return null;
         }
 
-        public Guid GetDeletedGroupId(HttpClient httpClient, string accessToken)
+        public Guid GetDeletedGroupId(PnPConnection connection, string accessToken)
         {
             if (_group != null)
             {
@@ -117,7 +117,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             }
             else if (!string.IsNullOrEmpty(_displayName))
             {
-                var group = Microsoft365GroupsUtility.GetDeletedGroupAsync(httpClient, _displayName, accessToken).GetAwaiter().GetResult();
+                var group = Microsoft365GroupsUtility.GetDeletedGroupAsync(connection, _displayName, accessToken).GetAwaiter().GetResult();
                 if (group != null)
                 {
                     return group.Id.Value;

--- a/src/Commands/Base/PipeBinds/PlannerBucketPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/PlannerBucketPipeBind.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Management.Automation;
-using System.Net.Http;
 using PnP.PowerShell.Commands.Model.Graph;
 using PnP.PowerShell.Commands.Model.Planner;
 using PnP.PowerShell.Commands.Utilities;
@@ -35,7 +34,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             }
         }
 
-        public PlannerBucket GetBucket(HttpClient httpClient, string accessToken, string planId)
+        public PlannerBucket GetBucket(PnPConnection connection, string accessToken, string planId)
         {
             // first try to get the bucket by id
             if (_bucket != null)
@@ -46,7 +45,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             {
                 try
                 {
-                    var buckets = PlannerUtility.GetBucketsAsync(httpClient, accessToken, planId).GetAwaiter().GetResult();
+                    var buckets = PlannerUtility.GetBucketsAsync(connection, accessToken, planId).GetAwaiter().GetResult();
                     if (buckets != null)
                     {
                         PlannerBucket bucket = null;

--- a/src/Commands/Base/PipeBinds/PlannerGroupPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/PlannerGroupPipeBind.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Management.Automation;
-using System.Net.Http;
 using PnP.PowerShell.Commands.Utilities.REST;
 
 namespace PnP.PowerShell.Commands.Base.PipeBinds
@@ -39,7 +38,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             _id = group.Id;
         }
 
-        public string GetGroupId(HttpClient httpClient, string accessToken)
+        public string GetGroupId(PnPConnection connection, string accessToken)
         {
             if (!string.IsNullOrEmpty(_id))
             {
@@ -47,7 +46,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             }
             else
             {
-                var collection = GraphHelper.GetAsync<RestResultCollection<Model.Graph.Group>>(httpClient, $"v1.0/groups?$filter=mailNickname eq '{_stringValue}'&$select=Id", accessToken).GetAwaiter().GetResult();
+                var collection = GraphHelper.GetAsync<RestResultCollection<Model.Graph.Group>>(connection, $"v1.0/groups?$filter=mailNickname eq '{_stringValue}'&$select=Id", accessToken).GetAwaiter().GetResult();
                 if (collection != null && collection.Items.Any())
                 {
                     return collection.Items.First().Id;
@@ -55,7 +54,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
                 else
                 {
                     // find the team by displayName
-                    var byDisplayNamecollection = GraphHelper.GetAsync<RestResultCollection<Model.Graph.Group>>(httpClient, $"v1.0/groups?$filter=displayName eq '{_stringValue}'&$select=Id", accessToken).GetAwaiter().GetResult();
+                    var byDisplayNamecollection = GraphHelper.GetAsync<RestResultCollection<Model.Graph.Group>>(connection, $"v1.0/groups?$filter=displayName eq '{_stringValue}'&$select=Id", accessToken).GetAwaiter().GetResult();
                     if (byDisplayNamecollection != null && byDisplayNamecollection.Items.Any())
                     {
                         if (byDisplayNamecollection.Items.Count() == 1)

--- a/src/Commands/Base/PipeBinds/PlannerPlanPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/PlannerPlanPipeBind.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Linq;
 using System.Management.Automation;
-using System.Net.Http;
 using System.Threading.Tasks;
 using PnP.PowerShell.Commands.Model.Graph;
 using PnP.PowerShell.Commands.Model.Planner;
@@ -15,7 +13,6 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
         private readonly PlannerPlan _plan;
         public PlannerPlanPipeBind()
         {
-
         }
 
         public PlannerPlanPipeBind(string input)
@@ -28,7 +25,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             _plan = plan;
         }
 
-        public async Task<PlannerPlan> GetPlanAsync(HttpClient httpClient, string accessToken, string groupId, bool resolveIdentities)
+        public async Task<PlannerPlan> GetPlanAsync(PnPConnection connection, string accessToken, string groupId, bool resolveIdentities)
         {
             if (_plan != null)
             {
@@ -37,11 +34,11 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             // first try to get the plan by id
             try
             {
-                return await PlannerUtility.GetPlanAsync(httpClient, accessToken, _id, resolveIdentities);
+                return await PlannerUtility.GetPlanAsync(connection, accessToken, _id, resolveIdentities);
             }
             catch (GraphException)
             {
-                var plans = await PlannerUtility.GetPlansAsync(httpClient, accessToken, groupId, resolveIdentities);
+                var plans = await PlannerUtility.GetPlansAsync(connection, accessToken, groupId, resolveIdentities);
                 if (plans != null && plans.Any())
                 {
                     var collection = plans.Where(p => p.Title.Equals(_id));
@@ -58,7 +55,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             return null;
         }
 
-        public async Task<string> GetIdAsync(HttpClient httpClient, string accessToken, string groupId)
+        public async Task<string> GetIdAsync(PnPConnection connection, string accessToken, string groupId)
         {
             if (_plan != null)
             {
@@ -67,12 +64,12 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             // first try to get the plan by id
             try
             {
-                var plan = await PlannerUtility.GetPlanAsync(httpClient, accessToken, _id, false);
+                var plan = await PlannerUtility.GetPlanAsync(connection, accessToken, _id, false);
                 return plan.Id;
             }
             catch (GraphException)
             {
-                var plans = await PlannerUtility.GetPlansAsync(httpClient, accessToken, groupId, false);
+                var plans = await PlannerUtility.GetPlansAsync(connection, accessToken, groupId, false);
                 if (plans != null && plans.Any())
                 {
                     var collection = plans.Where(p => p.Title.Equals(_id));

--- a/src/Commands/Base/PipeBinds/PlannerRosterPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/PlannerRosterPipeBind.cs
@@ -1,4 +1,3 @@
-using System.Net.Http;
 using System.Threading.Tasks;
 using PnP.PowerShell.Commands.Model.Planner;
 using PnP.PowerShell.Commands.Utilities;
@@ -11,7 +10,6 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
         private readonly PlannerRoster _roster;
         public PlannerRosterPipeBind()
         {
-
         }
 
         public PlannerRosterPipeBind(string input)
@@ -24,13 +22,13 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             _roster = roster;
         }
 
-        public async Task<PlannerRoster> GetPlannerRosterAsync(HttpClient httpClient, string accessToken)
+        public async Task<PlannerRoster> GetPlannerRosterAsync(PnPConnection connection, string accessToken)
         {
             if (_roster != null)
             {
                 return _roster;
             }
-            return await PlannerUtility.GetRosterAsync(httpClient, accessToken, _id);
+            return await PlannerUtility.GetRosterAsync(connection, accessToken, _id);
         }
     }
 }

--- a/src/Commands/Base/PipeBinds/SitePipeBind.cs
+++ b/src/Commands/Base/PipeBinds/SitePipeBind.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.SharePoint.Client;
 using System;
-using System.Net.Http;
 using System.Text.Json;
 
 namespace PnP.PowerShell.Commands.Base.PipeBinds
@@ -57,7 +56,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
 
         public Guid Id => _id;
 
-        public Guid GetSiteIdThroughGraph(HttpClient httpClient, string accesstoken)
+        public Guid GetSiteIdThroughGraph(PnPConnection connection, string accesstoken)
         {
             if (_site != null)
             {
@@ -71,7 +70,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             {
                 var uri = new Uri(_url);
 
-                var result = Utilities.REST.RestHelper.GetAsync(httpClient, $"https://{PnPConnection.Current.GraphEndPoint}/v1.0/sites/{uri.Host}:{uri.LocalPath}", accesstoken).GetAwaiter().GetResult();
+                var result = Utilities.REST.RestHelper.GetAsync(connection.HttpClient, $"https://{PnPConnection.Current.GraphEndPoint}/v1.0/sites/{uri.Host}:{uri.LocalPath}", accesstoken).GetAwaiter().GetResult();
                 if (!string.IsNullOrEmpty(result))
                 {
                     var resultElement = JsonSerializer.Deserialize<JsonElement>(result);

--- a/src/Commands/Base/PipeBinds/TeamsAppPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/TeamsAppPipeBind.cs
@@ -38,18 +38,18 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
 
         public string StringValue => _stringValue;
 
-        public TeamApp GetApp(HttpClient httpClient, string accessToken)
+        public TeamApp GetApp(PnPConnection connection, string accessToken)
         {
             if (Id != Guid.Empty)
             {
-                var collection = GraphHelper.GetAsync<RestResultCollection<TeamApp>>(httpClient, $"v1.0/appCatalogs/teamsApps?$filter=id eq '{_id}'", accessToken).GetAwaiter().GetResult();
+                var collection = GraphHelper.GetAsync<RestResultCollection<TeamApp>>(connection, $"v1.0/appCatalogs/teamsApps?$filter=id eq '{_id}'", accessToken).GetAwaiter().GetResult();
                 if (collection != null && collection.Items.Any())
                 {
                     return collection.Items.First();
                 }
                 else
                 {
-                    collection = GraphHelper.GetAsync<RestResultCollection<TeamApp>>(httpClient, $"v1.0/appCatalogs/teamsApps?$filter=externalId eq '{_id}'", accessToken).GetAwaiter().GetResult();
+                    collection = GraphHelper.GetAsync<RestResultCollection<TeamApp>>(connection, $"v1.0/appCatalogs/teamsApps?$filter=externalId eq '{_id}'", accessToken).GetAwaiter().GetResult();
                     if (collection != null && collection.Items.Any())
                     {
                         return collection.Items.First();
@@ -58,7 +58,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             }
             else
             {
-                var collection = GraphHelper.GetAsync<RestResultCollection<TeamApp>>(httpClient, $"v1.0/appCatalogs/teamsApps?$filter=displayName eq '{_stringValue}'", accessToken).GetAwaiter().GetResult();
+                var collection = GraphHelper.GetAsync<RestResultCollection<TeamApp>>(connection, $"v1.0/appCatalogs/teamsApps?$filter=displayName eq '{_stringValue}'", accessToken).GetAwaiter().GetResult();
                 if (collection != null && collection.Items.Any())
                 {
                     if (collection.Items.Count() == 1)

--- a/src/Commands/Base/PipeBinds/TeamsChannelMemberPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/TeamsChannelMemberPipeBind.cs
@@ -40,7 +40,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             _membership = membership;
         }
 
-        public async Task<string> GetIdAsync(HttpClient httpClient, string accessToken, string groupId, string channelId)
+        public async Task<string> GetIdAsync(PnPConnection Connection, string accessToken, string groupId, string channelId)
         {
             if (!string.IsNullOrEmpty(_id))
             {
@@ -52,7 +52,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
                 return _membership.Id;
             }
 
-            var memberships = await TeamsUtility.GetChannelMembersAsync(httpClient, accessToken, groupId, channelId);
+            var memberships = await TeamsUtility.GetChannelMembersAsync(Connection, accessToken, groupId, channelId);
             if (!string.IsNullOrEmpty(_userUpn))
             {
                 return memberships.FirstOrDefault(m => _userUpn.Equals(m.Email, StringComparison.OrdinalIgnoreCase))?.Id;
@@ -61,7 +61,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             return memberships.FirstOrDefault(m => !string.IsNullOrEmpty(m.UserId) && _userId.Equals(m.UserId, StringComparison.OrdinalIgnoreCase))?.Id;
         }
 
-        public async Task<TeamChannelMember> GetMembershipAsync(HttpClient httpClient, string accessToken, string groupId, string channelId)
+        public async Task<TeamChannelMember> GetMembershipAsync(PnPConnection Connection, string accessToken, string groupId, string channelId)
         {
             if (_membership != null)
             {
@@ -70,10 +70,10 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
 
             if (!string.IsNullOrEmpty(_id))
             {
-                return await TeamsUtility.GetChannelMemberAsync(httpClient, accessToken, groupId, channelId, _id);
+                return await TeamsUtility.GetChannelMemberAsync(Connection, accessToken, groupId, channelId, _id);
             }
 
-            var memberships = await TeamsUtility.GetChannelMembersAsync(httpClient, accessToken, groupId, channelId);
+            var memberships = await TeamsUtility.GetChannelMembersAsync(Connection, accessToken, groupId, channelId);
             if (!string.IsNullOrEmpty(_userUpn))
             {
                 return memberships.FirstOrDefault(m => _userUpn.Equals(m.Email, StringComparison.OrdinalIgnoreCase));

--- a/src/Commands/Base/PipeBinds/TeamsChannelPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/TeamsChannelPipeBind.cs
@@ -36,7 +36,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
 
         public string Id => _id;
 
-        public string GetId(HttpClient httpClient, string accessToken, string groupId)
+        public string GetId(PnPConnection connection, string accessToken, string groupId)
         {
             if (!string.IsNullOrEmpty(_id))
             {
@@ -44,14 +44,14 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             }
             else
             {
-                var channels = TeamsUtility.GetChannelsAsync(accessToken, httpClient, groupId).GetAwaiter().GetResult();
+                var channels = TeamsUtility.GetChannelsAsync(accessToken, connection, groupId).GetAwaiter().GetResult();
                 return channels.FirstOrDefault(c => c.DisplayName.Equals(_displayName, StringComparison.OrdinalIgnoreCase))?.Id;
             }
         }
 
-        public TeamChannel GetChannel(HttpClient httpClient, string accessToken, string groupId)
+        public TeamChannel GetChannel(PnPConnection connection, string accessToken, string groupId)
         {
-            var channels = TeamsUtility.GetChannelsAsync(accessToken, httpClient, groupId).GetAwaiter().GetResult();
+            var channels = TeamsUtility.GetChannelsAsync(accessToken, connection, groupId).GetAwaiter().GetResult();
             if(channels != null && channels.Any())
             {
                 if(!string.IsNullOrEmpty(_id))

--- a/src/Commands/Base/PipeBinds/TeamsTabPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/TeamsTabPipeBind.cs
@@ -1,13 +1,8 @@
-﻿using Microsoft.SharePoint.Client;
-using PnP.PowerShell.Commands.Model.Teams;
+﻿using PnP.PowerShell.Commands.Model.Teams;
 using PnP.PowerShell.Commands.Utilities;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
-using System.Net;
-using System.Net.Http;
-using System.Web;
 
 namespace PnP.PowerShell.Commands.Base.PipeBinds
 {
@@ -44,7 +39,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
 
         public string Id => _id;
 
-        public TeamTab GetTab(BasePSCmdlet cmdlet, HttpClient httpClient, string accessToken, string groupId, string channelId)
+        public TeamTab GetTab(BasePSCmdlet cmdlet, PnPConnection Connection, string accessToken, string groupId, string channelId)
         {
             if (_tab != null)
             {
@@ -52,10 +47,10 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             }
             else
             {
-                var tab = TeamsUtility.GetTabAsync(accessToken, httpClient, groupId, channelId, _id).GetAwaiter().GetResult();
+                var tab = TeamsUtility.GetTabAsync(accessToken, Connection, groupId, channelId, _id).GetAwaiter().GetResult();
                 if (string.IsNullOrEmpty(tab.Id))
                 {
-                    var tabs = TeamsUtility.GetTabsAsync(accessToken, httpClient, groupId, channelId).GetAwaiter().GetResult();
+                    var tabs = TeamsUtility.GetTabsAsync(accessToken, Connection, groupId, channelId).GetAwaiter().GetResult();
                     if (tabs != null)
                     {
                         // find the tab by id

--- a/src/Commands/Base/PipeBinds/TeamsTeamPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/TeamsTeamPipeBind.cs
@@ -4,7 +4,6 @@ using PnP.PowerShell.Commands.Utilities.REST;
 using System;
 using System.Linq;
 using System.Management.Automation;
-using System.Net.Http;
 using PnP.PowerShell.Commands.Utilities;
 
 namespace PnP.PowerShell.Commands.Base.PipeBinds
@@ -42,7 +41,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             _id = team.GroupId;
         }
 
-        public string GetGroupId(HttpClient httpClient, string accessToken)
+        public string GetGroupId(PnPConnection connection, string accessToken)
         {
             if (!string.IsNullOrEmpty(_id))
             {
@@ -50,7 +49,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             }
             else
             {
-                var collection = GraphHelper.GetAsync<RestResultCollection<Model.Graph.Group>>(httpClient, $"beta/groups?$filter=(resourceProvisioningOptions/Any(x:x eq 'Team') and mailNickname eq '{UrlUtilities.UrlEncode(_stringValue)}')&$select=Id", accessToken).GetAwaiter().GetResult();
+                var collection = GraphHelper.GetAsync<RestResultCollection<Model.Graph.Group>>(connection, $"beta/groups?$filter=(resourceProvisioningOptions/Any(x:x eq 'Team') and mailNickname eq '{UrlUtilities.UrlEncode(_stringValue)}')&$select=Id", accessToken).GetAwaiter().GetResult();
                 if (collection != null && collection.Items.Any())
                 {
                     return collection.Items.First().Id;
@@ -58,7 +57,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
                 else
                 {
                     // find the team by displayName
-                    var byDisplayNamecollection = GraphHelper.GetAsync<RestResultCollection<Model.Graph.Group>>(httpClient, $"beta/groups?$filter=(resourceProvisioningOptions/Any(x:x eq 'Team') and displayName eq '{UrlUtilities.UrlEncode(_stringValue)}')&$select=Id", accessToken).GetAwaiter().GetResult();
+                    var byDisplayNamecollection = GraphHelper.GetAsync<RestResultCollection<Model.Graph.Group>>(connection, $"beta/groups?$filter=(resourceProvisioningOptions/Any(x:x eq 'Team') and displayName eq '{UrlUtilities.UrlEncode(_stringValue)}')&$select=Id", accessToken).GetAwaiter().GetResult();
                     if (byDisplayNamecollection != null && byDisplayNamecollection.Items.Any())
                     {
                         if (byDisplayNamecollection.Items.Count() == 1)
@@ -75,22 +74,22 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             }
         }
 
-        public Team GetTeam(HttpClient httpClient, string accessToken)
+        public Team GetTeam(PnPConnection connection, string accessToken)
         {
             try
             {
                 if (!string.IsNullOrEmpty(_id))
                 {
-                    return GraphHelper.GetAsync<Team>(httpClient, $"v1.0/teams/{_id}", accessToken, false).GetAwaiter().GetResult();
+                    return GraphHelper.GetAsync<Team>(connection, $"v1.0/teams/{_id}", accessToken, false).GetAwaiter().GetResult();
                 }
                 else
                 {
-                    var collection = GraphHelper.GetAsync<RestResultCollection<Model.Graph.Group>>(httpClient, $"beta/groups?$filter=(resourceProvisioningOptions/Any(x:x eq 'Team') and displayName eq '{_stringValue}')&$select=Id", accessToken).GetAwaiter().GetResult();
+                    var collection = GraphHelper.GetAsync<RestResultCollection<Model.Graph.Group>>(connection, $"beta/groups?$filter=(resourceProvisioningOptions/Any(x:x eq 'Team') and displayName eq '{_stringValue}')&$select=Id", accessToken).GetAwaiter().GetResult();
                     if (collection != null && collection.Items.Any())
                     {
                         if (collection.Items.Count() == 1)
                         {
-                            return GraphHelper.GetAsync<Team>(httpClient, $"v1.0/teams/{collection.Items.First().Id}", accessToken, false).GetAwaiter().GetResult();
+                            return GraphHelper.GetAsync<Team>(connection, $"v1.0/teams/{collection.Items.First().Id}", accessToken, false).GetAwaiter().GetResult();
                         }
                         else
                         {
@@ -99,10 +98,10 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
                     }
                     else
                     {
-                        collection = GraphHelper.GetAsync<RestResultCollection<Model.Graph.Group>>(httpClient, $"beta/groups?$filter=(resourceProvisioningOptions/Any(x:x eq 'Team') and mailNickname eq '{_stringValue}')&$select=Id", accessToken).GetAwaiter().GetResult();
+                        collection = GraphHelper.GetAsync<RestResultCollection<Model.Graph.Group>>(connection, $"beta/groups?$filter=(resourceProvisioningOptions/Any(x:x eq 'Team') and mailNickname eq '{_stringValue}')&$select=Id", accessToken).GetAwaiter().GetResult();
                         if (collection != null && collection.Items.Count() == 1)
                         {
-                            return GraphHelper.GetAsync<Team>(httpClient, $"v1.0/teams/{collection.Items.First().Id}", accessToken, false).GetAwaiter().GetResult();
+                            return GraphHelper.GetAsync<Team>(connection, $"v1.0/teams/{collection.Items.First().Id}", accessToken, false).GetAwaiter().GetResult();
                         }
                     }
                 }
@@ -113,6 +112,5 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             }
             return null;
         }
-
     }
 }

--- a/src/Commands/Base/PnPConnectedCmdlet.cs
+++ b/src/Commands/Base/PnPConnectedCmdlet.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Management.Automation;
-using System.Net.Http;
 
 namespace PnP.PowerShell.Commands.Base
 {
@@ -13,11 +12,6 @@ namespace PnP.PowerShell.Commands.Base
         [Parameter(Mandatory = false, HelpMessage = "Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.")]
         public PnPConnection Connection = null;
         // do not remove '#!#99'
-
-        /// <summary>
-        /// Returns a reusable HTTPClient that can be used to make HTTP calls
-        /// </summary>
-        public HttpClient HttpClient => PnP.Framework.Http.PnPHttpClient.Instance.GetHttpClient();
 
         protected override void BeginProcessing()
         {

--- a/src/Commands/Base/PnPConnectedCmdlet.cs
+++ b/src/Commands/Base/PnPConnectedCmdlet.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Management.Automation;
 using System.Net.Http;
 
 namespace PnP.PowerShell.Commands.Base
@@ -8,6 +9,16 @@ namespace PnP.PowerShell.Commands.Base
     /// </summary>
     public abstract class PnPConnectedCmdlet : BasePSCmdlet
     {
+        // do not remove '#!#99'
+        [Parameter(Mandatory = false, HelpMessage = "Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.")]
+        public PnPConnection Connection = null;
+        // do not remove '#!#99'
+
+        /// <summary>
+        /// Returns a reusable HTTPClient that can be used to make HTTP calls
+        /// </summary>
+        public HttpClient HttpClient => PnP.Framework.Http.PnPHttpClient.Instance.GetHttpClient();
+
         protected override void BeginProcessing()
         {
             BeginProcessing(false);
@@ -17,16 +28,20 @@ namespace PnP.PowerShell.Commands.Base
         {
             base.BeginProcessing();
 
+            // If a specific connection has been provided, use that, otherwise use the current connection
+            if(Connection == null)
+            {
+                Connection = PnPConnection.Current;
+            }
+
             // Check if we should ensure that we are connected
             if(skipConnectedValidation) return;
 
             // Ensure there is an active connection
-            if (PnPConnection.Current == null)
+            if (Connection == null)
             {
                 throw new InvalidOperationException(Properties.Resources.NoConnection);
             }
         }
-
-        public HttpClient HttpClient => PnP.Framework.Http.PnPHttpClient.Instance.GetHttpClient();
     }
 }

--- a/src/Commands/Base/PnPConnection.cs
+++ b/src/Commands/Base/PnPConnection.cs
@@ -17,6 +17,7 @@ using TextCopy;
 using PnP.PowerShell.Commands.Utilities;
 using System.Threading.Tasks;
 using System.Threading;
+using System.Net.Http;
 
 namespace PnP.PowerShell.Commands.Base
 {
@@ -34,6 +35,10 @@ namespace PnP.PowerShell.Commands.Base
 
         #region Properties
 
+        /// <summary>
+        /// Returns a reusable HTTPClient that can be used to make HTTP calls on this connection instance
+        /// </summary>
+        internal HttpClient HttpClient => PnP.Framework.Http.PnPHttpClient.Instance.GetHttpClient();
 
         private PnPContext pnpContext { get; set; }
 

--- a/src/Commands/Base/PnPConnection.cs
+++ b/src/Commands/Base/PnPConnection.cs
@@ -64,7 +64,11 @@ namespace PnP.PowerShell.Commands.Base
 
         internal static List<ClientContext> ContextCache { get; set; }
 
+        /// <summary>
+        /// Connection instance which is set by connecting without -ReturnConnection
+        /// </summary>
         public static PnPConnection Current { get; internal set; }
+        
         public ConnectionType ConnectionType { get; protected set; }
 
         /// <summary>

--- a/src/Commands/Base/PnPGraphCmdlet.cs
+++ b/src/Commands/Base/PnPGraphCmdlet.cs
@@ -1,11 +1,7 @@
 ﻿using Microsoft.Graph;
 using Microsoft.SharePoint.Client;
 using PnP.Core.Services;
-using PnP.PowerShell.Commands.Attributes;
 using PnP.PowerShell.Commands.Model;
-using PnP.PowerShell.Commands.Properties;
-using System;
-using System.Collections.Generic;
 using System.Management.Automation;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -20,23 +16,19 @@ namespace PnP.PowerShell.Commands.Base
         /// <summary>
         /// Reference the the SharePoint context on the current connection. If NULL it means there is no SharePoint context available on the current connection.
         /// </summary>
-        public ClientContext ClientContext => Connection?.Context ?? PnPConnection.Current.Context;
+        public ClientContext ClientContext => Connection?.Context;
 
-        public PnPContext PnPContext => Connection?.PnPContext ?? PnPConnection.Current.PnPContext;
-
-        // do not remove '#!#99'
-        [Parameter(Mandatory = false, HelpMessage = "Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.")]
-        public PnPConnection Connection = null;
-        // do not remove '#!#99'
+        public PnPContext PnPContext => Connection?.PnPContext;
 
         private GraphServiceClient serviceClient;
 
         protected override void BeginProcessing()
         {
             base.BeginProcessing();
-            if (PnPConnection.Current?.Context != null)
+
+            if (Connection?.Context != null)
             {
-                var contextSettings = PnPConnection.Current.Context.GetContextSettings();
+                var contextSettings = Connection.Context.GetContextSettings();
                 if (contextSettings?.Type == Framework.Utilities.Context.ClientContextType.Cookie || contextSettings?.Type == Framework.Utilities.Context.ClientContextType.SharePointACSAppOnly)
                 {
                     var typeString = contextSettings?.Type == Framework.Utilities.Context.ClientContextType.Cookie ? "WebLogin/Cookie" : "ACS";
@@ -52,15 +44,15 @@ namespace PnP.PowerShell.Commands.Base
         {
             get
             {
-                if (PnPConnection.Current?.ConnectionMethod == ConnectionMethod.ManagedIdentity)
+                if (Connection?.ConnectionMethod == ConnectionMethod.ManagedIdentity)
                 {
-                    return TokenHandler.GetManagedIdentityTokenAsync(this, HttpClient, $"https://{PnPConnection.Current.GraphEndPoint}/").GetAwaiter().GetResult();
+                    return TokenHandler.GetManagedIdentityTokenAsync(this, HttpClient, $"https://{Connection.GraphEndPoint}/").GetAwaiter().GetResult();
                 }
                 else
                 {
-                    if (PnPConnection.Current?.Context != null)
+                    if (Connection?.Context != null)
                     {
-                        return TokenHandler.GetAccessToken(GetType(), $"https://{PnPConnection.Current.GraphEndPoint}/.default");
+                        return TokenHandler.GetAccessToken(GetType(), $"https://{Connection.GraphEndPoint}/.default", Connection);
                     }
                 }
 
@@ -74,7 +66,7 @@ namespace PnP.PowerShell.Commands.Base
             {
                 if (serviceClient == null)
                 {
-                    var baseUrl = $"https://{PnPConnection.Current.GraphEndPoint}/v1.0";
+                    var baseUrl = $"https://{Connection.GraphEndPoint}/v1.0";
                     serviceClient = new GraphServiceClient(baseUrl, new DelegateAuthenticationProvider(
                             async (requestMessage) =>
                             {
@@ -91,6 +83,5 @@ namespace PnP.PowerShell.Commands.Base
                 return serviceClient;
             }
         }
-
     }
 }

--- a/src/Commands/Base/PnPGraphCmdlet.cs
+++ b/src/Commands/Base/PnPGraphCmdlet.cs
@@ -46,7 +46,7 @@ namespace PnP.PowerShell.Commands.Base
             {
                 if (Connection?.ConnectionMethod == ConnectionMethod.ManagedIdentity)
                 {
-                    return TokenHandler.GetManagedIdentityTokenAsync(this, HttpClient, $"https://{Connection.GraphEndPoint}/").GetAwaiter().GetResult();
+                    return TokenHandler.GetManagedIdentityTokenAsync(this, Connection.HttpClient, $"https://{Connection.GraphEndPoint}/").GetAwaiter().GetResult();
                 }
                 else
                 {

--- a/src/Commands/Base/PnPOfficeManagementApiCmdlet.cs
+++ b/src/Commands/Base/PnPOfficeManagementApiCmdlet.cs
@@ -1,8 +1,4 @@
-﻿using PnP.PowerShell.Commands.Attributes;
-using PnP.PowerShell.Commands.Model;
-using PnP.PowerShell.Commands.Properties;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Management.Automation;
 using Microsoft.SharePoint.Client;
 using System.Linq;
@@ -21,9 +17,9 @@ namespace PnP.PowerShell.Commands.Base
         {
             get
             {
-                if (PnPConnection.Current?.Context != null)
+                if (Connection?.Context != null)
                 {
-                    return TokenHandler.GetAccessToken(GetType(), "https://manage.office.com/.default");
+                    return TokenHandler.GetAccessToken(GetType(), "https://manage.office.com/.default", Connection);
                 }
                 return null;
             }
@@ -32,9 +28,9 @@ namespace PnP.PowerShell.Commands.Base
         protected override void BeginProcessing()
         {
             base.BeginProcessing();
-            if (PnPConnection.Current?.Context != null)
+            if (Connection?.Context != null)
             {
-                if (PnPConnection.Current.Context.GetContextSettings().Type == Framework.Utilities.Context.ClientContextType.Cookie)
+                if (Connection?.Context.GetContextSettings().Type == Framework.Utilities.Context.ClientContextType.Cookie)
                 {
                     throw new PSInvalidOperationException("This cmdlet not work with a WebLogin/Cookie based connection towards SharePoint.");
                 }

--- a/src/Commands/Base/PnPSharePointCmdlet.cs
+++ b/src/Commands/Base/PnPSharePointCmdlet.cs
@@ -24,7 +24,7 @@ namespace PnP.PowerShell.Commands
 
         public PnPContext PnPContext => Connection?.PnPContext ?? Connection.PnPContext;
 
-        public new HttpClient HttpClient => PnP.Framework.Http.PnPHttpClient.Instance.GetHttpClient(ClientContext);
+        public HttpClient HttpClient => PnP.Framework.Http.PnPHttpClient.Instance.GetHttpClient(ClientContext);
 
         protected override void BeginProcessing()
         {
@@ -157,6 +157,5 @@ namespace PnP.PowerShell.Commands
             }
             WriteWarning("SharePoint Operation Wait Interrupted");
         }
-
     }
 }

--- a/src/Commands/Base/PnPSharePointCmdlet.cs
+++ b/src/Commands/Base/PnPSharePointCmdlet.cs
@@ -26,21 +26,10 @@ namespace PnP.PowerShell.Commands
 
         public new HttpClient HttpClient => PnP.Framework.Http.PnPHttpClient.Instance.GetHttpClient(ClientContext);
 
-        // do not remove '#!#99'
-        [Parameter(Mandatory = false, HelpMessage = "Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.")]
-        public PnPConnection Connection = null;
-        // do not remove '#!#99'
-
         protected override void BeginProcessing()
         {
             // Call the base but instruct it not to check if there's an active connection as we will do that in this method already
             base.BeginProcessing(true);
-
-            // If a specific connection has been provided, use that, otherwise use the current connection
-            if(Connection == null)
-            {
-                Connection = PnPConnection.Current;
-            }
 
             // Track the execution of the cmdlet
             if (Connection != null && Connection.ApplicationInsights != null)
@@ -137,7 +126,7 @@ namespace PnP.PowerShell.Commands
                 {
                     if (Connection?.Context != null)
                     {
-                        return TokenHandler.GetAccessToken(GetType(), $"https://{Connection.GraphEndPoint}/.default");
+                        return TokenHandler.GetAccessToken(GetType(), $"https://{Connection.GraphEndPoint}/.default", Connection);
                     }
                 }
 

--- a/src/Commands/Base/PnPWebCmdlet.cs
+++ b/src/Commands/Base/PnPWebCmdlet.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using PnP.PowerShell.Commands.Base;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 using System.Management.Automation;
 using Microsoft.SharePoint.Client;
-using PnP.PowerShell.Commands.Extensions;
 
 
 namespace PnP.PowerShell.Commands
@@ -48,20 +46,20 @@ namespace PnP.PowerShell.Commands
             {
                 var subWeb = Web.GetWeb(ClientContext);
                 subWeb.EnsureProperty(w => w.Url);
-                PnPConnection.Current.CloneContext(subWeb.Url);
-                web = PnPConnection.Current.Context.Web;
+                Connection.CloneContext(subWeb.Url);
+                web = Connection.Context.Web;
             }
 #pragma warning restore CS0618
             else
             {
-                if (PnPConnection.Current.Context.Url != PnPConnection.Current.Url)
+                if (Connection.Context.Url != Connection.Url)
                 {
-                    PnPConnection.Current.RestoreCachedContext(PnPConnection.Current.Url);
+                    Connection.RestoreCachedContext(Connection.Url);
                 }
                 web = ClientContext.Web;
             }
 
-            PnPConnection.Current.Context.ExecuteQueryRetry();
+            Connection.Context.ExecuteQueryRetry();
 
             return web;
         }
@@ -69,16 +67,16 @@ namespace PnP.PowerShell.Commands
         protected override void EndProcessing()
         {
             base.EndProcessing();
-            if (PnPConnection.Current.Context.Url != PnPConnection.Current.Url)
+            if (Connection.Context.Url != Connection.Url)
             {
-                PnPConnection.Current.RestoreCachedContext(PnPConnection.Current.Url);
+                Connection.RestoreCachedContext(Connection.Url);
             }
         }
 
         protected override void BeginProcessing()
         {
             base.BeginProcessing();
-            PnPConnection.Current.CacheContext();
+            Connection.CacheContext();
         }
     }
 }

--- a/src/Commands/Base/TokenHandling.cs
+++ b/src/Commands/Base/TokenHandling.cs
@@ -48,9 +48,9 @@ namespace PnP.PowerShell.Commands.Base
             }
         }
 
-        internal static string GetAccessToken(Type cmdletType, string appOnlyDefaultScope)
+        internal static string GetAccessToken(Type cmdletType, string appOnlyDefaultScope, PnPConnection connection)
         {
-            var contextSettings = PnPConnection.Current.Context.GetContextSettings();
+            var contextSettings = connection.Context.GetContextSettings();
             var authManager = contextSettings.AuthenticationManager;
             if (authManager != null)
             {

--- a/src/Commands/Graph/InvokeGraphMethod.cs
+++ b/src/Commands/Graph/InvokeGraphMethod.cs
@@ -179,7 +179,7 @@ namespace PnP.PowerShell.Commands.Base
 
         private void GetRequest()
         {
-            var result = GraphHelper.GetAsync(HttpClient, Url, AccessToken, AdditionalHeaders).GetAwaiter().GetResult();
+            var result = GraphHelper.GetAsync(Connection, Url, AccessToken, AdditionalHeaders).GetAwaiter().GetResult();
             if (Raw.IsPresent)
             {
                 WriteObject(result);
@@ -203,7 +203,7 @@ namespace PnP.PowerShell.Commands.Base
                                 break;
                             }
                             var nextLink = nextLinkProperty.ToString();
-                            result = GraphHelper.GetAsync(HttpClient, nextLink, AccessToken, AdditionalHeaders).GetAwaiter().GetResult();
+                            result = GraphHelper.GetAsync(Connection, nextLink, AccessToken, AdditionalHeaders).GetAwaiter().GetResult();
                             element = JsonSerializer.Deserialize<JsonElement>(result);
                             dynamic nextObj = Deserialize(element);
                             if (nextObj != null && nextObj.value != null && (nextObj.value is List<object>))
@@ -228,28 +228,28 @@ namespace PnP.PowerShell.Commands.Base
 
         private void PostRequest()
         {
-            var response = GraphHelper.PostAsync(HttpClient, Url, AccessToken, GetHttpContent(), AdditionalHeaders).GetAwaiter().GetResult();
+            var response = GraphHelper.PostAsync(Connection, Url, AccessToken, GetHttpContent(), AdditionalHeaders).GetAwaiter().GetResult();
             var result = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
             WriteGraphResult(result);
         }
 
         private void PutRequest()
         {
-            var response = GraphHelper.PutAsync(HttpClient, Url, AccessToken, GetHttpContent(), AdditionalHeaders).GetAwaiter().GetResult();
+            var response = GraphHelper.PutAsync(Connection, Url, AccessToken, GetHttpContent(), AdditionalHeaders).GetAwaiter().GetResult();
             var result = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
             WriteGraphResult(result);
         }
 
         private void PatchRequest()
         {
-            var response = GraphHelper.PatchAsync(HttpClient, AccessToken, GetHttpContent(), Url, AdditionalHeaders).GetAwaiter().GetResult();
+            var response = GraphHelper.PatchAsync(Connection, AccessToken, GetHttpContent(), Url, AdditionalHeaders).GetAwaiter().GetResult();
             var result = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
             WriteGraphResult(result);
         }
 
         private void DeleteRequest()
         {
-            var response = GraphHelper.DeleteAsync(HttpClient, Url, AccessToken, AdditionalHeaders).GetAwaiter().GetResult();
+            var response = GraphHelper.DeleteAsync(Connection, Url, AccessToken, AdditionalHeaders).GetAwaiter().GetResult();
             var result = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
             WriteGraphResult(result);
         }

--- a/src/Commands/Lists/CopyList.cs
+++ b/src/Commands/Lists/CopyList.cs
@@ -96,7 +96,7 @@ namespace PnP.PowerShell.Commands.Lists
 
             // Execute site script on destination site so the list will be created
             WriteVerbose($"Executing site script to site at {DestinationWebUrl}");
-            var actionResults = PnP.PowerShell.Commands.Utilities.SiteTemplates.InvokeSiteScript(HttpClient, AccessToken, script, DestinationWebUrl).GetAwaiter().GetResult().Items.ToArray();
+            var actionResults = PnP.PowerShell.Commands.Utilities.SiteTemplates.InvokeSiteScript(Connection, AccessToken, script, DestinationWebUrl).GetAwaiter().GetResult().Items.ToArray();
             
             // Ensure site script actions have been executed
             if(actionResults.Length == 0)

--- a/src/Commands/ManagementApi/GetUnifiedAuditLog.cs
+++ b/src/Commands/ManagementApi/GetUnifiedAuditLog.cs
@@ -57,7 +57,7 @@ namespace PnP.PowerShell.Commands.ManagementApi
         private IEnumerable<ManagementApiSubscription> GetSubscriptions()
         {
             var url = $"{ApiUrl}/subscriptions/list";
-            return GraphHelper.GetAsync<IEnumerable<ManagementApiSubscription>>(HttpClient, url, AccessToken).GetAwaiter().GetResult();
+            return GraphHelper.GetAsync<IEnumerable<ManagementApiSubscription>>(Connection, url, AccessToken).GetAwaiter().GetResult();
         }
 
         private void EnsureSubscription(string contentType)
@@ -66,7 +66,7 @@ namespace PnP.PowerShell.Commands.ManagementApi
             var subscription = subscriptions.FirstOrDefault(s => s.ContentType == contentType);
             if (subscription == null)
             {
-                subscription = GraphHelper.PostAsync<ManagementApiSubscription>(HttpClient, $"{ApiUrl}/subscriptions/start?contentType={contentType}&PublisherIdentifier={TenantId}", AccessToken).GetAwaiter().GetResult();
+                subscription = GraphHelper.PostAsync<ManagementApiSubscription>(Connection, $"{ApiUrl}/subscriptions/start?contentType={contentType}&PublisherIdentifier={TenantId}", AccessToken).GetAwaiter().GetResult();
                 if (!subscription.Status.Equals("enabled", StringComparison.OrdinalIgnoreCase))
                 {
                     throw new Exception($"Cannot enable subscription for {contentType}");
@@ -89,7 +89,7 @@ namespace PnP.PowerShell.Commands.ManagementApi
             }
 
             List<ManagementApiSubscriptionContent> subscriptionContents = new List<ManagementApiSubscriptionContent>();
-            var subscriptionResponse = GraphHelper.GetResponseAsync(HttpClient, url, AccessToken).GetAwaiter().GetResult();
+            var subscriptionResponse = GraphHelper.GetResponseAsync(Connection, url, AccessToken).GetAwaiter().GetResult();
             var content = subscriptionResponse.Content.ReadAsStringAsync().GetAwaiter().GetResult();
 
             if (subscriptionResponse.IsSuccessStatusCode)
@@ -97,7 +97,7 @@ namespace PnP.PowerShell.Commands.ManagementApi
                 subscriptionContents.AddRange(System.Text.Json.JsonSerializer.Deserialize<IEnumerable<ManagementApiSubscriptionContent>>(content, new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
                 while (subscriptionResponse.Headers.Contains("NextPageUri"))
                 {
-                    subscriptionResponse = GraphHelper.GetResponseAsync(HttpClient, subscriptionResponse.Headers.GetValues("NextPageUri").First(), AccessToken).GetAwaiter().GetResult();
+                    subscriptionResponse = GraphHelper.GetResponseAsync(Connection, subscriptionResponse.Headers.GetValues("NextPageUri").First(), AccessToken).GetAwaiter().GetResult();
                     if (subscriptionResponse.IsSuccessStatusCode)
                     {
                         content = subscriptionResponse.Content.ReadAsStringAsync().GetAwaiter().GetResult();
@@ -115,7 +115,7 @@ namespace PnP.PowerShell.Commands.ManagementApi
             {
                 foreach (var subscriptionContent in subscriptionContents)
                 {
-                    var logs = GraphHelper.GetAsync<IEnumerable<ManagementApiUnifiedLogRecord>>(HttpClient, subscriptionContent.ContentUri, AccessToken, false).GetAwaiter().GetResult();
+                    var logs = GraphHelper.GetAsync<IEnumerable<ManagementApiUnifiedLogRecord>>(Connection, subscriptionContent.ContentUri, AccessToken, false).GetAwaiter().GetResult();
                     WriteObject(logs, true);
                 }
             }

--- a/src/Commands/Microsoft365Groups/AddMicrosoft365GroupMember.cs
+++ b/src/Commands/Microsoft365Groups/AddMicrosoft365GroupMember.cs
@@ -23,7 +23,7 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
 
         protected override void ExecuteCmdlet()
         {
-            Microsoft365GroupsUtility.AddMembersAsync(HttpClient, Identity.GetGroupId(HttpClient, AccessToken), Users, AccessToken, RemoveExisting).GetAwaiter().GetResult();
+            Microsoft365GroupsUtility.AddMembersAsync(Connection, Identity.GetGroupId(Connection, AccessToken), Users, AccessToken, RemoveExisting).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Commands/Microsoft365Groups/AddMicrosoft365GroupOwner.cs
+++ b/src/Commands/Microsoft365Groups/AddMicrosoft365GroupOwner.cs
@@ -1,6 +1,4 @@
-﻿using PnP.Framework.Entities;
-using PnP.Framework.Graph;
-using PnP.PowerShell.Commands.Attributes;
+﻿using PnP.PowerShell.Commands.Attributes;
 using PnP.PowerShell.Commands.Base;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 using PnP.PowerShell.Commands.Utilities;
@@ -23,7 +21,7 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
 
         protected override void ExecuteCmdlet()
         {
-            Microsoft365GroupsUtility.AddOwnersAsync(HttpClient, Identity.GetGroupId(HttpClient, AccessToken), Users, AccessToken, RemoveExisting).GetAwaiter().GetResult();
+            Microsoft365GroupsUtility.AddOwnersAsync(Connection, Identity.GetGroupId(Connection, AccessToken), Users, AccessToken, RemoveExisting).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Commands/Microsoft365Groups/ClearMicrosoft365GroupMember.cs
+++ b/src/Commands/Microsoft365Groups/ClearMicrosoft365GroupMember.cs
@@ -17,7 +17,7 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
 
         protected override void ExecuteCmdlet()
         {
-           Microsoft365GroupsUtility.ClearMembersAsync(HttpClient, Identity.GetGroupId(HttpClient, AccessToken), AccessToken).GetAwaiter().GetResult();
+           Microsoft365GroupsUtility.ClearMembersAsync(Connection, Identity.GetGroupId(Connection, AccessToken), AccessToken).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Commands/Microsoft365Groups/ClearMicrosoft365GroupOwner.cs
+++ b/src/Commands/Microsoft365Groups/ClearMicrosoft365GroupOwner.cs
@@ -16,9 +16,9 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Identity.GetGroupId(HttpClient, AccessToken);
-            Microsoft365GroupsUtility.ClearOwnersAsync(HttpClient, groupId, AccessToken).GetAwaiter().GetResult();
-            var owners = Microsoft365GroupsUtility.GetOwnersAsync(HttpClient, groupId, AccessToken).GetAwaiter().GetResult();
+            var groupId = Identity.GetGroupId(Connection, AccessToken);
+            Microsoft365GroupsUtility.ClearOwnersAsync(Connection, groupId, AccessToken).GetAwaiter().GetResult();
+            var owners = Microsoft365GroupsUtility.GetOwnersAsync(Connection, groupId, AccessToken).GetAwaiter().GetResult();
             if (owners != null && owners.Any())
             {
                 WriteWarning($"Clearing all owners is not possible as there will always have to be at least one owner. To changed the owners with new owners use Set-PnPMicrosoft365GroupOwner -Identity {groupId} -Owners \"newowner@domain.com\"");

--- a/src/Commands/Microsoft365Groups/GetDeletedMicrosoft365Group.cs
+++ b/src/Commands/Microsoft365Groups/GetDeletedMicrosoft365Group.cs
@@ -18,11 +18,11 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
         {
             if (Identity != null)
             {
-                WriteObject(Identity.GetDeletedGroup(HttpClient, AccessToken));
+                WriteObject(Identity.GetDeletedGroup(Connection, AccessToken));
             }
             else
             {
-                var groups = Microsoft365GroupsUtility.GetDeletedGroupsAsync(HttpClient, AccessToken).GetAwaiter().GetResult();
+                var groups = Microsoft365GroupsUtility.GetDeletedGroupsAsync(Connection, AccessToken).GetAwaiter().GetResult();
                 WriteObject(groups.OrderBy(g => g.DisplayName), true);
             }
         }

--- a/src/Commands/Microsoft365Groups/GetMicrosoft365Group.cs
+++ b/src/Commands/Microsoft365Groups/GetMicrosoft365Group.cs
@@ -41,12 +41,12 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
 
             if (Identity != null)
             {
-                var group = Identity.GetGroup(HttpClient, AccessToken, includeSiteUrl, IncludeOwners);
+                var group = Identity.GetGroup(Connection, AccessToken, includeSiteUrl, IncludeOwners);
                 WriteObject(group);
             }
             else
             {
-                var groups = Microsoft365GroupsUtility.GetGroupsAsync(HttpClient, AccessToken, includeSiteUrl, IncludeOwners).GetAwaiter().GetResult();
+                var groups = Microsoft365GroupsUtility.GetGroupsAsync(Connection, AccessToken, includeSiteUrl, IncludeOwners).GetAwaiter().GetResult();
 
                 WriteObject(groups.OrderBy(p => p.DisplayName), true);
             }

--- a/src/Commands/Microsoft365Groups/GetMicrosoft365GroupMember.cs
+++ b/src/Commands/Microsoft365Groups/GetMicrosoft365GroupMember.cs
@@ -17,7 +17,7 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
 
         protected override void ExecuteCmdlet()
         {
-            var members = Microsoft365GroupsUtility.GetMembersAsync(HttpClient, Identity.GetGroupId(HttpClient, AccessToken), AccessToken).GetAwaiter().GetResult();
+            var members = Microsoft365GroupsUtility.GetMembersAsync(Connection, Identity.GetGroupId(Connection, AccessToken), AccessToken).GetAwaiter().GetResult();
             WriteObject(members?.OrderBy(m => m.DisplayName), true);
         }
     }

--- a/src/Commands/Microsoft365Groups/GetMicrosoft365GroupOwner.cs
+++ b/src/Commands/Microsoft365Groups/GetMicrosoft365GroupOwner.cs
@@ -17,7 +17,7 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
 
         protected override void ExecuteCmdlet()
         {
-            var owners = Microsoft365GroupsUtility.GetOwnersAsync(HttpClient, Identity.GetGroupId(HttpClient, AccessToken), AccessToken).GetAwaiter().GetResult();
+            var owners = Microsoft365GroupsUtility.GetOwnersAsync(Connection, Identity.GetGroupId(Connection, AccessToken), AccessToken).GetAwaiter().GetResult();
             WriteObject(owners?.OrderBy(o => o.DisplayName), true);
         }
     }

--- a/src/Commands/Microsoft365Groups/GetMicrosoft365GroupSettingTemplates.cs
+++ b/src/Commands/Microsoft365Groups/GetMicrosoft365GroupSettingTemplates.cs
@@ -16,12 +16,12 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
         {
             if (Identity != null)
             {
-                var groupSettingTemplate = Microsoft365GroupsUtility.GetGroupTemplateSettingsAsync(HttpClient, AccessToken, Identity).GetAwaiter().GetResult();
+                var groupSettingTemplate = Microsoft365GroupsUtility.GetGroupTemplateSettingsAsync(Connection, AccessToken, Identity).GetAwaiter().GetResult();
                 WriteObject(groupSettingTemplate);
             }
             else
             {
-                var groupSettingTemplates = Microsoft365GroupsUtility.GetGroupTemplateSettingsAsync(HttpClient, AccessToken).GetAwaiter().GetResult();
+                var groupSettingTemplates = Microsoft365GroupsUtility.GetGroupTemplateSettingsAsync(Connection, AccessToken).GetAwaiter().GetResult();
                 WriteObject(groupSettingTemplates?.Value, true);
             }
         }

--- a/src/Commands/Microsoft365Groups/GetMicrosoft365GroupSettings.cs
+++ b/src/Commands/Microsoft365Groups/GetMicrosoft365GroupSettings.cs
@@ -18,13 +18,13 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
         {
             if (Identity != null)
             {
-                var groupId = Identity.GetGroupId(HttpClient, AccessToken);
-                var groupSettings = Microsoft365GroupsUtility.GetGroupSettingsAsync(HttpClient, AccessToken, groupId.ToString()).GetAwaiter().GetResult();
+                var groupId = Identity.GetGroupId(Connection, AccessToken);
+                var groupSettings = Microsoft365GroupsUtility.GetGroupSettingsAsync(Connection, AccessToken, groupId.ToString()).GetAwaiter().GetResult();
                 WriteObject(groupSettings?.Value, true);
             }
             else
             {
-                var groupSettings = Microsoft365GroupsUtility.GetGroupSettingsAsync(HttpClient, AccessToken).GetAwaiter().GetResult();
+                var groupSettings = Microsoft365GroupsUtility.GetGroupSettingsAsync(Connection, AccessToken).GetAwaiter().GetResult();
                 WriteObject(groupSettings?.Value, true);
             }
         }

--- a/src/Commands/Microsoft365Groups/NewMicrosoft365Group.cs
+++ b/src/Commands/Microsoft365Groups/NewMicrosoft365Group.cs
@@ -1,14 +1,11 @@
 ﻿using Microsoft.SharePoint.Client;
-using PnP.Framework.Graph;
 using PnP.PowerShell.Commands.Attributes;
 using PnP.PowerShell.Commands.Base;
 using PnP.PowerShell.Commands.Enums;
 using PnP.PowerShell.Commands.Model;
-using PnP.PowerShell.Commands.Properties;
 using PnP.PowerShell.Commands.Utilities;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Management.Automation;
 
 namespace PnP.PowerShell.Commands.Microsoft365Groups
@@ -67,7 +64,7 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
 
             if (!Force)
             {
-                var candidate = Microsoft365GroupsUtility.GetGroupAsync(HttpClient, MailNickname, AccessToken, false, false).GetAwaiter().GetResult();
+                var candidate = Microsoft365GroupsUtility.GetGroupAsync(Connection, MailNickname, AccessToken, false, false).GetAwaiter().GetResult();
                 forceCreation = candidate == null || ShouldContinue($"The Microsoft 365 Group '{MailNickname} already exists. Do you want to create a new one?", Properties.Resources.Confirm);
             }
             else
@@ -129,14 +126,14 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
                     }                    
                 }
 
-                var group = Microsoft365GroupsUtility.CreateAsync(HttpClient, AccessToken, newGroup, CreateTeam, LogoPath, Owners, Members, HideFromAddressLists, HideFromOutlookClients, Labels).GetAwaiter().GetResult();
+                var group = Microsoft365GroupsUtility.CreateAsync(Connection, AccessToken, newGroup, CreateTeam, LogoPath, Owners, Members, HideFromAddressLists, HideFromOutlookClients, Labels).GetAwaiter().GetResult();
 
                 if (ParameterSpecified(nameof(HideFromAddressLists)) || ParameterSpecified(nameof(HideFromOutlookClients)))
                 {
-                    Microsoft365GroupsUtility.SetVisibilityAsync(HttpClient, AccessToken, group.Id.Value, HideFromAddressLists, HideFromOutlookClients).GetAwaiter().GetResult();
+                    Microsoft365GroupsUtility.SetVisibilityAsync(Connection, AccessToken, group.Id.Value, HideFromAddressLists, HideFromOutlookClients).GetAwaiter().GetResult();
                 }
 
-                var updatedGroup = Microsoft365GroupsUtility.GetGroupAsync(HttpClient, group.Id.Value, AccessToken, true, false).GetAwaiter().GetResult();
+                var updatedGroup = Microsoft365GroupsUtility.GetGroupAsync(Connection, group.Id.Value, AccessToken, true, false).GetAwaiter().GetResult();
 
                 WriteObject(updatedGroup);
             }

--- a/src/Commands/Microsoft365Groups/NewMicrosoft365GroupSettings.cs
+++ b/src/Commands/Microsoft365Groups/NewMicrosoft365GroupSettings.cs
@@ -32,17 +32,17 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
         {
             if (Identity != null)
             {
-                var groupId = Identity.GetGroupId(HttpClient, AccessToken);
+                var groupId = Identity.GetGroupId(Connection, AccessToken);
                 var groupSettingObject = GroupSettingsObject();
 
-                var responseValue = Microsoft365GroupsUtility.CreateGroupSetting(HttpClient, AccessToken, groupId.ToString(), groupSettingObject).GetAwaiter().GetResult();
+                var responseValue = Microsoft365GroupsUtility.CreateGroupSetting(Connection, AccessToken, groupId.ToString(), groupSettingObject).GetAwaiter().GetResult();
                 WriteObject(responseValue);
             }
             else
             {
                 var groupSettingObject = GroupSettingsObject();
 
-                var responseValue = Microsoft365GroupsUtility.CreateGroupSetting(HttpClient, AccessToken, groupSettingObject).GetAwaiter().GetResult();
+                var responseValue = Microsoft365GroupsUtility.CreateGroupSetting(Connection, AccessToken, groupSettingObject).GetAwaiter().GetResult();
                 WriteObject(responseValue);
             }
         }

--- a/src/Commands/Microsoft365Groups/RemoveDeletedMicrosoft365Group.cs
+++ b/src/Commands/Microsoft365Groups/RemoveDeletedMicrosoft365Group.cs
@@ -16,7 +16,7 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
 
         protected override void ExecuteCmdlet()
         {
-            Microsoft365GroupsUtility.PermanentlyDeleteDeletedGroupAsync(HttpClient, Identity.GetDeletedGroupId(HttpClient, AccessToken), AccessToken).GetAwaiter().GetResult();
+            Microsoft365GroupsUtility.PermanentlyDeleteDeletedGroupAsync(Connection, Identity.GetDeletedGroupId(Connection, AccessToken), AccessToken).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Commands/Microsoft365Groups/RemoveMicrosoft365Group.cs
+++ b/src/Commands/Microsoft365Groups/RemoveMicrosoft365Group.cs
@@ -17,7 +17,7 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
 
         protected override void ExecuteCmdlet()
         {
-            Microsoft365GroupsUtility.RemoveGroupAsync(HttpClient, Identity.GetGroupId(HttpClient, AccessToken), AccessToken).GetAwaiter().GetResult();
+            Microsoft365GroupsUtility.RemoveGroupAsync(Connection, Identity.GetGroupId(Connection, AccessToken), AccessToken).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Commands/Microsoft365Groups/RemoveMicrosoft365GroupMember.cs
+++ b/src/Commands/Microsoft365Groups/RemoveMicrosoft365GroupMember.cs
@@ -1,6 +1,4 @@
-﻿using PnP.Framework.Entities;
-using PnP.Framework.Graph;
-using PnP.PowerShell.Commands.Attributes;
+﻿using PnP.PowerShell.Commands.Attributes;
 using PnP.PowerShell.Commands.Base;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 using PnP.PowerShell.Commands.Utilities;
@@ -20,7 +18,7 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
 
         protected override void ExecuteCmdlet()
         {
-            Microsoft365GroupsUtility.RemoveMembersAsync(HttpClient, Identity.GetGroupId(HttpClient, AccessToken), Users, AccessToken).GetAwaiter().GetResult();
+            Microsoft365GroupsUtility.RemoveMembersAsync(Connection, Identity.GetGroupId(Connection, AccessToken), Users, AccessToken).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Commands/Microsoft365Groups/RemoveMicrosoft365GroupOwner.cs
+++ b/src/Commands/Microsoft365Groups/RemoveMicrosoft365GroupOwner.cs
@@ -20,7 +20,7 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
 
         protected override void ExecuteCmdlet()
         {
-            Microsoft365GroupsUtility.RemoveOwnersAsync(HttpClient, Identity.GetGroupId(HttpClient, AccessToken), Users, AccessToken).GetAwaiter().GetResult();
+            Microsoft365GroupsUtility.RemoveOwnersAsync(Connection, Identity.GetGroupId(Connection, AccessToken), Users, AccessToken).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Commands/Microsoft365Groups/RemoveMicrosoft365GroupSettings.cs
+++ b/src/Commands/Microsoft365Groups/RemoveMicrosoft365GroupSettings.cs
@@ -22,12 +22,12 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
         {
             if (Group != null)
             {
-                var groupId = Group.GetGroupId(HttpClient, AccessToken);
-                Microsoft365GroupsUtility.RemoveGroupSetting(HttpClient, AccessToken, Identity, groupId.ToString()).GetAwaiter().GetResult();
+                var groupId = Group.GetGroupId(Connection, AccessToken);
+                Microsoft365GroupsUtility.RemoveGroupSetting(Connection, AccessToken, Identity, groupId.ToString()).GetAwaiter().GetResult();
             }
             else
             {
-                Microsoft365GroupsUtility.RemoveGroupSetting(HttpClient, AccessToken, Identity).GetAwaiter().GetResult();
+                Microsoft365GroupsUtility.RemoveGroupSetting(Connection, AccessToken, Identity).GetAwaiter().GetResult();
             }
         }
     }

--- a/src/Commands/Microsoft365Groups/ResetMicrosoft365GroupExpiration.cs
+++ b/src/Commands/Microsoft365Groups/ResetMicrosoft365GroupExpiration.cs
@@ -17,7 +17,7 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
 
         protected override void ExecuteCmdlet()
         {
-            Microsoft365GroupsUtility.RenewAsync(HttpClient, AccessToken, Identity.GetGroupId(HttpClient, AccessToken)).GetAwaiter().GetResult();
+            Microsoft365GroupsUtility.RenewAsync(Connection, AccessToken, Identity.GetGroupId(Connection, AccessToken)).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Commands/Microsoft365Groups/RestoreDeletedMicrosoft365Group.cs
+++ b/src/Commands/Microsoft365Groups/RestoreDeletedMicrosoft365Group.cs
@@ -16,7 +16,7 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
 
         protected override void ExecuteCmdlet()
         {
-            WriteObject(Microsoft365GroupsUtility.RestoreDeletedGroupAsync(HttpClient, Identity.GetDeletedGroupId(HttpClient, AccessToken), AccessToken).GetAwaiter().GetResult());
+            WriteObject(Microsoft365GroupsUtility.RestoreDeletedGroupAsync(Connection, Identity.GetDeletedGroupId(Connection, AccessToken), AccessToken).GetAwaiter().GetResult());
         }
     }
 }

--- a/src/Commands/Microsoft365Groups/SetMicrosoft365Group.cs
+++ b/src/Commands/Microsoft365Groups/SetMicrosoft365Group.cs
@@ -54,7 +54,7 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
 
         protected override void ExecuteCmdlet()
         {
-            var group = Identity.GetGroup(HttpClient, AccessToken, false, false);
+            var group = Identity.GetGroup(Connection, AccessToken, false, false);
 
 
             if (group != null)
@@ -77,17 +77,17 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
                 }
                 if (changed)
                 {
-                    group = Microsoft365GroupsUtility.UpdateAsync(HttpClient, AccessToken, group).GetAwaiter().GetResult();
+                    group = Microsoft365GroupsUtility.UpdateAsync(Connection, AccessToken, group).GetAwaiter().GetResult();
                 }
 
                 if (ParameterSpecified(nameof(Owners)))
                 {
-                    Microsoft365GroupsUtility.UpdateOwnersAsync(HttpClient, group.Id.Value, AccessToken, Owners).GetAwaiter().GetResult();
+                    Microsoft365GroupsUtility.UpdateOwnersAsync(Connection, group.Id.Value, AccessToken, Owners).GetAwaiter().GetResult();
                 }
 
                 if (ParameterSpecified(nameof(Members)))
                 {
-                    Microsoft365GroupsUtility.UpdateMembersAsync(HttpClient, group.Id.Value, AccessToken, Members).GetAwaiter().GetResult();
+                    Microsoft365GroupsUtility.UpdateMembersAsync(Connection, group.Id.Value, AccessToken, Members).GetAwaiter().GetResult();
                 }
 
                 if (ParameterSpecified(nameof(LogoPath)))
@@ -96,14 +96,14 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
                     {
                         LogoPath = Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, LogoPath);
                     }
-                    Microsoft365GroupsUtility.UploadLogoAsync(HttpClient, AccessToken, group.Id.Value, LogoPath).GetAwaiter().GetResult();
+                    Microsoft365GroupsUtility.UploadLogoAsync(Connection, AccessToken, group.Id.Value, LogoPath).GetAwaiter().GetResult();
                 }
 
                 if (ParameterSpecified(nameof(CreateTeam)))
                 {
                     if (!group.ResourceProvisioningOptions.Contains("Team"))
                     {
-                        Microsoft365GroupsUtility.CreateTeamAsync(HttpClient, AccessToken, group.Id.Value).GetAwaiter().GetResult();
+                        Microsoft365GroupsUtility.CreateTeamAsync(Connection, AccessToken, group.Id.Value).GetAwaiter().GetResult();
                     }
                     else
                     {
@@ -114,7 +114,7 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
                 if (ParameterSpecified(nameof(HideFromAddressLists)) || ParameterSpecified(nameof(HideFromOutlookClients)))
                 {
                     // For this scenario a separate call needs to be made
-                    Microsoft365GroupsUtility.SetVisibilityAsync(HttpClient, AccessToken, group.Id.Value, HideFromAddressLists, HideFromOutlookClients).GetAwaiter().GetResult();
+                    Microsoft365GroupsUtility.SetVisibilityAsync(Connection, AccessToken, group.Id.Value, HideFromAddressLists, HideFromOutlookClients).GetAwaiter().GetResult();
                 }
 
                 var assignedLabels = new List<AssignedLabels>();
@@ -133,7 +133,7 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
                                 });
                             }
                         }
-                        Microsoft365GroupsUtility.SetSensitivityLabelsAsync(HttpClient, AccessToken, group.Id.Value, assignedLabels).GetAwaiter().GetResult();
+                        Microsoft365GroupsUtility.SetSensitivityLabelsAsync(Connection, AccessToken, group.Id.Value, assignedLabels).GetAwaiter().GetResult();
                     }
                     else
                     {

--- a/src/Commands/Microsoft365Groups/SetMicrosoft365GroupSettings.cs
+++ b/src/Commands/Microsoft365Groups/SetMicrosoft365GroupSettings.cs
@@ -28,15 +28,15 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
         {
             if (Group != null)
             {
-                var groupId = Group.GetGroupId(HttpClient, AccessToken);
+                var groupId = Group.GetGroupId(Connection, AccessToken);
                 var groupSettingObject = GroupSettingsObject();
 
-                Microsoft365GroupsUtility.UpdateGroupSetting(HttpClient, AccessToken, Identity, groupId.ToString(), groupSettingObject).GetAwaiter().GetResult();
+                Microsoft365GroupsUtility.UpdateGroupSetting(Connection, AccessToken, Identity, groupId.ToString(), groupSettingObject).GetAwaiter().GetResult();
             }
             else
             {
                 var groupSettingObject = GroupSettingsObject();
-                Microsoft365GroupsUtility.UpdateGroupSetting(HttpClient, AccessToken, Identity, groupSettingObject).GetAwaiter().GetResult();
+                Microsoft365GroupsUtility.UpdateGroupSetting(Connection, AccessToken, Identity, groupSettingObject).GetAwaiter().GetResult();
             }
         }
 

--- a/src/Commands/Planner/AddPlannerBucket.cs
+++ b/src/Commands/Planner/AddPlannerBucket.cs
@@ -28,14 +28,14 @@ namespace SharePointPnP.PowerShell.Commands.Graph
         {
             if (ParameterSetName == ParameterName_BYGROUP)
             {
-                var groupId = Group.GetGroupId(HttpClient, AccessToken);
+                var groupId = Group.GetGroupId(Connection, AccessToken);
                 if (groupId != null)
                 {
-                    var planId = Plan.GetIdAsync(HttpClient, AccessToken, groupId).GetAwaiter().GetResult();
+                    var planId = Plan.GetIdAsync(Connection, AccessToken, groupId).GetAwaiter().GetResult();
 
                     if (planId != null)
                     {
-                        WriteObject(PlannerUtility.CreateBucketAsync(HttpClient, AccessToken, Name, planId).GetAwaiter().GetResult(), true);
+                        WriteObject(PlannerUtility.CreateBucketAsync(Connection, AccessToken, Name, planId).GetAwaiter().GetResult(), true);
                     }
                     else
                     {
@@ -49,7 +49,7 @@ namespace SharePointPnP.PowerShell.Commands.Graph
             }
             else if (ParameterSetName == ParameterName_BYPLANID)
             {
-                WriteObject(PlannerUtility.CreateBucketAsync(HttpClient, AccessToken, Name, PlanId).GetAwaiter().GetResult(), true);
+                WriteObject(PlannerUtility.CreateBucketAsync(Connection, AccessToken, Name, PlanId).GetAwaiter().GetResult(), true);
             }
         }
     }

--- a/src/Commands/Planner/AddPlannerRoster.cs
+++ b/src/Commands/Planner/AddPlannerRoster.cs
@@ -11,7 +11,7 @@ namespace SharePointPnP.PowerShell.Commands.Graph
     {
         protected override void ExecuteCmdlet()
         {
-            PlannerUtility.CreateRosterAsync(HttpClient, AccessToken).GetAwaiter().GetResult();
+            PlannerUtility.CreateRosterAsync(Connection, AccessToken).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Commands/Planner/AddPlannerRosterMember.cs
+++ b/src/Commands/Planner/AddPlannerRosterMember.cs
@@ -18,14 +18,14 @@ namespace SharePointPnP.PowerShell.Commands.Graph
 
         protected override void ExecuteCmdlet()
         {
-            var roster = Identity.GetPlannerRosterAsync(HttpClient, AccessToken).GetAwaiter().GetResult();
+            var roster = Identity.GetPlannerRosterAsync(Connection, AccessToken).GetAwaiter().GetResult();
 
             if(roster == null)
             {
                 throw new PSArgumentException("Provided Planner Roster could not be found", nameof(Identity));
             }
 
-            PlannerUtility.AddRosterMemberAsync(HttpClient, AccessToken, roster.Id, User).GetAwaiter().GetResult();
+            PlannerUtility.AddRosterMemberAsync(Connection, AccessToken, roster.Id, User).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Commands/Planner/AddPlannerTask.cs
+++ b/src/Commands/Planner/AddPlannerTask.cs
@@ -94,7 +94,7 @@ namespace PnP.PowerShell.Commands.Planner
                 var chunks = AssignedTo.Chunk(20);
                 foreach (var chunk in chunks)
                 {
-                    var userIds = BatchUtility.GetPropertyBatchedAsync(HttpClient, AccessToken, chunk.ToArray(), "/users/{0}", "id").GetAwaiter().GetResult();
+                    var userIds = BatchUtility.GetPropertyBatchedAsync(Connection, AccessToken, chunk.ToArray(), "/users/{0}", "id").GetAwaiter().GetResult();
                     foreach (var userId in userIds)
                     {
                         newTask.Assignments.Add(userId.Value, new TaskAssignment());
@@ -105,32 +105,32 @@ namespace PnP.PowerShell.Commands.Planner
             // By Group
             if (ParameterSetName == ParameterName_BYGROUP)
             {
-                var groupId = Group.GetGroupId(HttpClient, AccessToken);
+                var groupId = Group.GetGroupId(Connection, AccessToken);
                 if (groupId == null)
                 {
                     throw new PSArgumentException("Group not found", nameof(Group));
                 }
 
-                var planId = Plan.GetIdAsync(HttpClient, AccessToken, groupId).GetAwaiter().GetResult();
+                var planId = Plan.GetIdAsync(Connection, AccessToken, groupId).GetAwaiter().GetResult();
                 if (planId == null)
                 {
                     throw new PSArgumentException("Plan not found", nameof(Plan));
                 }
                 newTask.PlanId = planId;
 
-                var bucket = Bucket.GetBucket(HttpClient, AccessToken, planId);
+                var bucket = Bucket.GetBucket(Connection, AccessToken, planId);
                 if (bucket == null)
                 {
                     throw new PSArgumentException("Bucket not found", nameof(Bucket));
                 }
                 newTask.BucketId = bucket.Id;
 
-                createdTask = PlannerUtility.AddTaskAsync(HttpClient, AccessToken, newTask).GetAwaiter().GetResult();
+                createdTask = PlannerUtility.AddTaskAsync(Connection, AccessToken, newTask).GetAwaiter().GetResult();
             }
             // By PlanId
             else
             {
-                var bucket = Bucket.GetBucket(HttpClient, AccessToken, PlanId);
+                var bucket = Bucket.GetBucket(Connection, AccessToken, PlanId);
                 if (bucket == null)
                 {
                     throw new PSArgumentException("Bucket not found", nameof(Bucket));
@@ -139,13 +139,13 @@ namespace PnP.PowerShell.Commands.Planner
                 newTask.PlanId = PlanId;
                 newTask.BucketId = bucket.Id;
 
-                createdTask = PlannerUtility.AddTaskAsync(HttpClient, AccessToken, newTask).GetAwaiter().GetResult();
+                createdTask = PlannerUtility.AddTaskAsync(Connection, AccessToken, newTask).GetAwaiter().GetResult();
             }
 
             if (ParameterSpecified(nameof(Description)))
             {
-                var existingTaskDetails = PlannerUtility.GetTaskDetailsAsync(HttpClient, AccessToken, createdTask.Id, false).GetAwaiter().GetResult();
-                PlannerUtility.UpdateTaskDetailsAsync(HttpClient, AccessToken, existingTaskDetails, Description).GetAwaiter().GetResult();
+                var existingTaskDetails = PlannerUtility.GetTaskDetailsAsync(Connection, AccessToken, createdTask.Id, false).GetAwaiter().GetResult();
+                PlannerUtility.UpdateTaskDetailsAsync(Connection, AccessToken, existingTaskDetails, Description).GetAwaiter().GetResult();
             }
         }
     }

--- a/src/Commands/Planner/GetPlannerBucket.cs
+++ b/src/Commands/Planner/GetPlannerBucket.cs
@@ -29,19 +29,19 @@ namespace PnP.PowerShell.Commands.Planner
         {
             if (ParameterSetName == ParameterName_BYGROUP)
             {
-                var groupId = Group.GetGroupId(HttpClient, AccessToken);
+                var groupId = Group.GetGroupId(Connection, AccessToken);
                 if (groupId != null)
                 {
-                    var planId = Plan.GetIdAsync(HttpClient, AccessToken, groupId).GetAwaiter().GetResult();
+                    var planId = Plan.GetIdAsync(Connection, AccessToken, groupId).GetAwaiter().GetResult();
                     if (planId != null)
                     {
                         if (!ParameterSpecified(nameof(Identity)))
                         {
-                            WriteObject(PlannerUtility.GetBucketsAsync(HttpClient, AccessToken, planId).GetAwaiter().GetResult(), true);
+                            WriteObject(PlannerUtility.GetBucketsAsync(Connection, AccessToken, planId).GetAwaiter().GetResult(), true);
                         }
                         else
                         {
-                            WriteObject(Identity.GetBucket(HttpClient, AccessToken, planId));
+                            WriteObject(Identity.GetBucket(Connection, AccessToken, planId));
                         }
                     }
                     else
@@ -56,7 +56,7 @@ namespace PnP.PowerShell.Commands.Planner
             }
             else
             {
-                WriteObject(PlannerUtility.GetBucketsAsync(HttpClient, AccessToken, PlanId).GetAwaiter().GetResult(), true);
+                WriteObject(PlannerUtility.GetBucketsAsync(Connection, AccessToken, PlanId).GetAwaiter().GetResult(), true);
             }
         }
     }

--- a/src/Commands/Planner/GetPlannerConfiguration.cs
+++ b/src/Commands/Planner/GetPlannerConfiguration.cs
@@ -11,7 +11,7 @@ namespace PnP.PowerShell.Commands.Planner
     {
         protected override void ExecuteCmdlet()
         {
-            var result = PlannerUtility.GetPlannerConfigAsync(HttpClient, AccessToken).GetAwaiter().GetResult();
+            var result = PlannerUtility.GetPlannerConfigAsync(Connection, AccessToken).GetAwaiter().GetResult();
             WriteObject(result);
         }
     }

--- a/src/Commands/Planner/GetPlannerPlan.cs
+++ b/src/Commands/Planner/GetPlannerPlan.cs
@@ -29,16 +29,16 @@ namespace PnP.PowerShell.Commands.Planner
         {
             if (ParameterSetName == ParameterName_BYGROUP)
             {
-                var groupId = Group.GetGroupId(HttpClient, AccessToken);
+                var groupId = Group.GetGroupId(Connection, AccessToken);
                 if (groupId != null)
                 {
                     if (ParameterSpecified(nameof(Identity)))
                     {
-                        WriteObject(Identity.GetPlanAsync(HttpClient, AccessToken, groupId, ResolveIdentities).GetAwaiter().GetResult());
+                        WriteObject(Identity.GetPlanAsync(Connection, AccessToken, groupId, ResolveIdentities).GetAwaiter().GetResult());
                     }
                     else
                     {
-                        WriteObject(PlannerUtility.GetPlansAsync(HttpClient, AccessToken, groupId, ResolveIdentities).GetAwaiter().GetResult(), true);
+                        WriteObject(PlannerUtility.GetPlansAsync(Connection, AccessToken, groupId, ResolveIdentities).GetAwaiter().GetResult(), true);
                     }
                 }
                 else
@@ -48,7 +48,7 @@ namespace PnP.PowerShell.Commands.Planner
             }
             else
             {
-                WriteObject(PlannerUtility.GetPlanAsync(HttpClient, AccessToken, Id, ResolveIdentities).GetAwaiter().GetResult());
+                WriteObject(PlannerUtility.GetPlanAsync(Connection, AccessToken, Id, ResolveIdentities).GetAwaiter().GetResult());
             }
         }
     }

--- a/src/Commands/Planner/GetPlannerRosterMember.cs
+++ b/src/Commands/Planner/GetPlannerRosterMember.cs
@@ -15,14 +15,14 @@ namespace SharePointPnP.PowerShell.Commands.Graph
 
         protected override void ExecuteCmdlet()
         {
-            var roster = Identity.GetPlannerRosterAsync(HttpClient, AccessToken).GetAwaiter().GetResult();
+            var roster = Identity.GetPlannerRosterAsync(Connection, AccessToken).GetAwaiter().GetResult();
 
             if(roster == null)
             {
                 throw new PSArgumentException("Provided Planner Roster could not be found", nameof(Identity));
             }
 
-            PlannerUtility.GetRosterMembersAsync(HttpClient, AccessToken, roster.Id).GetAwaiter().GetResult();
+            PlannerUtility.GetRosterMembersAsync(Connection, AccessToken, roster.Id).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Commands/Planner/GetPlannerRosterPlan.cs
+++ b/src/Commands/Planner/GetPlannerRosterPlan.cs
@@ -24,16 +24,16 @@ namespace PnP.PowerShell.Commands.Planner
             switch (ParameterSetName)
             {
                 case ParameterSet_BYUSER:
-                    WriteObject(PlannerUtility.GetRosterPlansByUserAsync(HttpClient, AccessToken, User).GetAwaiter().GetResult(), true);
+                    WriteObject(PlannerUtility.GetRosterPlansByUserAsync(Connection, AccessToken, User).GetAwaiter().GetResult(), true);
                     break;
                     
                 case ParameterSet_BYROSTER:
-                    var plannerRoster = Identity.GetPlannerRosterAsync(HttpClient, AccessToken).GetAwaiter().GetResult();
+                    var plannerRoster = Identity.GetPlannerRosterAsync(Connection, AccessToken).GetAwaiter().GetResult();
                     if (plannerRoster == null)
                     {
                         throw new PSArgumentException($"Planner Roster provided through {nameof(Identity)} could not be found", nameof(Identity));
                     }
-                    WriteObject(PlannerUtility.GetRosterPlansByRosterAsync(HttpClient, AccessToken, plannerRoster.Id).GetAwaiter().GetResult(), true);
+                    WriteObject(PlannerUtility.GetRosterPlansByRosterAsync(Connection, AccessToken, plannerRoster.Id).GetAwaiter().GetResult(), true);
                     break;
             }
         }

--- a/src/Commands/Planner/GetPlannerTask.cs
+++ b/src/Commands/Planner/GetPlannerTask.cs
@@ -40,13 +40,13 @@ namespace PnP.PowerShell.Commands.Planner
         {
             if (ParameterSetName == ParameterSetName_BYGROUP)
             {
-                var groupId = Group.GetGroupId(HttpClient, AccessToken);
+                var groupId = Group.GetGroupId(Connection, AccessToken);
                 if (groupId != null)
                 {
-                    var planId = Plan.GetIdAsync(HttpClient, AccessToken, groupId).GetAwaiter().GetResult();
+                    var planId = Plan.GetIdAsync(Connection, AccessToken, groupId).GetAwaiter().GetResult();
                     if (planId != null)
                     {
-                        WriteObject(PlannerUtility.GetTasksAsync(HttpClient, AccessToken, planId, ResolveUserDisplayNames).GetAwaiter().GetResult(), true);
+                        WriteObject(PlannerUtility.GetTasksAsync(Connection, AccessToken, planId, ResolveUserDisplayNames).GetAwaiter().GetResult(), true);
                     }
                     else
                     {
@@ -60,15 +60,15 @@ namespace PnP.PowerShell.Commands.Planner
             }
             else if (ParameterSetName == ParameterSetName_BYPLANID)
             {
-                WriteObject(PlannerUtility.GetTasksAsync(HttpClient, AccessToken, PlanId, ResolveUserDisplayNames).GetAwaiter().GetResult(), true);
+                WriteObject(PlannerUtility.GetTasksAsync(Connection, AccessToken, PlanId, ResolveUserDisplayNames).GetAwaiter().GetResult(), true);
             }
             else if (ParameterSetName == ParameterSetName_BYBUCKET)
             {
-                WriteObject(PlannerUtility.GetBucketTasksAsync(HttpClient, AccessToken, Bucket.GetId(), ResolveUserDisplayNames).GetAwaiter().GetResult(), true);
+                WriteObject(PlannerUtility.GetBucketTasksAsync(Connection, AccessToken, Bucket.GetId(), ResolveUserDisplayNames).GetAwaiter().GetResult(), true);
             }
             else if (ParameterSetName == ParameterSetName_BYTASKID)
             {
-                WriteObject(PlannerUtility.GetTaskAsync(HttpClient, AccessToken, TaskId, ResolveUserDisplayNames, IncludeDetails).GetAwaiter().GetResult());
+                WriteObject(PlannerUtility.GetTaskAsync(Connection, AccessToken, TaskId, ResolveUserDisplayNames, IncludeDetails).GetAwaiter().GetResult());
             }
         }
     }

--- a/src/Commands/Planner/GetPlannerUserPolicy.cs
+++ b/src/Commands/Planner/GetPlannerUserPolicy.cs
@@ -13,7 +13,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
         public string Identity;
         protected override void ExecuteCmdlet()
         {
-            var result = PlannerUtility.GetPlannerUserPolicyAsync(HttpClient, AccessToken, Identity).GetAwaiter().GetResult();
+            var result = PlannerUtility.GetPlannerUserPolicyAsync(Connection, AccessToken, Identity).GetAwaiter().GetResult();
             WriteObject(result);
         }
     }

--- a/src/Commands/Planner/NewPlannerPlan.cs
+++ b/src/Commands/Planner/NewPlannerPlan.cs
@@ -17,10 +17,10 @@ namespace PnP.PowerShell.Commands.Planner
         public string Title;
         protected override void ExecuteCmdlet()
         {
-            var groupId = Group.GetGroupId(HttpClient, AccessToken);
+            var groupId = Group.GetGroupId(Connection, AccessToken);
             if (groupId != null)
             {
-                WriteObject(PlannerUtility.CreatePlanAsync(HttpClient, AccessToken, groupId, Title).GetAwaiter().GetResult());
+                WriteObject(PlannerUtility.CreatePlanAsync(Connection, AccessToken, groupId, Title).GetAwaiter().GetResult());
             }
             else
             {

--- a/src/Commands/Planner/RemovePlannerBucket.cs
+++ b/src/Commands/Planner/RemovePlannerBucket.cs
@@ -28,19 +28,19 @@ namespace SharePointPnP.PowerShell.Commands.Graph
         {
             if (ParameterSetName == ParameterName_BYNAME)
             {
-                var groupId = Group.GetGroupId(HttpClient, AccessToken);
+                var groupId = Group.GetGroupId(Connection, AccessToken);
                 if (groupId != null)
                 {
-                    var planId = Plan.GetIdAsync(HttpClient, AccessToken, groupId).GetAwaiter().GetResult();
+                    var planId = Plan.GetIdAsync(Connection, AccessToken, groupId).GetAwaiter().GetResult();
 
                     if (planId != null)
                     {
-                        var bucket = Identity.GetBucket(HttpClient, AccessToken, planId);
+                        var bucket = Identity.GetBucket(Connection, AccessToken, planId);
                         if (bucket != null)
                         {
                             if (ShouldProcess($"Remove bucket '{bucket.Name}'"))
                             {
-                                PlannerUtility.RemoveBucketAsync(HttpClient, AccessToken, bucket.Id).GetAwaiter().GetResult();
+                                PlannerUtility.RemoveBucketAsync(Connection, AccessToken, bucket.Id).GetAwaiter().GetResult();
                             }
                         }
                         else
@@ -60,12 +60,12 @@ namespace SharePointPnP.PowerShell.Commands.Graph
             }
             else if (ParameterSetName == ParameterName_BYBUCKETID)
             {
-                var bucket = Identity.GetBucket(HttpClient, AccessToken, BucketId);
+                var bucket = Identity.GetBucket(Connection, AccessToken, BucketId);
                 if (bucket != null)
                 {
                     if (ShouldProcess($"Remove bucket '{bucket.Name}'"))
                     {
-                        PlannerUtility.RemoveBucketAsync(HttpClient, AccessToken, BucketId).GetAwaiter().GetResult();
+                        PlannerUtility.RemoveBucketAsync(Connection, AccessToken, BucketId).GetAwaiter().GetResult();
                     }
                 }
                 else

--- a/src/Commands/Planner/RemovePlannerPlan.cs
+++ b/src/Commands/Planner/RemovePlannerPlan.cs
@@ -19,15 +19,15 @@ namespace PnP.PowerShell.Commands.Planner
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Group.GetGroupId(HttpClient, AccessToken);
+            var groupId = Group.GetGroupId(Connection, AccessToken);
             if (groupId != null)
             {
-                var planId = Identity.GetIdAsync(HttpClient, AccessToken, groupId).GetAwaiter().GetResult();
+                var planId = Identity.GetIdAsync(Connection, AccessToken, groupId).GetAwaiter().GetResult();
                 if (!string.IsNullOrEmpty(planId))
                 {
                     if (ShouldProcess($"Delete plan with id {planId}"))
                     {
-                        PlannerUtility.DeletePlanAsync(HttpClient, AccessToken, planId).GetAwaiter().GetResult();
+                        PlannerUtility.DeletePlanAsync(Connection, AccessToken, planId).GetAwaiter().GetResult();
                     }
                 }
                 else

--- a/src/Commands/Planner/RemovePlannerRoster.cs
+++ b/src/Commands/Planner/RemovePlannerRoster.cs
@@ -15,14 +15,14 @@ namespace PnP.PowerShell.Commands.Planner
 
         protected override void ExecuteCmdlet()
         {
-            var roster = Identity.GetPlannerRosterAsync(HttpClient, AccessToken).GetAwaiter().GetResult();
+            var roster = Identity.GetPlannerRosterAsync(Connection, AccessToken).GetAwaiter().GetResult();
 
             if(roster == null)
             {
                 throw new PSArgumentException("Provided Planner Roster could not be found", nameof(Identity));
             }
 
-            PlannerUtility.DeleteRosterAsync(HttpClient, AccessToken, roster.Id).GetAwaiter().GetResult();
+            PlannerUtility.DeleteRosterAsync(Connection, AccessToken, roster.Id).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Commands/Planner/RemovePlannerRosterMember.cs
+++ b/src/Commands/Planner/RemovePlannerRosterMember.cs
@@ -18,14 +18,14 @@ namespace SharePointPnP.PowerShell.Commands.Graph
 
         protected override void ExecuteCmdlet()
         {
-            var roster = Identity.GetPlannerRosterAsync(HttpClient, AccessToken).GetAwaiter().GetResult();
+            var roster = Identity.GetPlannerRosterAsync(Connection, AccessToken).GetAwaiter().GetResult();
 
             if(roster == null)
             {
                 throw new PSArgumentException("Provided Planner Roster could not be found", nameof(Identity));
             }
 
-            PlannerUtility.RemoveRosterMemberAsync(HttpClient, AccessToken, roster.Id, User).GetAwaiter().GetResult();
+            PlannerUtility.RemoveRosterMemberAsync(Connection, AccessToken, roster.Id, User).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Commands/Planner/RemovePlannerTask.cs
+++ b/src/Commands/Planner/RemovePlannerTask.cs
@@ -15,7 +15,7 @@ namespace PnP.PowerShell.Commands.Planner
 
         protected override void ExecuteCmdlet()
         {
-            PlannerUtility.DeleteTaskAsync(HttpClient, AccessToken, Task.Id).GetAwaiter().GetResult();
+            PlannerUtility.DeleteTaskAsync(Connection, AccessToken, Task.Id).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Commands/Planner/SetPlannerBucket.cs
+++ b/src/Commands/Planner/SetPlannerBucket.cs
@@ -33,17 +33,17 @@ namespace PnP.PowerShell.Commands.Graph
         {
             if (ParameterSetName == ParameterName_BYGROUP)
             {
-                var groupId = Group.GetGroupId(HttpClient, AccessToken);
+                var groupId = Group.GetGroupId(Connection, AccessToken);
                 if (groupId != null)
                 {
-                    var planId = Plan.GetIdAsync(HttpClient, AccessToken, groupId).GetAwaiter().GetResult();
+                    var planId = Plan.GetIdAsync(Connection, AccessToken, groupId).GetAwaiter().GetResult();
                     if (planId != null)
                     {
 
-                        var bucket = Bucket.GetBucket(HttpClient, AccessToken, planId);
+                        var bucket = Bucket.GetBucket(Connection, AccessToken, planId);
                         if (bucket != null)
                         {
-                            WriteObject(PlannerUtility.UpdateBucketAsync(HttpClient, AccessToken, Name, bucket.Id).GetAwaiter().GetResult());
+                            WriteObject(PlannerUtility.UpdateBucketAsync(Connection, AccessToken, Name, bucket.Id).GetAwaiter().GetResult());
                         }
                         else
                         {
@@ -62,10 +62,10 @@ namespace PnP.PowerShell.Commands.Graph
             }
             else
             {
-                var bucket = Bucket.GetBucket(HttpClient, AccessToken, PlanId);
+                var bucket = Bucket.GetBucket(Connection, AccessToken, PlanId);
                 if (bucket != null)
                 {
-                    WriteObject(PlannerUtility.UpdateBucketAsync(HttpClient, AccessToken, Name, bucket.Id).GetAwaiter().GetResult());
+                    WriteObject(PlannerUtility.UpdateBucketAsync(Connection, AccessToken, Name, bucket.Id).GetAwaiter().GetResult());
                 }
                 else
                 {

--- a/src/Commands/Planner/SetPlannerConfiguration.cs
+++ b/src/Commands/Planner/SetPlannerConfiguration.cs
@@ -29,7 +29,7 @@ namespace PnP.PowerShell.Commands.Planner
 
         protected override void ExecuteCmdlet()
         {
-            var result = PlannerUtility.SetPlannerConfigAsync(HttpClient, AccessToken, IsPlannerAllowed, AllowCalendarSharing, AllowTenantMoveWithDataLoss, AllowTenantMoveWithDataMigration, AllowRosterCreation, AllowPlannerMobilePushNotifications).GetAwaiter().GetResult();
+            var result = PlannerUtility.SetPlannerConfigAsync(Connection, AccessToken, IsPlannerAllowed, AllowCalendarSharing, AllowTenantMoveWithDataLoss, AllowTenantMoveWithDataMigration, AllowRosterCreation, AllowPlannerMobilePushNotifications).GetAwaiter().GetResult();
             WriteObject(result);
         }
     }

--- a/src/Commands/Planner/SetPlannerPlan.cs
+++ b/src/Commands/Planner/SetPlannerPlan.cs
@@ -29,13 +29,13 @@ namespace PnP.PowerShell.Commands.Graph
         {
             if (ParameterSetName == ParameterName_BYGROUP)
             {
-                var groupId = Group.GetGroupId(HttpClient, AccessToken);
+                var groupId = Group.GetGroupId(Connection, AccessToken);
                 if (groupId != null)
                 {
-                    var plan = Plan.GetPlanAsync(HttpClient, AccessToken, groupId, false).GetAwaiter().GetResult();
+                    var plan = Plan.GetPlanAsync(Connection, AccessToken, groupId, false).GetAwaiter().GetResult();
                     if (plan != null)
                     {
-                        WriteObject(PlannerUtility.UpdatePlanAsync(HttpClient, AccessToken, plan, Title).GetAwaiter().GetResult());
+                        WriteObject(PlannerUtility.UpdatePlanAsync(Connection, AccessToken, plan, Title).GetAwaiter().GetResult());
                     }
                     else
                     {
@@ -49,10 +49,10 @@ namespace PnP.PowerShell.Commands.Graph
             }
             else
             {
-                var plan = PlannerUtility.GetPlanAsync(HttpClient, AccessToken, PlanId, false).GetAwaiter().GetResult();
+                var plan = PlannerUtility.GetPlanAsync(Connection, AccessToken, PlanId, false).GetAwaiter().GetResult();
                 if (plan != null)
                 {
-                    WriteObject(PlannerUtility.UpdatePlanAsync(HttpClient, AccessToken, plan, Title).GetAwaiter().GetResult());
+                    WriteObject(PlannerUtility.UpdatePlanAsync(Connection, AccessToken, plan, Title).GetAwaiter().GetResult());
                 }
                 else
                 {

--- a/src/Commands/Planner/SetPlannerTask.cs
+++ b/src/Commands/Planner/SetPlannerTask.cs
@@ -43,7 +43,7 @@ namespace PnP.PowerShell.Commands.Planner
 
         protected override void ExecuteCmdlet()
         {
-            var existingTask = PlannerUtility.GetTaskAsync(HttpClient, AccessToken, TaskId, false, false).GetAwaiter().GetResult();
+            var existingTask = PlannerUtility.GetTaskAsync(Connection, AccessToken, TaskId, false, false).GetAwaiter().GetResult();
             if (existingTask != null)
             {
                 var plannerTask = new PlannerTask();
@@ -53,7 +53,7 @@ namespace PnP.PowerShell.Commands.Planner
                 }
                 if (ParameterSpecified(nameof(Bucket)))
                 {
-                    var bucket = Bucket.GetBucket(HttpClient, AccessToken, existingTask.PlanId);
+                    var bucket = Bucket.GetBucket(Connection, AccessToken, existingTask.PlanId);
                     if (bucket != null)
                     {
                         plannerTask.BucketId = bucket.Id;
@@ -90,7 +90,7 @@ namespace PnP.PowerShell.Commands.Planner
                     var chunks = BatchUtility.Chunk(AssignedTo, 20);
                     foreach (var chunk in chunks)
                     {
-                        var userIds = BatchUtility.GetPropertyBatchedAsync(HttpClient, AccessToken, chunk.ToArray(), "/users/{0}", "id").GetAwaiter().GetResult();
+                        var userIds = BatchUtility.GetPropertyBatchedAsync(Connection, AccessToken, chunk.ToArray(), "/users/{0}", "id").GetAwaiter().GetResult();
                         foreach (var userId in userIds)
                         {
                             plannerTask.Assignments.Add(userId.Value, new TaskAssignment());
@@ -106,12 +106,12 @@ namespace PnP.PowerShell.Commands.Planner
                 }
 
 
-                PlannerUtility.UpdateTaskAsync(HttpClient, AccessToken, existingTask, plannerTask).GetAwaiter().GetResult();
+                PlannerUtility.UpdateTaskAsync(Connection, AccessToken, existingTask, plannerTask).GetAwaiter().GetResult();
 
                 if (ParameterSpecified(nameof(Description)))
                 {
-                    var existingTaskDetails = PlannerUtility.GetTaskDetailsAsync(HttpClient, AccessToken, TaskId, false).GetAwaiter().GetResult();
-                    PlannerUtility.UpdateTaskDetailsAsync(HttpClient, AccessToken, existingTaskDetails, Description).GetAwaiter().GetResult();
+                    var existingTaskDetails = PlannerUtility.GetTaskDetailsAsync(Connection, AccessToken, TaskId, false).GetAwaiter().GetResult();
+                    PlannerUtility.UpdateTaskDetailsAsync(Connection, AccessToken, existingTaskDetails, Description).GetAwaiter().GetResult();
                 }
             }
             else

--- a/src/Commands/Planner/SetPlannerUserPolicy.cs
+++ b/src/Commands/Planner/SetPlannerUserPolicy.cs
@@ -17,7 +17,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
 
         protected override void ExecuteCmdlet()
         {
-            var result = PlannerUtility.SetPlannerUserPolicyAsync(HttpClient, AccessToken, Identity, BlockDeleteTasksNotCreatedBySelf).GetAwaiter().GetResult();
+            var result = PlannerUtility.SetPlannerUserPolicyAsync(Connection, AccessToken, Identity, BlockDeleteTasksNotCreatedBySelf).GetAwaiter().GetResult();
             WriteObject(result);
         }
     }

--- a/src/Commands/PowerPlatform/Environment/GetPowerPlatformEnvironment.cs
+++ b/src/Commands/PowerPlatform/Environment/GetPowerPlatformEnvironment.cs
@@ -17,7 +17,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.Environment
 
         protected override void ExecuteCmdlet()
         {
-            var environments = GraphHelper.GetResultCollectionAsync<Model.PowerPlatform.Environment.Environment>(HttpClient, "https://management.azure.com/providers/Microsoft.ProcessSimple/environments?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
+            var environments = GraphHelper.GetResultCollectionAsync<Model.PowerPlatform.Environment.Environment>(Connection, "https://management.azure.com/providers/Microsoft.ProcessSimple/environments?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
 
             if(ParameterSpecified(nameof(IsDefault)) && IsDefault.HasValue)
             {

--- a/src/Commands/PowerPlatform/PowerAutomate/DisableFlow.cs
+++ b/src/Commands/PowerPlatform/PowerAutomate/DisableFlow.cs
@@ -23,7 +23,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
         {
             var environmentName = Environment.GetName();
             var flowName = Identity.GetName();
-            RestHelper.PostAsync(HttpClient, $"https://management.azure.com/providers/Microsoft.ProcessSimple{(AsAdmin ? "/scopes/admin" : "")}/environments/{environmentName}/flows/{flowName}/stop?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
+            RestHelper.PostAsync(Connection.HttpClient, $"https://management.azure.com/providers/Microsoft.ProcessSimple{(AsAdmin ? "/scopes/admin" : "")}/environments/{environmentName}/flows/{flowName}/stop?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Commands/PowerPlatform/PowerAutomate/EnableFlow.cs
+++ b/src/Commands/PowerPlatform/PowerAutomate/EnableFlow.cs
@@ -23,7 +23,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
         {
             var environmentName = Environment.GetName();
             var flowName = Identity.GetName();
-            RestHelper.PostAsync(HttpClient, $"https://management.azure.com/providers/Microsoft.ProcessSimple{(AsAdmin ? "/scopes/admin" : "")}/environments/{environmentName}/flows/{flowName}/start?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
+            RestHelper.PostAsync(Connection.HttpClient, $"https://management.azure.com/providers/Microsoft.ProcessSimple{(AsAdmin ? "/scopes/admin" : "")}/environments/{environmentName}/flows/{flowName}/start?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Commands/PowerPlatform/PowerAutomate/ExportFlow.cs
+++ b/src/Commands/PowerPlatform/PowerAutomate/ExportFlow.cs
@@ -77,7 +77,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
                     $"/providers/Microsoft.Flow/flows/{flowName}"
                 }
                 };
-                var wrapper = RestHelper.PostAsync<Model.PowerPlatform.PowerAutomate.FlowExportPackageWrapper>(HttpClient, $"https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/environments/{environmentName}/listPackageResources?api-version=2016-11-01", AccessToken, payload: postData).GetAwaiter().GetResult();
+                var wrapper = RestHelper.PostAsync<Model.PowerPlatform.PowerAutomate.FlowExportPackageWrapper>(Connection.HttpClient, $"https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/environments/{environmentName}/listPackageResources?api-version=2016-11-01", AccessToken, payload: postData).GetAwaiter().GetResult();
 
                 if (wrapper.Status == Model.PowerPlatform.PowerAutomate.Enums.FlowExportStatus.Succeeded)
                 {
@@ -110,7 +110,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
                         resources = wrapper.Resources
                     };
 
-                    var resultElement = RestHelper.PostAsync<JsonElement>(HttpClient, $"https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/environments/{environmentName}/exportPackage?api-version=2016-11-01", AccessToken, payload: exportPostData).GetAwaiter().GetResult();
+                    var resultElement = RestHelper.PostAsync<JsonElement>(Connection.HttpClient, $"https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/environments/{environmentName}/exportPackage?api-version=2016-11-01", AccessToken, payload: exportPostData).GetAwaiter().GetResult();
                     if (resultElement.TryGetProperty("status", out JsonElement statusElement))
                     {
                         if (statusElement.GetString() == "Succeeded")
@@ -123,7 +123,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
                                     using (var requestMessage = new HttpRequestMessage(HttpMethod.Get, packageLink))
                                     {
                                         //requestMessage.Headers.Add("Authorization", $"Bearer {AccessToken}");
-                                        var response = HttpClient.SendAsync(requestMessage).GetAwaiter().GetResult();
+                                        var response = Connection.HttpClient.SendAsync(requestMessage).GetAwaiter().GetResult();
                                         var byteArray = response.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult();
                                         var fileName = string.Empty;
                                         if (ParameterSpecified(nameof(OutPath)))
@@ -161,7 +161,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
             }
             else
             {
-                var json = RestHelper.PostAsync(HttpClient, $"https://management.azure.com/providers/Microsoft.ProcessSimple/environments/{environmentName}/flows/{flowName}/exportToARMTemplate?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
+                var json = RestHelper.PostAsync(Connection.HttpClient, $"https://management.azure.com/providers/Microsoft.ProcessSimple/environments/{environmentName}/flows/{flowName}/exportToARMTemplate?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
                 WriteObject(json);
             }
         }

--- a/src/Commands/PowerPlatform/PowerAutomate/GetFlow.cs
+++ b/src/Commands/PowerPlatform/PowerAutomate/GetFlow.cs
@@ -28,12 +28,12 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
             if (ParameterSpecified(nameof(Identity)))
             {
                 var flowName = Identity.GetName();
-                var result = GraphHelper.GetAsync<Model.PowerPlatform.PowerAutomate.Flow>(HttpClient, $"https://management.azure.com/providers/Microsoft.ProcessSimple{(AsAdmin ? "/scopes/admin" : "")}/environments/{environmentName}/flows/{flowName}?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
+                var result = GraphHelper.GetAsync<Model.PowerPlatform.PowerAutomate.Flow>(Connection, $"https://management.azure.com/providers/Microsoft.ProcessSimple{(AsAdmin ? "/scopes/admin" : "")}/environments/{environmentName}/flows/{flowName}?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
                 WriteObject(result, false);
             }
             else
             {
-                var flows = GraphHelper.GetResultCollectionAsync<Model.PowerPlatform.PowerAutomate.Flow>(HttpClient, $"https://management.azure.com/providers/Microsoft.ProcessSimple{(AsAdmin ? "/scopes/admin" : "")}/environments/{environmentName}/flows?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
+                var flows = GraphHelper.GetResultCollectionAsync<Model.PowerPlatform.PowerAutomate.Flow>(Connection, $"https://management.azure.com/providers/Microsoft.ProcessSimple{(AsAdmin ? "/scopes/admin" : "")}/environments/{environmentName}/flows?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
                 WriteObject(flows, true);
             }
         }

--- a/src/Commands/PowerPlatform/PowerAutomate/GetFlowRun.cs
+++ b/src/Commands/PowerPlatform/PowerAutomate/GetFlowRun.cs
@@ -37,12 +37,12 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
             if (ParameterSpecified(nameof(Identity)))
             {
                 var flowRunName = Identity.GetName();
-                var flowRun = GraphHelper.GetAsync<FlowRun>(HttpClient, $"https://management.azure.com/providers/Microsoft.ProcessSimple/environments/{environmentName}/flows/{flowName}/runs/{flowRunName}?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
+                var flowRun = GraphHelper.GetAsync<FlowRun>(Connection, $"https://management.azure.com/providers/Microsoft.ProcessSimple/environments/{environmentName}/flows/{flowName}/runs/{flowRunName}?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
                 WriteObject(flowRun, false);
             }
             else
             {
-                var flowRuns = GraphHelper.GetResultCollectionAsync<FlowRun>(HttpClient, $"https://management.azure.com/providers/Microsoft.ProcessSimple/environments/{environmentName}/flows/{flowName}/runs?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
+                var flowRuns = GraphHelper.GetResultCollectionAsync<FlowRun>(Connection, $"https://management.azure.com/providers/Microsoft.ProcessSimple/environments/{environmentName}/flows/{flowName}/runs?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
                 WriteObject(flowRuns, true);
             }
         }

--- a/src/Commands/PowerPlatform/PowerAutomate/RemoveFlow.cs
+++ b/src/Commands/PowerPlatform/PowerAutomate/RemoveFlow.cs
@@ -29,7 +29,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
 
             if (Force || ShouldContinue($"Remove flow with name '{flowName}'?", "Remove flow"))
             {
-                var result = RestHelper.DeleteAsync<RestResultCollection<Model.PowerPlatform.PowerAutomate.Flow>>(HttpClient, $"https://management.azure.com/providers/Microsoft.ProcessSimple{(AsAdmin ? "/scopes/admin" : "")}/environments/{environmentName}/flows/{flowName}?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
+                var result = RestHelper.DeleteAsync<RestResultCollection<Model.PowerPlatform.PowerAutomate.Flow>>(Connection.HttpClient, $"https://management.azure.com/providers/Microsoft.ProcessSimple{(AsAdmin ? "/scopes/admin" : "")}/environments/{environmentName}/flows/{flowName}?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
             }
         }
     }

--- a/src/Commands/PowerPlatform/PowerAutomate/RestartFlowRun.cs
+++ b/src/Commands/PowerPlatform/PowerAutomate/RestartFlowRun.cs
@@ -48,8 +48,8 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
             if (!Force && !ShouldContinue($"Restart flow run with name '{flowRunName}'?", Resources.Confirm))
                 return;
 
-            var triggers = GraphHelper.GetResultCollectionAsync<FlowRunTrigger>(HttpClient, $"https://management.azure.com/providers/Microsoft.ProcessSimple/environments/{environmentName}/flows/{flowName}/triggers?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
-            RestHelper.PostAsync(HttpClient, $"https://management.azure.com/providers/Microsoft.ProcessSimple/environments/{environmentName}/flows/{flowName}/triggers/{triggers.First().Name}/histories/{flowRunName}/resubmit?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
+            var triggers = GraphHelper.GetResultCollectionAsync<FlowRunTrigger>(Connection, $"https://management.azure.com/providers/Microsoft.ProcessSimple/environments/{environmentName}/flows/{flowName}/triggers?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
+            RestHelper.PostAsync(Connection.HttpClient, $"https://management.azure.com/providers/Microsoft.ProcessSimple/environments/{environmentName}/flows/{flowName}/triggers/{triggers.First().Name}/histories/{flowRunName}/resubmit?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Commands/PowerPlatform/PowerAutomate/StopFlowRun.cs
+++ b/src/Commands/PowerPlatform/PowerAutomate/StopFlowRun.cs
@@ -45,7 +45,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
 
             if (Force || ShouldContinue($"Stop flow run with name '{flowRunName}'?", Resources.Confirm))
             {
-                RestHelper.PostAsync(HttpClient, $"https://management.azure.com/providers/Microsoft.ProcessSimple/environments/{environmentName}/flows/{flowName}/runs/{flowRunName}/cancel?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
+                RestHelper.PostAsync(Connection.HttpClient, $"https://management.azure.com/providers/Microsoft.ProcessSimple/environments/{environmentName}/flows/{flowName}/runs/{flowRunName}/cancel?api-version=2016-11-01", AccessToken).GetAwaiter().GetResult();
             }
         }
     }

--- a/src/Commands/Properties/Resources.resx
+++ b/src/Commands/Properties/Resources.resx
@@ -322,7 +322,7 @@
     <value>Unable to retrieve a token for {0}. Ensure you connect using one of the Connect-PnPOnline commands which uses the -ClientId argument or use Connect-PnPOnline -Scopes to connect.</value>
   </data>
   <data name="NoConnection" xml:space="preserve">
-    <value>There is currently no connection yet. Use Connect-PnPOnline to connect.</value>
+    <value>There is currently no connection yet. Use Connect-PnPOnline to connect or provide a valid connection using -Connection.</value>
   </data>
   <data name="AccessTokenConnectFailed" xml:space="preserve">
     <value>No URL specified nor does the provided access token contain an audience</value>

--- a/src/Commands/ServiceHealth/GetMessageCenterAnnouncement.cs
+++ b/src/Commands/ServiceHealth/GetMessageCenterAnnouncement.cs
@@ -16,11 +16,11 @@ namespace PnP.PowerShell.Commands.ServiceHealth
         {
             if (ParameterSpecified(nameof(Identity)))
             {
-                WriteObject(ServiceHealthUtility.GetServiceUpdateMessageByIdAsync(Identity, HttpClient, AccessToken).GetAwaiter().GetResult(), false);
+                WriteObject(ServiceHealthUtility.GetServiceUpdateMessageByIdAsync(Identity, Connection, AccessToken).GetAwaiter().GetResult(), false);
             }
             else
             {
-                WriteObject(ServiceHealthUtility.GetServiceUpdateMessagesAsync(HttpClient, AccessToken).GetAwaiter().GetResult(), true);
+                WriteObject(ServiceHealthUtility.GetServiceUpdateMessagesAsync(Connection, AccessToken).GetAwaiter().GetResult(), true);
             }
         }        
     }

--- a/src/Commands/ServiceHealth/GetServiceCurrentHealth.cs
+++ b/src/Commands/ServiceHealth/GetServiceCurrentHealth.cs
@@ -16,11 +16,11 @@ namespace PnP.PowerShell.Commands.ServiceHealth
         {
             if (ParameterSpecified(nameof(Identity)))
             {
-                WriteObject(ServiceHealthUtility.GetServiceCurrentHealthByIdAsync(Identity, HttpClient, AccessToken).GetAwaiter().GetResult(), false);
+                WriteObject(ServiceHealthUtility.GetServiceCurrentHealthByIdAsync(Identity, Connection, AccessToken).GetAwaiter().GetResult(), false);
             }
             else
             {
-                WriteObject(ServiceHealthUtility.GetServiceCurrentHealthAsync(HttpClient, AccessToken).GetAwaiter().GetResult(), true);
+                WriteObject(ServiceHealthUtility.GetServiceCurrentHealthAsync(Connection, AccessToken).GetAwaiter().GetResult(), true);
             }
         }
     }

--- a/src/Commands/ServiceHealth/GetServiceHealthIssue.cs
+++ b/src/Commands/ServiceHealth/GetServiceHealthIssue.cs
@@ -16,11 +16,11 @@ namespace PnP.PowerShell.Commands.ServiceHealth
         {
             if (ParameterSpecified(nameof(Identity)))
             {
-                WriteObject(ServiceHealthUtility.GetServiceHealthIssueByIdAsync(Identity, HttpClient, AccessToken).GetAwaiter().GetResult(), false);
+                WriteObject(ServiceHealthUtility.GetServiceHealthIssueByIdAsync(Identity, Connection, AccessToken).GetAwaiter().GetResult(), false);
             }
             else
             {
-                WriteObject(ServiceHealthUtility.GetServiceHealthIssuesAsync(HttpClient, AccessToken).GetAwaiter().GetResult(), true);
+                WriteObject(ServiceHealthUtility.GetServiceHealthIssuesAsync(Connection, AccessToken).GetAwaiter().GetResult(), true);
             }
         }
     }

--- a/src/Commands/ServiceHealth/SetMessageCenterAnnouncementAsArchived.cs
+++ b/src/Commands/ServiceHealth/SetMessageCenterAnnouncementAsArchived.cs
@@ -17,18 +17,18 @@ namespace PnP.PowerShell.Commands.ServiceHealth
         {
             if (ParameterSpecified(nameof(Identity)))
             {
-                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsArchivedByIdAsync(Identity, HttpClient, AccessToken).GetAwaiter().GetResult(), true);
+                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsArchivedByIdAsync(Identity, Connection, AccessToken).GetAwaiter().GetResult(), true);
             }
             else
             {
                 // Retrieve all message center announcements
-                var messageCenterAnnouncements = ServiceHealthUtility.GetServiceUpdateMessagesAsync(HttpClient, AccessToken).GetAwaiter().GetResult();
+                var messageCenterAnnouncements = ServiceHealthUtility.GetServiceUpdateMessagesAsync(Connection, AccessToken).GetAwaiter().GetResult();
 
                 // Create an array of the Ids of all message center announcements
                 var messageCenterAnnouncementIds = messageCenterAnnouncements.Select(item => item.Id).ToArray();
 
                 // Mark all message center announcements as archived
-                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsArchivedByIdAsync(messageCenterAnnouncementIds, HttpClient, AccessToken).GetAwaiter().GetResult(), true);
+                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsArchivedByIdAsync(messageCenterAnnouncementIds, Connection, AccessToken).GetAwaiter().GetResult(), true);
             }
         }        
     }

--- a/src/Commands/ServiceHealth/SetMessageCenterAnnouncementAsFavorite.cs
+++ b/src/Commands/ServiceHealth/SetMessageCenterAnnouncementAsFavorite.cs
@@ -17,18 +17,18 @@ namespace PnP.PowerShell.Commands.ServiceHealth
         {
             if (ParameterSpecified(nameof(Identity)))
             {
-                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsFavoriteByIdAsync(Identity, HttpClient, AccessToken).GetAwaiter().GetResult(), true);
+                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsFavoriteByIdAsync(Identity, Connection, AccessToken).GetAwaiter().GetResult(), true);
             }
             else
             {
                 // Retrieve all message center announcements
-                var messageCenterAnnouncements = ServiceHealthUtility.GetServiceUpdateMessagesAsync(HttpClient, AccessToken).GetAwaiter().GetResult();
+                var messageCenterAnnouncements = ServiceHealthUtility.GetServiceUpdateMessagesAsync(Connection, AccessToken).GetAwaiter().GetResult();
 
                 // Create an array of the Ids of all message center announcements
                 var messageCenterAnnouncementIds = messageCenterAnnouncements.Select(item => item.Id).ToArray();
 
                 // Mark all message center announcements as favorite
-                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsFavoriteByIdAsync(messageCenterAnnouncementIds, HttpClient, AccessToken).GetAwaiter().GetResult(), true);
+                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsFavoriteByIdAsync(messageCenterAnnouncementIds, Connection, AccessToken).GetAwaiter().GetResult(), true);
             }
         }        
     }

--- a/src/Commands/ServiceHealth/SetMessageCenterAnnouncementAsNotArchived.cs
+++ b/src/Commands/ServiceHealth/SetMessageCenterAnnouncementAsNotArchived.cs
@@ -17,18 +17,18 @@ namespace PnP.PowerShell.Commands.ServiceHealth
         {
             if (ParameterSpecified(nameof(Identity)))
             {
-                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsUnarchivedByIdAsync(Identity, HttpClient, AccessToken).GetAwaiter().GetResult(), true);
+                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsUnarchivedByIdAsync(Identity, Connection, AccessToken).GetAwaiter().GetResult(), true);
             }
             else
             {
                 // Retrieve all message center announcements
-                var messageCenterAnnouncements = ServiceHealthUtility.GetServiceUpdateMessagesAsync(HttpClient, AccessToken).GetAwaiter().GetResult();
+                var messageCenterAnnouncements = ServiceHealthUtility.GetServiceUpdateMessagesAsync(Connection, AccessToken).GetAwaiter().GetResult();
 
                 // Create an array of the Ids of all message center announcements
                 var messageCenterAnnouncementIds = messageCenterAnnouncements.Select(item => item.Id).ToArray();
 
                 // Mark all message center announcements as not archived
-                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsUnarchivedByIdAsync(messageCenterAnnouncementIds, HttpClient, AccessToken).GetAwaiter().GetResult(), true);
+                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsUnarchivedByIdAsync(messageCenterAnnouncementIds, Connection, AccessToken).GetAwaiter().GetResult(), true);
             }
         }        
     }

--- a/src/Commands/ServiceHealth/SetMessageCenterAnnouncementAsNotFavorite.cs
+++ b/src/Commands/ServiceHealth/SetMessageCenterAnnouncementAsNotFavorite.cs
@@ -16,18 +16,18 @@ namespace PnP.PowerShell.Commands.ServiceHealth
         {
             if (ParameterSpecified(nameof(Identity)))
             {
-                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsNotfavoriteByIdAsync(Identity, HttpClient, AccessToken).GetAwaiter().GetResult(), true);
+                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsNotfavoriteByIdAsync(Identity, Connection, AccessToken).GetAwaiter().GetResult(), true);
             }
             else
             {
                 // Retrieve all message center announcements
-                var messageCenterAnnouncements = ServiceHealthUtility.GetServiceUpdateMessagesAsync(HttpClient, AccessToken).GetAwaiter().GetResult();
+                var messageCenterAnnouncements = ServiceHealthUtility.GetServiceUpdateMessagesAsync(Connection, AccessToken).GetAwaiter().GetResult();
 
                 // Create an array of the Ids of all message center announcements
                 var messageCenterAnnouncementIds = messageCenterAnnouncements.Select(item => item.Id).ToArray();
 
                 // Mark all message center announcements as not favorites
-                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsNotfavoriteByIdAsync(messageCenterAnnouncementIds, HttpClient, AccessToken).GetAwaiter().GetResult(), true);
+                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsNotfavoriteByIdAsync(messageCenterAnnouncementIds, Connection, AccessToken).GetAwaiter().GetResult(), true);
             }
         }        
     }

--- a/src/Commands/ServiceHealth/SetMessageCenterAnnouncementAsRead.cs
+++ b/src/Commands/ServiceHealth/SetMessageCenterAnnouncementAsRead.cs
@@ -17,18 +17,18 @@ namespace PnP.PowerShell.Commands.ServiceHealth
         {
             if (ParameterSpecified(nameof(Identity)))
             {
-                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsReadByIdAsync(Identity, HttpClient, AccessToken).GetAwaiter().GetResult(), true);
+                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsReadByIdAsync(Identity, Connection, AccessToken).GetAwaiter().GetResult(), true);
             }
             else
             {
                 // Retrieve all message center announcements
-                var messageCenterAnnouncements = ServiceHealthUtility.GetServiceUpdateMessagesAsync(HttpClient, AccessToken).GetAwaiter().GetResult();
+                var messageCenterAnnouncements = ServiceHealthUtility.GetServiceUpdateMessagesAsync(Connection, AccessToken).GetAwaiter().GetResult();
 
                 // Create an array of the Ids of all message center announcements
                 var messageCenterAnnouncementIds = messageCenterAnnouncements.Select(item => item.Id).ToArray();
 
                 // Mark all message center announcements as read
-                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsReadByIdAsync(messageCenterAnnouncementIds, HttpClient, AccessToken).GetAwaiter().GetResult(), true);
+                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsReadByIdAsync(messageCenterAnnouncementIds, Connection, AccessToken).GetAwaiter().GetResult(), true);
             }
         }        
     }

--- a/src/Commands/ServiceHealth/SetMessageCenterAnnouncementAsUnread.cs
+++ b/src/Commands/ServiceHealth/SetMessageCenterAnnouncementAsUnread.cs
@@ -17,18 +17,18 @@ namespace PnP.PowerShell.Commands.ServiceHealth
         {
             if (ParameterSpecified(nameof(Identity)))
             {
-                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsUnreadByIdAsync(Identity, HttpClient, AccessToken).GetAwaiter().GetResult(), true);
+                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsUnreadByIdAsync(Identity, Connection, AccessToken).GetAwaiter().GetResult(), true);
             }
             else
             {
                 // Retrieve all message center announcements
-                var messageCenterAnnouncements = ServiceHealthUtility.GetServiceUpdateMessagesAsync(HttpClient, AccessToken).GetAwaiter().GetResult();
+                var messageCenterAnnouncements = ServiceHealthUtility.GetServiceUpdateMessagesAsync(Connection, AccessToken).GetAwaiter().GetResult();
 
                 // Create an array of the Ids of all message center announcements
                 var messageCenterAnnouncementIds = messageCenterAnnouncements.Select(item => item.Id).ToArray();
 
                 // Mark all message center announcements as unread
-                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsUnreadByIdAsync(messageCenterAnnouncementIds, HttpClient, AccessToken).GetAwaiter().GetResult(), true);
+                WriteObject(ServiceHealthUtility.SetServiceUpdateMessageAsUnreadByIdAsync(messageCenterAnnouncementIds, Connection, AccessToken).GetAwaiter().GetResult(), true);
             }
         }        
     }

--- a/src/Commands/Site/AddTeamsTeam.cs
+++ b/src/Commands/Site/AddTeamsTeam.cs
@@ -26,7 +26,7 @@ namespace PnP.PowerShell.Commands.Site
                 try
                 {
                     var groupId = ClientContext.Site.EnsureProperty(s => s.GroupId);                    
-                    Microsoft365GroupsUtility.CreateTeamAsync(HttpClient, AccessToken, groupId).GetAwaiter().GetResult();                    
+                    Microsoft365GroupsUtility.CreateTeamAsync(Connection, AccessToken, groupId).GetAwaiter().GetResult();                    
                 }
                 catch
                 {

--- a/src/Commands/SiteDesigns/InvokeSiteScript.cs
+++ b/src/Commands/SiteDesigns/InvokeSiteScript.cs
@@ -54,7 +54,7 @@ namespace PnP.PowerShell.Commands
                     else
                     {
                         WriteVerbose($"Executing provided script");
-                        result = PnP.PowerShell.Commands.Utilities.SiteTemplates.InvokeSiteScript(HttpClient, AccessToken, Script, hostUrl).GetAwaiter().GetResult().Items;
+                        result = PnP.PowerShell.Commands.Utilities.SiteTemplates.InvokeSiteScript(Connection, AccessToken, Script, hostUrl).GetAwaiter().GetResult().Items;
                     }
                     break;
 
@@ -80,7 +80,7 @@ namespace PnP.PowerShell.Commands
                         else
                         {
                             WriteVerbose($"Executing site script '{script.Title}' ({script.Id})");
-                            result = PnP.PowerShell.Commands.Utilities.SiteTemplates.InvokeSiteScript(HttpClient, AccessToken, script, hostUrl).GetAwaiter().GetResult().Items;
+                            result = PnP.PowerShell.Commands.Utilities.SiteTemplates.InvokeSiteScript(Connection, AccessToken, script, hostUrl).GetAwaiter().GetResult().Items;
                         }
                     }
                     break;

--- a/src/Commands/Teams/AddTeamsChannel.cs
+++ b/src/Commands/Teams/AddTeamsChannel.cs
@@ -2,7 +2,6 @@
 using PnP.PowerShell.Commands.Base;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 using PnP.PowerShell.Commands.Model.Graph;
-using PnP.PowerShell.Commands.Model.Teams;
 using PnP.PowerShell.Commands.Utilities;
 using System.Management.Automation;
 
@@ -38,12 +37,12 @@ namespace PnP.PowerShell.Commands.Graph
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            var groupId = Team.GetGroupId(Connection, AccessToken);
             if (groupId != null)
             {
                 try
                 {
-                    var channel = TeamsUtility.AddChannelAsync(AccessToken, HttpClient, groupId, DisplayName, Description, Private, OwnerUPN, IsFavoriteByDefault).GetAwaiter().GetResult();
+                    var channel = TeamsUtility.AddChannelAsync(AccessToken, Connection, groupId, DisplayName, Description, Private, OwnerUPN, IsFavoriteByDefault).GetAwaiter().GetResult();
                     WriteObject(channel);
                 }
                 catch (GraphException ex)

--- a/src/Commands/Teams/AddTeamsChannelUser.cs
+++ b/src/Commands/Teams/AddTeamsChannelUser.cs
@@ -26,13 +26,13 @@ namespace PnP.PowerShell.Commands.Teams
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            var groupId = Team.GetGroupId(Connection, AccessToken);
             if (groupId == null)
             {
                 throw new PSArgumentException("Group not found");
             }
 
-            var channelId = Channel.GetId(HttpClient, AccessToken, groupId);
+            var channelId = Channel.GetId(Connection, AccessToken, groupId);
             if (channelId == null)
             {
                 throw new PSArgumentException("Channel not found");
@@ -40,7 +40,7 @@ namespace PnP.PowerShell.Commands.Teams
 
             try
             {
-                TeamsUtility.AddChannelMemberAsync(HttpClient, AccessToken, groupId, channelId, User, Role).GetAwaiter().GetResult();
+                TeamsUtility.AddChannelMemberAsync(Connection, AccessToken, groupId, channelId, User, Role).GetAwaiter().GetResult();
             }
             catch (GraphException ex)
             {

--- a/src/Commands/Teams/AddTeamsTab.cs
+++ b/src/Commands/Teams/AddTeamsTab.cs
@@ -60,10 +60,10 @@ namespace PnP.PowerShell.Commands.Graph
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            var groupId = Team.GetGroupId(Connection, AccessToken);
             if (groupId != null)
             {
-                var channelId = Channel.GetId(HttpClient, AccessToken, groupId);
+                var channelId = Channel.GetId(Connection, AccessToken, groupId);
                 if (channelId != null)
                 {
                     try
@@ -100,7 +100,7 @@ namespace PnP.PowerShell.Commands.Graph
                                     break;
                                 }
                         }
-                        WriteObject(TeamsUtility.AddTabAsync(HttpClient, AccessToken, groupId, channelId, DisplayName, Type, teamsAppId, entityId, contentUrl, removeUrl, webSiteUrl).GetAwaiter().GetResult());
+                        WriteObject(TeamsUtility.AddTabAsync(Connection, AccessToken, groupId, channelId, DisplayName, Type, teamsAppId, entityId, contentUrl, removeUrl, webSiteUrl).GetAwaiter().GetResult());
                     }
                     catch (GraphException ex)
                     {

--- a/src/Commands/Teams/AddTeamsUser.cs
+++ b/src/Commands/Teams/AddTeamsUser.cs
@@ -33,29 +33,29 @@ namespace PnP.PowerShell.Commands.Graph
         public string Role;
         protected override void ExecuteCmdlet()
         {
-            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            var groupId = Team.GetGroupId(Connection, AccessToken);
             if (groupId != null)
             {
                 try
                 {
                     if (ParameterSpecified(nameof(Channel)))
                     {
-                        var channelId = Channel.GetId(HttpClient, AccessToken, groupId);
+                        var channelId = Channel.GetId(Connection, AccessToken, groupId);
                         if (channelId == null)
                         {
                             throw new PSArgumentException("Channel not found");
                         }
-                        TeamsUtility.AddChannelMemberAsync(HttpClient, AccessToken, groupId, channelId, User, Role).GetAwaiter().GetResult();
+                        TeamsUtility.AddChannelMemberAsync(Connection, AccessToken, groupId, channelId, User, Role).GetAwaiter().GetResult();
                     }
                     else
                     {
                         if (ParameterSetName == ParamSet_ByUser)
                         {
-                            TeamsUtility.AddUserAsync(HttpClient, AccessToken, groupId, User, Role).GetAwaiter().GetResult();
+                            TeamsUtility.AddUserAsync(Connection, AccessToken, groupId, User, Role).GetAwaiter().GetResult();
                         }
                         else
                         {
-                            TeamsUtility.AddUsersAsync(HttpClient, AccessToken, groupId, Users, Role).GetAwaiter().GetResult();
+                            TeamsUtility.AddUsersAsync(Connection, AccessToken, groupId, Users, Role).GetAwaiter().GetResult();
                         }
                     }
                 }

--- a/src/Commands/Teams/CopyTeamsTeam.cs
+++ b/src/Commands/Teams/CopyTeamsTeam.cs
@@ -48,7 +48,7 @@ namespace PnP.PowerShell.Commands.Teams
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Identity.GetGroupId(HttpClient, AccessToken);
+            var groupId = Identity.GetGroupId(Connection, AccessToken);
             
             if (groupId == null)
             {
@@ -70,7 +70,7 @@ namespace PnP.PowerShell.Commands.Teams
             * but currently ignored and can't be set by user */
             teamClone.MailNickName = DisplayName;
             teamClone.Visibility = (GroupVisibility)Enum.Parse(typeof(GroupVisibility), Visibility.ToString());
-            TeamsUtility.CloneTeamAsync(AccessToken, HttpClient, groupId, teamClone).GetAwaiter().GetResult();
+            TeamsUtility.CloneTeamAsync(AccessToken, Connection, groupId, teamClone).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Commands/Teams/GetTeamsApp.cs
+++ b/src/Commands/Teams/GetTeamsApp.cs
@@ -20,7 +20,7 @@ namespace PnP.PowerShell.Commands.Graph
         {
             if (ParameterSpecified(nameof(Identity)))
             {
-                var app = Identity.GetApp(HttpClient, AccessToken);
+                var app = Identity.GetApp(Connection, AccessToken);
                 if (app != null)
                 {
                     WriteObject(app);
@@ -28,7 +28,7 @@ namespace PnP.PowerShell.Commands.Graph
             }
             else
             {
-                WriteObject(TeamsUtility.GetAppsAsync(AccessToken, HttpClient).GetAwaiter().GetResult(), true);
+                WriteObject(TeamsUtility.GetAppsAsync(AccessToken, Connection).GetAwaiter().GetResult(), true);
             }
         }
     }

--- a/src/Commands/Teams/GetTeamsChannel.cs
+++ b/src/Commands/Teams/GetTeamsChannel.cs
@@ -1,11 +1,7 @@
-﻿using PnP.Framework.Graph;
-using PnP.PowerShell.Commands.Attributes;
+﻿using PnP.PowerShell.Commands.Attributes;
 using PnP.PowerShell.Commands.Base;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 using PnP.PowerShell.Commands.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Management.Automation;
 
 namespace PnP.PowerShell.Commands.Teams
@@ -23,16 +19,16 @@ namespace PnP.PowerShell.Commands.Teams
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            var groupId = Team.GetGroupId(Connection, AccessToken);
             if (groupId != null)
             {
                 if (ParameterSpecified(nameof(Identity)))
                 {
-                    WriteObject(Identity.GetChannel(HttpClient, AccessToken, groupId));
+                    WriteObject(Identity.GetChannel(Connection, AccessToken, groupId));
                 }
                 else
                 {
-                    WriteObject(TeamsUtility.GetChannelsAsync(AccessToken, HttpClient, groupId).GetAwaiter().GetResult());
+                    WriteObject(TeamsUtility.GetChannelsAsync(AccessToken, Connection, groupId).GetAwaiter().GetResult());
                 }
             } else
             {

--- a/src/Commands/Teams/GetTeamsChannelFilesFolder.cs
+++ b/src/Commands/Teams/GetTeamsChannelFilesFolder.cs
@@ -1,8 +1,6 @@
 ﻿using PnP.PowerShell.Commands.Attributes;
 using PnP.PowerShell.Commands.Base;
 using PnP.PowerShell.Commands.Base.PipeBinds;
-using System;
-using System.Collections.Generic;
 using System.Management.Automation;
 
 namespace PnP.PowerShell.Commands.Teams
@@ -19,17 +17,17 @@ namespace PnP.PowerShell.Commands.Teams
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            var groupId = Team.GetGroupId(Connection, AccessToken);
             if (groupId != null)
             {
 
-                var channelId = Channel.GetId(HttpClient, AccessToken, groupId);
+                var channelId = Channel.GetId(Connection, AccessToken, groupId);
                 if (channelId == null)
                 {
                     throw new PSArgumentException("Channel not found");
                 }
                               
-                WriteObject(Utilities.TeamsUtility.GetChannelsFilesFolderAsync(HttpClient, AccessToken, groupId, channelId).GetAwaiter().GetResult());
+                WriteObject(Utilities.TeamsUtility.GetChannelsFilesFolderAsync(Connection, AccessToken, groupId, channelId).GetAwaiter().GetResult());
                                 
             }
             else

--- a/src/Commands/Teams/GetTeamsChannelMessage.cs
+++ b/src/Commands/Teams/GetTeamsChannelMessage.cs
@@ -24,13 +24,13 @@ namespace PnP.PowerShell.Commands.Teams
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            var groupId = Team.GetGroupId(Connection, AccessToken);
             if (groupId == null)
             {
                 throw new PSArgumentException("Team not found");
             }
 
-            var channelId = Channel.GetId(HttpClient, AccessToken, groupId);
+            var channelId = Channel.GetId(Connection, AccessToken, groupId);
             if (channelId == null)
             {
                 throw new PSArgumentException("Channel not found");
@@ -43,12 +43,12 @@ namespace PnP.PowerShell.Commands.Teams
                     throw new PSArgumentException($"Don't specify {nameof(IncludeDeleted)} when using the {nameof(Identity)} parameter.");
                 }
 
-                var message = TeamsUtility.GetMessageAsync(HttpClient, AccessToken, groupId, channelId, Identity.GetId()).GetAwaiter().GetResult();
+                var message = TeamsUtility.GetMessageAsync(Connection, AccessToken, groupId, channelId, Identity.GetId()).GetAwaiter().GetResult();
                 WriteObject(message);
             }
             else
             {
-                var messages = TeamsUtility.GetMessagesAsync(HttpClient, AccessToken, groupId, channelId, IncludeDeleted).GetAwaiter().GetResult();
+                var messages = TeamsUtility.GetMessagesAsync(Connection, AccessToken, groupId, channelId, IncludeDeleted).GetAwaiter().GetResult();
                 WriteObject(messages, true);
             }
         }

--- a/src/Commands/Teams/GetTeamsChannelMessageReply.cs
+++ b/src/Commands/Teams/GetTeamsChannelMessageReply.cs
@@ -27,13 +27,13 @@ namespace PnP.PowerShell.Commands.Teams
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            var groupId = Team.GetGroupId(Connection, AccessToken);
             if (groupId == null)
             {
                 throw new PSArgumentException("Group not found");
             }
 
-            var channelId = Channel.GetId(HttpClient, AccessToken, groupId);
+            var channelId = Channel.GetId(Connection, AccessToken, groupId);
             if (channelId == null)
             {
                 throw new PSArgumentException("Channel not found");
@@ -54,12 +54,12 @@ namespace PnP.PowerShell.Commands.Teams
                         throw new PSArgumentException($"Don't specify {nameof(IncludeDeleted)} when using the {nameof(Identity)} parameter.");
                     }
 
-                    var reply = TeamsUtility.GetMessageReplyAsync(HttpClient, AccessToken, groupId, channelId, messageId, Identity.GetId()).GetAwaiter().GetResult();
+                    var reply = TeamsUtility.GetMessageReplyAsync(Connection, AccessToken, groupId, channelId, messageId, Identity.GetId()).GetAwaiter().GetResult();
                     WriteObject(reply);
                 }
                 else
                 {
-                    var replies = TeamsUtility.GetMessageRepliesAsync(HttpClient, AccessToken, groupId, channelId, messageId, IncludeDeleted).GetAwaiter().GetResult();
+                    var replies = TeamsUtility.GetMessageRepliesAsync(Connection, AccessToken, groupId, channelId, messageId, IncludeDeleted).GetAwaiter().GetResult();
                     WriteObject(replies, true);
                 }
             }

--- a/src/Commands/Teams/GetTeamsChannelUser.cs
+++ b/src/Commands/Teams/GetTeamsChannelUser.cs
@@ -25,13 +25,13 @@ namespace PnP.PowerShell.Commands.Teams
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            var groupId = Team.GetGroupId(Connection, AccessToken);
             if (groupId == null)
             {
                 throw new PSArgumentException("Group not found");
             }
 
-            var channelId = Channel.GetId(HttpClient, AccessToken, groupId);
+            var channelId = Channel.GetId(Connection, AccessToken, groupId);
             if (channelId == null)
             {
                 throw new PSArgumentException("Channel not found");
@@ -39,11 +39,11 @@ namespace PnP.PowerShell.Commands.Teams
 
             if (ParameterSpecified(nameof(Identity)))
             {
-                WriteObject(Identity.GetMembershipAsync(HttpClient, AccessToken, groupId, channelId).GetAwaiter().GetResult());
+                WriteObject(Identity.GetMembershipAsync(Connection, AccessToken, groupId, channelId).GetAwaiter().GetResult());
             }
             else
             {
-                WriteObject(TeamsUtility.GetChannelMembersAsync(HttpClient, AccessToken, groupId, channelId, Role).GetAwaiter().GetResult(), true);
+                WriteObject(TeamsUtility.GetChannelMembersAsync(Connection, AccessToken, groupId, channelId, Role).GetAwaiter().GetResult(), true);
             }
         }
     }

--- a/src/Commands/Teams/GetTeamsPrimaryChannel.cs
+++ b/src/Commands/Teams/GetTeamsPrimaryChannel.cs
@@ -1,11 +1,7 @@
-﻿using PnP.Framework.Graph;
-using PnP.PowerShell.Commands.Attributes;
+﻿using PnP.PowerShell.Commands.Attributes;
 using PnP.PowerShell.Commands.Base;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 using PnP.PowerShell.Commands.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Management.Automation;
 
 namespace PnP.PowerShell.Commands.Teams
@@ -20,10 +16,10 @@ namespace PnP.PowerShell.Commands.Teams
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            var groupId = Team.GetGroupId(Connection, AccessToken);
             if (groupId != null)
             { 
-              WriteObject(TeamsUtility.GetPrimaryChannelAsync(AccessToken, HttpClient, groupId).GetAwaiter().GetResult());
+              WriteObject(TeamsUtility.GetPrimaryChannelAsync(AccessToken, Connection, groupId).GetAwaiter().GetResult());
             } else
             {
                 throw new PSArgumentException("Team not found", nameof(Team));

--- a/src/Commands/Teams/GetTeamsTab.cs
+++ b/src/Commands/Teams/GetTeamsTab.cs
@@ -23,19 +23,19 @@ namespace PnP.PowerShell.Commands.Graph
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            var groupId = Team.GetGroupId(Connection, AccessToken);
             if (groupId != null)
             {
-                var channelId = Channel.GetId(HttpClient, AccessToken, groupId);
+                var channelId = Channel.GetId(Connection, AccessToken, groupId);
                 if (!string.IsNullOrEmpty(channelId))
                 {
                     if (ParameterSpecified(nameof(Identity)))
                     {
-                        WriteObject(Identity.GetTab(this,HttpClient, AccessToken, groupId, channelId));
+                        WriteObject(Identity.GetTab(this,Connection, AccessToken, groupId, channelId));
                     }
                     else
                     {
-                        WriteObject(TeamsUtility.GetTabsAsync(AccessToken, HttpClient, groupId, channelId).GetAwaiter().GetResult(), true);
+                        WriteObject(TeamsUtility.GetTabsAsync(AccessToken, Connection, groupId, channelId).GetAwaiter().GetResult(), true);
                     }
                 }
                 else

--- a/src/Commands/Teams/GetTeamsTeam.cs
+++ b/src/Commands/Teams/GetTeamsTeam.cs
@@ -17,15 +17,15 @@ namespace PnP.PowerShell.Commands.Graph
         {
             if (ParameterSpecified(nameof(Identity)))
             {
-                var groupId = Identity.GetGroupId(HttpClient, AccessToken);
+                var groupId = Identity.GetGroupId(Connection, AccessToken);
                 if (groupId != null)
                 {
-                    WriteObject(TeamsUtility.GetTeamAsync(AccessToken, HttpClient, groupId).GetAwaiter().GetResult());
+                    WriteObject(TeamsUtility.GetTeamAsync(AccessToken, Connection, groupId).GetAwaiter().GetResult());
                 }
             }
             else
             {
-                WriteObject(TeamsUtility.GetTeamsAsync(AccessToken, HttpClient).GetAwaiter().GetResult(), true);
+                WriteObject(TeamsUtility.GetTeamsAsync(AccessToken, Connection).GetAwaiter().GetResult(), true);
             }
         }
     }

--- a/src/Commands/Teams/GetTeamsUser.cs
+++ b/src/Commands/Teams/GetTeamsUser.cs
@@ -25,22 +25,22 @@ namespace PnP.PowerShell.Commands.Graph
         public string Role;
         protected override void ExecuteCmdlet()
         {
-            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            var groupId = Team.GetGroupId(Connection, AccessToken);
             if (groupId != null)
             {
                 try
                 {
                     if (ParameterSpecified(nameof(Channel)))
                     {
-                        var teamChannels = TeamsUtility.GetChannelsAsync(AccessToken, HttpClient, groupId).GetAwaiter().GetResult();
+                        var teamChannels = TeamsUtility.GetChannelsAsync(AccessToken, Connection, groupId).GetAwaiter().GetResult();
                         
-                        var channelId = Channel.GetId(HttpClient, AccessToken, groupId);
+                        var channelId = Channel.GetId(Connection, AccessToken, groupId);
 
                         var requestedChannel = teamChannels.FirstOrDefault(c => c.Id == channelId);
 
                         if (!string.IsNullOrEmpty(channelId) && requestedChannel != null && requestedChannel.MembershipType.ToLower() == TeamChannelType.Private.ToString().ToLower())
                         {
-                            WriteObject(TeamsUtility.GetUsersAsync(HttpClient, AccessToken, groupId, channelId, Role).GetAwaiter().GetResult(), true);
+                            WriteObject(TeamsUtility.GetUsersAsync(Connection, AccessToken, groupId, channelId, Role).GetAwaiter().GetResult(), true);
                         }
                         else
                         {
@@ -49,7 +49,7 @@ namespace PnP.PowerShell.Commands.Graph
                     }
                     else
                     {
-                        WriteObject(TeamsUtility.GetUsersAsync(HttpClient, AccessToken, groupId, Role).GetAwaiter().GetResult(), true);
+                        WriteObject(TeamsUtility.GetUsersAsync(Connection, AccessToken, groupId, Role).GetAwaiter().GetResult(), true);
                     }
                 }
                 catch (GraphException ex)

--- a/src/Commands/Teams/NewTeamsApp.cs
+++ b/src/Commands/Teams/NewTeamsApp.cs
@@ -27,7 +27,7 @@ namespace PnP.PowerShell.Commands.Graph
                 try
                 {
                     var bytes = System.IO.File.ReadAllBytes(Path);
-                    TeamsUtility.AddAppAsync(HttpClient, AccessToken, bytes).GetAwaiter().GetResult();
+                    TeamsUtility.AddAppAsync(Connection, AccessToken, bytes).GetAwaiter().GetResult();
                 }
                 catch (GraphException ex)
                 {

--- a/src/Commands/Teams/NewTeamsTeam.cs
+++ b/src/Commands/Teams/NewTeamsTeam.cs
@@ -159,7 +159,7 @@ namespace PnP.PowerShell.Commands.Graph
                 }
             }
 
-            WriteObject(TeamsUtility.NewTeamAsync(AccessToken, HttpClient, GroupId, DisplayName, Description, Classification, MailNickName, (GroupVisibility)Enum.Parse(typeof(GroupVisibility), Visibility.ToString()), teamCI, Owners, Members, SensitivityLabels, Template, ResourceBehaviorOptions).GetAwaiter().GetResult());
+            WriteObject(TeamsUtility.NewTeamAsync(AccessToken, Connection, GroupId, DisplayName, Description, Classification, MailNickName, (GroupVisibility)Enum.Parse(typeof(GroupVisibility), Visibility.ToString()), teamCI, Owners, Members, SensitivityLabels, Template, ResourceBehaviorOptions).GetAwaiter().GetResult());
         }
     }
 }

--- a/src/Commands/Teams/RemoveTeamsApp.cs
+++ b/src/Commands/Teams/RemoveTeamsApp.cs
@@ -20,14 +20,14 @@ namespace PnP.PowerShell.Commands.Graph
 
         protected override void ExecuteCmdlet()
         {
-            var app = Identity.GetApp(HttpClient, AccessToken);
+            var app = Identity.GetApp(Connection, AccessToken);
             if (app == null)
             {
                 throw new PSArgumentException("App not found");
             }
             if (Force || ShouldContinue($"Do you want to remove {app.DisplayName}?", Properties.Resources.Confirm))
             {
-                var response = TeamsUtility.DeleteAppAsync(HttpClient, AccessToken, app.Id).GetAwaiter().GetResult();
+                var response = TeamsUtility.DeleteAppAsync(Connection, AccessToken, app.Id).GetAwaiter().GetResult();
                 if (!response.IsSuccessStatusCode)
                 {
                     if (GraphHelper.TryGetGraphException(response, out GraphException ex))

--- a/src/Commands/Teams/RemoveTeamsChannel.cs
+++ b/src/Commands/Teams/RemoveTeamsChannel.cs
@@ -27,13 +27,13 @@ namespace PnP.PowerShell.Commands.Teams
         {
             if (Force || ShouldContinue("Removing the channel will also remove all the messages in the channel.", Properties.Resources.Confirm))
             {
-                var groupId = Team.GetGroupId(HttpClient, AccessToken);
+                var groupId = Team.GetGroupId(Connection, AccessToken);
                 if (groupId != null)
                 {
-                    var channel = Identity.GetChannel(HttpClient, AccessToken, groupId);
+                    var channel = Identity.GetChannel(Connection, AccessToken, groupId);
                     if (channel != null)
                     {
-                        var response = TeamsUtility.DeleteChannelAsync(AccessToken, HttpClient, groupId, channel.Id).GetAwaiter().GetResult();
+                        var response = TeamsUtility.DeleteChannelAsync(AccessToken, Connection, groupId, channel.Id).GetAwaiter().GetResult();
                         if (!response.IsSuccessStatusCode)
                         {
                             if (GraphHelper.TryGetGraphException(response, out GraphException ex))

--- a/src/Commands/Teams/RemoveTeamsChannelUser.cs
+++ b/src/Commands/Teams/RemoveTeamsChannelUser.cs
@@ -26,19 +26,19 @@ namespace PnP.PowerShell.Commands.Teams
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            var groupId = Team.GetGroupId(Connection, AccessToken);
             if (string.IsNullOrEmpty(groupId))
             {
                 throw new PSArgumentException("Group not found");
             }
 
-            var channelId = Channel.GetId(HttpClient, AccessToken, groupId);
+            var channelId = Channel.GetId(Connection, AccessToken, groupId);
             if (string.IsNullOrEmpty(channelId))
             {
                 throw new PSArgumentException("Channel not found in the specified team");
             }
 
-            var memberId = Identity.GetIdAsync(HttpClient, AccessToken, groupId, channelId).GetAwaiter().GetResult();
+            var memberId = Identity.GetIdAsync(Connection, AccessToken, groupId, channelId).GetAwaiter().GetResult();
             if (string.IsNullOrEmpty(memberId))
             {
                 throw new PSArgumentException("User was not found in the specified Teams channel");
@@ -46,7 +46,7 @@ namespace PnP.PowerShell.Commands.Teams
 
             if (Force || ShouldContinue("Remove specified member from the Microsoft Teams channel?", Resources.Confirm))
             {
-                var response = TeamsUtility.DeleteChannelMemberAsync(HttpClient, AccessToken, groupId, channelId, memberId).GetAwaiter().GetResult();
+                var response = TeamsUtility.DeleteChannelMemberAsync(Connection, AccessToken, groupId, channelId, memberId).GetAwaiter().GetResult();
 
                 if (!response.IsSuccessStatusCode)
                 {

--- a/src/Commands/Teams/RemoveTeamsTab.cs
+++ b/src/Commands/Teams/RemoveTeamsTab.cs
@@ -27,18 +27,18 @@ namespace PnP.PowerShell.Commands.Graph
         protected override void ExecuteCmdlet()
         {
 
-            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            var groupId = Team.GetGroupId(Connection, AccessToken);
             if (groupId != null)
             {
-                var channelId = Channel.GetId(HttpClient, AccessToken, groupId);
+                var channelId = Channel.GetId(Connection, AccessToken, groupId);
                 if (channelId != null)
                 {
-                    var tab = Identity.GetTab(this, HttpClient, AccessToken, groupId, channelId);
+                    var tab = Identity.GetTab(this, Connection, AccessToken, groupId, channelId);
                     if (tab != null)
                     {
                         if (Force || ShouldContinue("Removing the tab will remove the settings of this tab too.", Properties.Resources.Confirm))
                         {
-                            var response = TeamsUtility.DeleteTabAsync(AccessToken, HttpClient, groupId, channelId, tab.Id).GetAwaiter().GetResult();
+                            var response = TeamsUtility.DeleteTabAsync(AccessToken, Connection, groupId, channelId, tab.Id).GetAwaiter().GetResult();
                             if (!response.IsSuccessStatusCode)
                             {
                                 if (GraphHelper.TryGetGraphException(response, out GraphException ex))

--- a/src/Commands/Teams/RemoveTeamsTeam.cs
+++ b/src/Commands/Teams/RemoveTeamsTeam.cs
@@ -21,12 +21,12 @@ namespace PnP.PowerShell.Commands.Graph
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Identity.GetGroupId(HttpClient, AccessToken);
+            var groupId = Identity.GetGroupId(Connection, AccessToken);
             if (groupId != null)
             {
                 if (Force || ShouldContinue("Removing the team will remove all messages in all channels in the team.", Properties.Resources.Confirm))
                 {
-                    var response = TeamsUtility.DeleteTeamAsync(AccessToken, HttpClient, groupId).GetAwaiter().GetResult();
+                    var response = TeamsUtility.DeleteTeamAsync(AccessToken, Connection, groupId).GetAwaiter().GetResult();
                     if (!response.IsSuccessStatusCode)
                     {
                         if (GraphHelper.TryGetGraphException(response, out GraphException ex))

--- a/src/Commands/Teams/RemoveTeamsUser.cs
+++ b/src/Commands/Teams/RemoveTeamsUser.cs
@@ -25,14 +25,14 @@ namespace PnP.PowerShell.Commands.Graph
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            var groupId = Team.GetGroupId(Connection, AccessToken);
             if (groupId != null)
             {
                 try
                 {
                     if (Force || ShouldContinue($"Remove user with UPN {User}?", Properties.Resources.Confirm))
                     {
-                        TeamsUtility.DeleteUserAsync(HttpClient, AccessToken, groupId, User, Role).GetAwaiter().GetResult();
+                        TeamsUtility.DeleteUserAsync(Connection, AccessToken, groupId, User, Role).GetAwaiter().GetResult();
                     }
                 }
                 catch (GraphException ex)

--- a/src/Commands/Teams/SetTeamsChannel.cs
+++ b/src/Commands/Teams/SetTeamsChannel.cs
@@ -28,10 +28,10 @@ namespace PnP.PowerShell.Commands.Graph
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            var groupId = Team.GetGroupId(Connection, AccessToken);
             if (groupId != null)
             {
-                var teamChannel = Identity.GetChannel(HttpClient, AccessToken, groupId);
+                var teamChannel = Identity.GetChannel(Connection, AccessToken, groupId);
                 if (teamChannel != null)
                 {
                     if (ParameterSpecified(nameof(DisplayName)) && teamChannel.DisplayName != DisplayName)
@@ -60,7 +60,7 @@ namespace PnP.PowerShell.Commands.Graph
                     teamChannel.MembershipType = null;
                     try 
                     {
-                        var updated = TeamsUtility.UpdateChannelAsync(HttpClient, AccessToken, groupId, teamChannel.Id, teamChannel).GetAwaiter().GetResult();
+                        var updated = TeamsUtility.UpdateChannelAsync(Connection, AccessToken, groupId, teamChannel.Id, teamChannel).GetAwaiter().GetResult();
                         WriteObject(updated);
                     }
                     catch (GraphException ex)

--- a/src/Commands/Teams/SetTeamsChannelUser.cs
+++ b/src/Commands/Teams/SetTeamsChannelUser.cs
@@ -26,19 +26,19 @@ namespace PnP.PowerShell.Commands.Teams
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            var groupId = Team.GetGroupId(Connection, AccessToken);
             if (groupId == null)
             {
                 throw new PSArgumentException("Group not found");
             }
 
-            var channelId = Channel.GetId(HttpClient, AccessToken, groupId);
+            var channelId = Channel.GetId(Connection, AccessToken, groupId);
             if (channelId == null)
             {
                 throw new PSArgumentException("Channel not found");
             }
 
-            var membershipId = Identity.GetIdAsync(HttpClient, AccessToken, groupId, channelId).GetAwaiter().GetResult();
+            var membershipId = Identity.GetIdAsync(Connection, AccessToken, groupId, channelId).GetAwaiter().GetResult();
             if (string.IsNullOrEmpty(membershipId))
             {
                 throw new PSArgumentException("User was not found in the specified Teams channel");
@@ -46,7 +46,7 @@ namespace PnP.PowerShell.Commands.Teams
 
             try
             {
-                var updatedMember = TeamsUtility.UpdateChannelMemberAsync(HttpClient, AccessToken, groupId, channelId, membershipId, Role).GetAwaiter().GetResult();
+                var updatedMember = TeamsUtility.UpdateChannelMemberAsync(Connection, AccessToken, groupId, channelId, membershipId, Role).GetAwaiter().GetResult();
                 WriteObject(updatedMember);
             }
             catch (GraphException ex)

--- a/src/Commands/Teams/SetTeamsTab.cs
+++ b/src/Commands/Teams/SetTeamsTab.cs
@@ -24,20 +24,20 @@ namespace PnP.PowerShell.Commands.Graph
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            var groupId = Team.GetGroupId(Connection, AccessToken);
             if (groupId != null)
             {
-                var channelId = Channel.GetId(HttpClient, AccessToken, groupId);
+                var channelId = Channel.GetId(Connection, AccessToken, groupId);
                 if (channelId != null)
                 {
-                    var tab = Identity.GetTab(this,HttpClient, AccessToken, groupId, channelId);
+                    var tab = Identity.GetTab(this,Connection, AccessToken, groupId, channelId);
                     if (tab != null)
                     {
                         if (ParameterSpecified(nameof(DisplayName)) && tab.DisplayName != DisplayName)
                         {
                             tab.DisplayName = DisplayName;
                         }
-                        TeamsUtility.UpdateTabAsync(HttpClient, AccessToken, groupId, channelId, tab).GetAwaiter().GetResult();
+                        TeamsUtility.UpdateTabAsync(Connection, AccessToken, groupId, channelId, tab).GetAwaiter().GetResult();
                     }
                     else
                     {

--- a/src/Commands/Teams/SetTeamsTeam.cs
+++ b/src/Commands/Teams/SetTeamsTeam.cs
@@ -84,12 +84,12 @@ namespace PnP.PowerShell.Commands.Graph
         public bool? AllowCreatePrivateChannels;
         protected override void ExecuteCmdlet()
         {
-            var groupId = Identity.GetGroupId(HttpClient, AccessToken);
+            var groupId = Identity.GetGroupId(Connection, AccessToken);
             if (groupId != null)
             {
                 try
                 {
-                    var team = TeamsUtility.GetTeamAsync(AccessToken, HttpClient, groupId).GetAwaiter().GetResult();
+                    var team = TeamsUtility.GetTeamAsync(AccessToken, Connection, groupId).GetAwaiter().GetResult();
                     var updateGroup = false;
                     var group = new Group();
                     if (team != null)
@@ -125,7 +125,7 @@ namespace PnP.PowerShell.Commands.Graph
 
                         if(updateGroup)
                         {
-                            TeamsUtility.UpdateGroupAsync(HttpClient, AccessToken, groupId, group).GetAwaiter().GetResult();
+                            TeamsUtility.UpdateGroupAsync(Connection, AccessToken, groupId, group).GetAwaiter().GetResult();
                         }
 
                         var teamCI = new TeamCreationInformation();
@@ -147,7 +147,7 @@ namespace PnP.PowerShell.Commands.Graph
                         teamCI.Classification = ParameterSpecified(nameof(Classification)) ? Classification : null;
                         teamCI.AllowCreatePrivateChannels = ParameterSpecified(nameof(AllowCreatePrivateChannels)) ? AllowCreatePrivateChannels : null;                        
 
-                        var updated = TeamsUtility.UpdateTeamAsync(HttpClient, AccessToken, groupId, teamCI.ToTeam(group.Visibility)).GetAwaiter().GetResult();
+                        var updated = TeamsUtility.UpdateTeamAsync(Connection, AccessToken, groupId, teamCI.ToTeam(group.Visibility)).GetAwaiter().GetResult();
                         WriteObject(updated);
                     }
                 }

--- a/src/Commands/Teams/SetTeamsTeamArchivedState.cs
+++ b/src/Commands/Teams/SetTeamsTeamArchivedState.cs
@@ -30,15 +30,15 @@ namespace PnP.PowerShell.Commands.Graph
             {
                 throw new PSArgumentException("You can only modify the read only state of a site when archiving a team");
             }
-            var groupId = Identity.GetGroupId(HttpClient, AccessToken);
+            var groupId = Identity.GetGroupId(Connection, AccessToken);
             if (groupId != null)
             {
-                var team = Identity.GetTeam(HttpClient, AccessToken);
+                var team = Identity.GetTeam(Connection, AccessToken);
                 if (Archived == team.IsArchived)
                 {
                     throw new PSInvalidOperationException($"Team {team.DisplayName} {(Archived ? "has already been" : "is not")} archived");
                 }
-                var response = TeamsUtility.SetTeamArchivedStateAsync(HttpClient, AccessToken, groupId, Archived, SetSiteReadOnlyForMembers).GetAwaiter().GetResult();
+                var response = TeamsUtility.SetTeamArchivedStateAsync(Connection, AccessToken, groupId, Archived, SetSiteReadOnlyForMembers).GetAwaiter().GetResult();
                 if (!response.IsSuccessStatusCode)
                 {
                     if (GraphHelper.TryGetGraphException(response, out GraphException ex))

--- a/src/Commands/Teams/SetTeamsTeamPicture.cs
+++ b/src/Commands/Teams/SetTeamsTeamPicture.cs
@@ -21,7 +21,7 @@ namespace PnP.PowerShell.Commands.Graph
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            var groupId = Team.GetGroupId(Connection, AccessToken);
             if (groupId != null)
             {
                 if (!System.IO.Path.IsPathRooted(Path))
@@ -52,7 +52,7 @@ namespace PnP.PowerShell.Commands.Graph
                         throw new PSArgumentException("File is not of a supported content type (jpg/png)");
                     }
                     var byteArray = File.ReadAllBytes(Path);
-                    TeamsUtility.SetTeamPictureAsync(HttpClient, AccessToken, groupId, byteArray, contentType).GetAwaiter().GetResult();
+                    TeamsUtility.SetTeamPictureAsync(Connection, AccessToken, groupId, byteArray, contentType).GetAwaiter().GetResult();
                 }
                 else
                 {

--- a/src/Commands/Teams/SubmitTeamsChannelMessage.cs
+++ b/src/Commands/Teams/SubmitTeamsChannelMessage.cs
@@ -29,10 +29,10 @@ namespace PnP.PowerShell.Commands.Graph
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            var groupId = Team.GetGroupId(Connection, AccessToken);
             if (groupId != null)
             {
-                var channel = Channel.GetChannel(HttpClient, AccessToken, groupId);
+                var channel = Channel.GetChannel(Connection, AccessToken, groupId);
                 if (channel != null)
                 {
                     var channelMessage = new TeamChannelMessage();
@@ -40,7 +40,7 @@ namespace PnP.PowerShell.Commands.Graph
                     channelMessage.Body.Content = Message;
                     channelMessage.Body.ContentType = ContentType == TeamChannelMessageContentType.Html ? "html" : "text";
 
-                    TeamsUtility.PostMessageAsync(HttpClient, AccessToken, groupId, channel.Id, channelMessage).GetAwaiter().GetResult();
+                    TeamsUtility.PostMessageAsync(Connection, AccessToken, groupId, channel.Id, channelMessage).GetAwaiter().GetResult();
                 }
                 else
                 {

--- a/src/Commands/Teams/UpdateTeamsApp.cs
+++ b/src/Commands/Teams/UpdateTeamsApp.cs
@@ -29,12 +29,12 @@ namespace PnP.PowerShell.Commands.Graph
 
             if (System.IO.File.Exists(Path))
             {
-                var app = Identity.GetApp(HttpClient, AccessToken);
+                var app = Identity.GetApp(Connection, AccessToken);
                 if (app != null)
                 {
 
                     var bytes = System.IO.File.ReadAllBytes(Path);
-                    var response = TeamsUtility.UpdateAppAsync(HttpClient, AccessToken, bytes, app.Id).GetAwaiter().GetResult();
+                    var response = TeamsUtility.UpdateAppAsync(Connection, AccessToken, bytes, app.Id).GetAwaiter().GetResult();
                     if (!response.IsSuccessStatusCode)
                     {
                         if (GraphHelper.TryGetGraphException(response, out GraphException ex))

--- a/src/Commands/Teams/UpdateTeamsUser.cs
+++ b/src/Commands/Teams/UpdateTeamsUser.cs
@@ -26,24 +26,24 @@ namespace PnP.PowerShell.Commands.Graph
 
         protected override void ExecuteCmdlet()
         {
-            var groupId = Team.GetGroupId(HttpClient, AccessToken);
+            var groupId = Team.GetGroupId(Connection, AccessToken);
             if (groupId != null)
             {
                 try
                 {
                     if (Force || ShouldContinue($"Update role for user with UPN {User} ?", Properties.Resources.Confirm))
                     {
-                        var teamsUser = TeamsUtility.GetUsersAsync(HttpClient, AccessToken, groupId, string.Empty).GetAwaiter().GetResult();
+                        var teamsUser = TeamsUtility.GetUsersAsync(Connection, AccessToken, groupId, string.Empty).GetAwaiter().GetResult();
 
                         var specifiedUser = teamsUser.Find(u => u.UserPrincipalName.ToLower() == User.ToLower());
                         if (specifiedUser != null)
                         {
                             // No easy way to get member Id for teams endpoint, need to rely on display name filter to fetch memberId of the specified user and then update
-                            var teamUserWithDisplayName = TeamsUtility.GetTeamUsersWithDisplayNameAsync(HttpClient, AccessToken, groupId, specifiedUser.DisplayName).GetAwaiter().GetResult();
+                            var teamUserWithDisplayName = TeamsUtility.GetTeamUsersWithDisplayNameAsync(Connection, AccessToken, groupId, specifiedUser.DisplayName).GetAwaiter().GetResult();
                             var userToUpdate = teamUserWithDisplayName.Find(u => u.UserId == specifiedUser.Id);
 
                             // Pass the member id of the user whose role we are changing
-                            WriteObject(TeamsUtility.UpdateTeamUserRole(HttpClient, AccessToken, groupId, userToUpdate.Id, Role).GetAwaiter().GetResult());
+                            WriteObject(TeamsUtility.UpdateTeamUserRole(Connection, AccessToken, groupId, userToUpdate.Id, Role).GetAwaiter().GetResult());
                         }
                         else
                         {

--- a/src/Commands/Utilities/Microsoft365GroupsUtility.cs
+++ b/src/Commands/Utilities/Microsoft365GroupsUtility.cs
@@ -12,10 +12,10 @@ namespace PnP.PowerShell.Commands.Utilities
 {
     internal static class Microsoft365GroupsUtility
     {
-        internal static async Task<IEnumerable<Microsoft365Group>> GetGroupsAsync(HttpClient httpClient, string accessToken, bool includeSiteUrl, bool includeOwners)
+        internal static async Task<IEnumerable<Microsoft365Group>> GetGroupsAsync(PnPConnection connection, string accessToken, bool includeSiteUrl, bool includeOwners)
         {
             var items = new List<Microsoft365Group>();
-            var result = await GraphHelper.GetResultCollectionAsync<Microsoft365Group>(httpClient, "v1.0/groups?$filter=groupTypes/any(c:c+eq+'Unified')", accessToken);
+            var result = await GraphHelper.GetResultCollectionAsync<Microsoft365Group>(connection, "v1.0/groups?$filter=groupTypes/any(c:c+eq+'Unified')", accessToken);
             if (result != null && result.Any())
             {
                 items.AddRange(result);
@@ -27,7 +27,7 @@ namespace PnP.PowerShell.Commands.Utilities
                 {
                     foreach (var chunk in chunks)
                     {
-                        var ownerResults = await BatchUtility.GetObjectCollectionBatchedAsync<Microsoft365User>(httpClient, accessToken, chunk.ToArray(), "/groups/{0}/owners");
+                        var ownerResults = await BatchUtility.GetObjectCollectionBatchedAsync<Microsoft365User>(connection, accessToken, chunk.ToArray(), "/groups/{0}/owners");
                         foreach (var ownerResult in ownerResults)
                         {
                             items.First(i => i.Id.ToString() == ownerResult.Key).Owners = ownerResult.Value;
@@ -39,8 +39,8 @@ namespace PnP.PowerShell.Commands.Utilities
                 {
                     foreach (var chunk in chunks)
                     {
-                        var results = await BatchUtility.GetPropertyBatchedAsync(httpClient, accessToken, chunk.ToArray(), "/groups/{0}/sites/root", "webUrl");
-                        //var results = await GetSiteUrlBatchedAsync(httpClient, accessToken, chunk.ToArray());
+                        var results = await BatchUtility.GetPropertyBatchedAsync(connection, accessToken, chunk.ToArray(), "/groups/{0}/sites/root", "webUrl");
+                        //var results = await GetSiteUrlBatchedAsync(connection, accessToken, chunk.ToArray());
                         foreach (var batchResult in results)
                         {
                             items.First(i => i.Id.ToString() == batchResult.Key).SiteUrl = batchResult.Value;
@@ -50,9 +50,9 @@ namespace PnP.PowerShell.Commands.Utilities
             }
             return items;
         }
-        internal static async Task<Microsoft365Group> GetGroupAsync(HttpClient httpClient, Guid groupId, string accessToken, bool includeSiteUrl, bool includeOwners)
+        internal static async Task<Microsoft365Group> GetGroupAsync(PnPConnection connection, Guid groupId, string accessToken, bool includeSiteUrl, bool includeOwners)
         {
-            var group = await GraphHelper.GetAsync<Microsoft365Group>(httpClient, $"v1.0/groups/{groupId}", accessToken);
+            var group = await GraphHelper.GetAsync<Microsoft365Group>(connection, $"v1.0/groups/{groupId}", accessToken);
             if (includeSiteUrl)
             {
                 bool wait = true;
@@ -63,7 +63,7 @@ namespace PnP.PowerShell.Commands.Utilities
                     iterations++;
                     try
                     {
-                        var siteUrlResult = await GraphHelper.GetAsync(httpClient, $"v1.0/groups/{group.Id}/sites/root?$select=webUrl", accessToken);
+                        var siteUrlResult = await GraphHelper.GetAsync(connection, $"v1.0/groups/{group.Id}/sites/root?$select=webUrl", accessToken);
                         if (!string.IsNullOrEmpty(siteUrlResult))
                         {
                             wait = false;
@@ -91,19 +91,19 @@ namespace PnP.PowerShell.Commands.Utilities
             }
             if (includeOwners)
             {
-                group.Owners = await GetGroupMembersAsync("owners", httpClient, group.Id.Value, accessToken);
+                group.Owners = await GetGroupMembersAsync("owners", connection, group.Id.Value, accessToken);
             }
             return group;
         }
-        internal static async Task<Microsoft365Group> GetGroupAsync(HttpClient httpClient, string displayName, string accessToken, bool includeSiteUrl, bool includeOwners)
+        internal static async Task<Microsoft365Group> GetGroupAsync(PnPConnection connection, string displayName, string accessToken, bool includeSiteUrl, bool includeOwners)
         {
-            var results = await GraphHelper.GetAsync<RestResultCollection<Microsoft365Group>>(httpClient, $"v1.0/groups?$filter=groupTypes/any(c:c+eq+'Unified') and displayName eq '{displayName}' or mailNickName eq '{displayName}'", accessToken);
+            var results = await GraphHelper.GetAsync<RestResultCollection<Microsoft365Group>>(connection, $"v1.0/groups?$filter=groupTypes/any(c:c+eq+'Unified') and displayName eq '{displayName}' or mailNickName eq '{displayName}'", accessToken);
             if (results != null && results.Items.Any())
             {
                 var group = results.Items.First();
                 if (includeSiteUrl)
                 {
-                    var siteUrlResult = await GraphHelper.GetAsync(httpClient, $"v1.0/groups/{group.Id}/sites/root?$select=webUrl", accessToken);
+                    var siteUrlResult = await GraphHelper.GetAsync(connection, $"v1.0/groups/{group.Id}/sites/root?$select=webUrl", accessToken);
                     var resultElement = JsonSerializer.Deserialize<JsonElement>(siteUrlResult);
                     if (resultElement.TryGetProperty("webUrl", out JsonElement webUrlElement))
                     {
@@ -112,21 +112,21 @@ namespace PnP.PowerShell.Commands.Utilities
                 }
                 if (includeOwners)
                 {
-                    group.Owners = await GetGroupMembersAsync("owners", httpClient, group.Id.Value, accessToken);
+                    group.Owners = await GetGroupMembersAsync("owners", connection, group.Id.Value, accessToken);
                 }
                 return group;
             }
             return null;
         }
 
-        internal static async Task<Microsoft365Group> GetDeletedGroupAsync(HttpClient httpClient, Guid groupId, string accessToken)
+        internal static async Task<Microsoft365Group> GetDeletedGroupAsync(PnPConnection connection, Guid groupId, string accessToken)
         {
-            return await GraphHelper.GetAsync<Microsoft365Group>(httpClient, $"v1.0/directory/deleteditems/microsoft.graph.group/{groupId}", accessToken);
+            return await GraphHelper.GetAsync<Microsoft365Group>(connection, $"v1.0/directory/deleteditems/microsoft.graph.group/{groupId}", accessToken);
         }
 
-        internal static async Task<Microsoft365Group> GetDeletedGroupAsync(HttpClient httpClient, string groupName, string accessToken)
+        internal static async Task<Microsoft365Group> GetDeletedGroupAsync(PnPConnection connection, string groupName, string accessToken)
         {
-            var results = await GraphHelper.GetAsync<RestResultCollection<Microsoft365Group>>(httpClient, $"v1.0/directory/deleteditems/microsoft.graph.group?$filter=displayName eq '{groupName}' or mailNickname eq '{groupName}'", accessToken);
+            var results = await GraphHelper.GetAsync<RestResultCollection<Microsoft365Group>>(connection, $"v1.0/directory/deleteditems/microsoft.graph.group?$filter=displayName eq '{groupName}' or mailNickname eq '{groupName}'", accessToken);
             if (results != null && results.Items.Any())
             {
                 return results.Items.First();
@@ -134,30 +134,30 @@ namespace PnP.PowerShell.Commands.Utilities
             return null;
         }
 
-        internal static async Task<IEnumerable<Microsoft365Group>> GetDeletedGroupsAsync(HttpClient httpClient, string accessToken)
+        internal static async Task<IEnumerable<Microsoft365Group>> GetDeletedGroupsAsync(PnPConnection connection, string accessToken)
         {
-            var result = await GraphHelper.GetResultCollectionAsync<Microsoft365Group>(httpClient, "v1.0/directory/deleteditems/microsoft.graph.group", accessToken);
+            var result = await GraphHelper.GetResultCollectionAsync<Microsoft365Group>(connection, "v1.0/directory/deleteditems/microsoft.graph.group", accessToken);
             return result;
         }
 
-        internal static async Task<Microsoft365Group> RestoreDeletedGroupAsync(HttpClient httpClient, Guid groupId, string accessToken)
+        internal static async Task<Microsoft365Group> RestoreDeletedGroupAsync(PnPConnection connection, Guid groupId, string accessToken)
         {
-            return await GraphHelper.PostAsync<Microsoft365Group>(httpClient, $"v1.0/directory/deleteditems/microsoft.graph.group/{groupId}/restore", accessToken);
+            return await GraphHelper.PostAsync<Microsoft365Group>(connection, $"v1.0/directory/deleteditems/microsoft.graph.group/{groupId}/restore", accessToken);
         }
 
-        internal static async Task PermanentlyDeleteDeletedGroupAsync(HttpClient httpClient, Guid groupId, string accessToken)
+        internal static async Task PermanentlyDeleteDeletedGroupAsync(PnPConnection connection, Guid groupId, string accessToken)
         {
-            await GraphHelper.DeleteAsync(httpClient, $"v1.0/directory/deleteditems/microsoft.graph.group/{groupId}", accessToken);
+            await GraphHelper.DeleteAsync(connection, $"v1.0/directory/deleteditems/microsoft.graph.group/{groupId}", accessToken);
         }
 
-        internal static async Task AddOwnersAsync(HttpClient httpClient, Guid groupId, string[] users, string accessToken, bool removeExisting)
+        internal static async Task AddOwnersAsync(PnPConnection connection, Guid groupId, string[] users, string accessToken, bool removeExisting)
         {
-            await AddUsersToGroupAsync("owners", httpClient, groupId, users, accessToken, removeExisting);
+            await AddUsersToGroupAsync("owners", connection, groupId, users, accessToken, removeExisting);
         }
 
-        internal static async Task AddMembersAsync(HttpClient httpClient, Guid groupId, string[] users, string accessToken, bool removeExisting)
+        internal static async Task AddMembersAsync(PnPConnection connection, Guid groupId, string[] users, string accessToken, bool removeExisting)
         {
-            await AddUsersToGroupAsync("members", httpClient, groupId, users, accessToken, removeExisting);
+            await AddUsersToGroupAsync("members", connection, groupId, users, accessToken, removeExisting);
         }
 
         internal static string GetUserGraphUrlForUPN(string upn)
@@ -170,11 +170,11 @@ namespace PnP.PowerShell.Commands.Utilities
             return $"users/{escapedUpn}";
         }
 
-        private static async Task AddUsersToGroupAsync(string groupName, HttpClient httpClient, Guid groupId, string[] users, string accessToken, bool removeExisting)
+        private static async Task AddUsersToGroupAsync(string groupName, PnPConnection connection, Guid groupId, string[] users, string accessToken, bool removeExisting)
         {
             foreach (var user in users)
             {
-                var userIdResult = await GraphHelper.GetAsync(httpClient, $"v1.0/{GetUserGraphUrlForUPN(user)}?$select=Id", accessToken);
+                var userIdResult = await GraphHelper.GetAsync(connection, $"v1.0/{GetUserGraphUrlForUPN(user)}?$select=Id", accessToken);
                 var resultElement = JsonSerializer.Deserialize<JsonElement>(userIdResult);
                 if (resultElement.TryGetProperty("id", out JsonElement idProperty))
                 {
@@ -187,114 +187,114 @@ namespace PnP.PowerShell.Commands.Utilities
                     var stringContent = new StringContent(JsonSerializer.Serialize(postData));
                     stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
 
-                    await GraphHelper.PostAsync(httpClient, $"v1.0/groups/{groupId}/{groupName}/$ref", accessToken, stringContent);
+                    await GraphHelper.PostAsync(connection, $"v1.0/groups/{groupId}/{groupName}/$ref", accessToken, stringContent);
                 }
             }
         }
 
-        internal static async Task RemoveOwnersAsync(HttpClient httpClient, Guid groupId, string[] users, string accessToken)
+        internal static async Task RemoveOwnersAsync(PnPConnection connection, Guid groupId, string[] users, string accessToken)
         {
-            await RemoveUserFromGroupAsync("owners", httpClient, groupId, users, accessToken);
+            await RemoveUserFromGroupAsync("owners", connection, groupId, users, accessToken);
         }
 
-        internal static async Task RemoveMembersAsync(HttpClient httpClient, Guid groupId, string[] users, string accessToken)
+        internal static async Task RemoveMembersAsync(PnPConnection connection, Guid groupId, string[] users, string accessToken)
         {
-            await RemoveUserFromGroupAsync("members", httpClient, groupId, users, accessToken);
+            await RemoveUserFromGroupAsync("members", connection, groupId, users, accessToken);
         }
 
-        private static async Task RemoveUserFromGroupAsync(string groupName, HttpClient httpClient, Guid groupId, string[] users, string accessToken)
+        private static async Task RemoveUserFromGroupAsync(string groupName, PnPConnection connection, Guid groupId, string[] users, string accessToken)
         {
             foreach (var user in users)
             {
-                var resultString = await GraphHelper.GetAsync(httpClient, $"v1.0/{GetUserGraphUrlForUPN(user)}?$select=Id", accessToken);
+                var resultString = await GraphHelper.GetAsync(connection, $"v1.0/{GetUserGraphUrlForUPN(user)}?$select=Id", accessToken);
                 var resultElement = JsonSerializer.Deserialize<JsonElement>(resultString);
                 if (resultElement.TryGetProperty("id", out JsonElement idElement))
                 {
-                    await GraphHelper.DeleteAsync(httpClient, $"v1.0/groups/{groupId}/{groupName}/{idElement.GetString()}/$ref", accessToken);
+                    await GraphHelper.DeleteAsync(connection, $"v1.0/groups/{groupId}/{groupName}/{idElement.GetString()}/$ref", accessToken);
                 }
             }
         }
 
-        internal static async Task RemoveGroupAsync(HttpClient httpClient, Guid groupId, string accessToken)
+        internal static async Task RemoveGroupAsync(PnPConnection connection, Guid groupId, string accessToken)
         {
-            await GraphHelper.DeleteAsync(httpClient, $"v1.0/groups/{groupId}", accessToken);
+            await GraphHelper.DeleteAsync(connection, $"v1.0/groups/{groupId}", accessToken);
         }
 
-        internal static async Task<IEnumerable<Microsoft365User>> GetOwnersAsync(HttpClient httpClient, Guid groupId, string accessToken)
+        internal static async Task<IEnumerable<Microsoft365User>> GetOwnersAsync(PnPConnection connection, Guid groupId, string accessToken)
         {
-            return await GetGroupMembersAsync("owners", httpClient, groupId, accessToken);
+            return await GetGroupMembersAsync("owners", connection, groupId, accessToken);
         }
 
-        internal static async Task<IEnumerable<Microsoft365User>> GetMembersAsync(HttpClient httpClient, Guid groupId, string accessToken)
+        internal static async Task<IEnumerable<Microsoft365User>> GetMembersAsync(PnPConnection connection, Guid groupId, string accessToken)
         {
-            return await GetGroupMembersAsync("members", httpClient, groupId, accessToken);
+            return await GetGroupMembersAsync("members", connection, groupId, accessToken);
         }
 
-        private static async Task<IEnumerable<Microsoft365User>> GetGroupMembersAsync(string userType, HttpClient httpClient, Guid groupId, string accessToken)
+        private static async Task<IEnumerable<Microsoft365User>> GetGroupMembersAsync(string userType, PnPConnection connection, Guid groupId, string accessToken)
         {
-            var results = await GraphHelper.GetResultCollectionAsync<Microsoft365User>(httpClient, $"v1.0/groups/{groupId}/{userType}?$select=*", accessToken);
+            var results = await GraphHelper.GetResultCollectionAsync<Microsoft365User>(connection, $"v1.0/groups/{groupId}/{userType}?$select=*", accessToken);
             return results;
         }
 
-        internal static async Task ClearMembersAsync(HttpClient httpClient, Guid groupId, string accessToken)
+        internal static async Task ClearMembersAsync(PnPConnection connection, Guid groupId, string accessToken)
         {
-            var members = await GetMembersAsync(httpClient, groupId, accessToken);
+            var members = await GetMembersAsync(connection, groupId, accessToken);
 
             foreach (var member in members)
             {
-                await GraphHelper.DeleteAsync(httpClient, $"v1.0/groups/{groupId}/members/{member.Id}/$ref", accessToken);
+                await GraphHelper.DeleteAsync(connection, $"v1.0/groups/{groupId}/members/{member.Id}/$ref", accessToken);
             }
         }
 
-        internal static async Task ClearOwnersAsync(HttpClient httpClient, Guid groupId, string accessToken)
+        internal static async Task ClearOwnersAsync(PnPConnection connection, Guid groupId, string accessToken)
         {
-            var members = await GetOwnersAsync(httpClient, groupId, accessToken);
+            var members = await GetOwnersAsync(connection, groupId, accessToken);
 
             foreach (var member in members)
             {
-                await GraphHelper.DeleteAsync(httpClient, $"v1.0/groups/{groupId}/owners/{member.Id}/$ref", accessToken);
+                await GraphHelper.DeleteAsync(connection, $"v1.0/groups/{groupId}/owners/{member.Id}/$ref", accessToken);
             }
         }
 
-        internal static async Task UpdateOwnersAsync(HttpClient httpClient, Guid groupId, string accessToken, string[] owners)
+        internal static async Task UpdateOwnersAsync(PnPConnection connection, Guid groupId, string accessToken, string[] owners)
         {
-            var existingOwners = await GetOwnersAsync(httpClient, groupId, accessToken);
+            var existingOwners = await GetOwnersAsync(connection, groupId, accessToken);
             foreach (var owner in owners)
             {
                 if (existingOwners.FirstOrDefault(o => o.UserPrincipalName == owner) == null)
                 {
-                    await AddOwnersAsync(httpClient, groupId, new string[] { owner }, accessToken, false);
+                    await AddOwnersAsync(connection, groupId, new string[] { owner }, accessToken, false);
                 }
             }
             foreach (var existingOwner in existingOwners)
             {
                 if (!owners.Contains(existingOwner.UserPrincipalName))
                 {
-                    await GraphHelper.DeleteAsync(httpClient, $"v1.0/groups/{groupId}/owners/{existingOwner.Id}/$ref", accessToken);
+                    await GraphHelper.DeleteAsync(connection, $"v1.0/groups/{groupId}/owners/{existingOwner.Id}/$ref", accessToken);
                 }
             }
         }
 
-        internal static async Task UpdateMembersAsync(HttpClient httpClient, Guid groupId, string accessToken, string[] members)
+        internal static async Task UpdateMembersAsync(PnPConnection connection, Guid groupId, string accessToken, string[] members)
         {
-            var existingMembers = await GetMembersAsync(httpClient, groupId, accessToken);
+            var existingMembers = await GetMembersAsync(connection, groupId, accessToken);
             foreach (var member in members)
             {
                 if (existingMembers.FirstOrDefault(o => o.UserPrincipalName == member) == null)
                 {
-                    await AddMembersAsync(httpClient, groupId, new string[] { member }, accessToken, false);
+                    await AddMembersAsync(connection, groupId, new string[] { member }, accessToken, false);
                 }
             }
             foreach (var existingMember in existingMembers)
             {
                 if (!members.Contains(existingMember.UserPrincipalName))
                 {
-                    await GraphHelper.DeleteAsync(httpClient, $"v1.0/groups/{groupId}/members/{existingMember.Id}/$ref", accessToken);
+                    await GraphHelper.DeleteAsync(connection, $"v1.0/groups/{groupId}/members/{existingMember.Id}/$ref", accessToken);
                 }
             }
         }
 
-        internal static async Task<Dictionary<string, string>> GetSiteUrlBatchedAsync(HttpClient httpClient, string accessToken, string[] groupIds)
+        internal static async Task<Dictionary<string, string>> GetSiteUrlBatchedAsync(PnPConnection connection, string accessToken, string[] groupIds)
         {
             Dictionary<string, string> returnValue = new Dictionary<string, string>();
 
@@ -309,7 +309,7 @@ namespace PnP.PowerShell.Commands.Utilities
             }
             var stringContent = new StringContent(JsonSerializer.Serialize(batch));
             stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-            var result = await GraphHelper.PostAsync<GraphBatchResponse>(httpClient, "v1.0/$batch", stringContent, accessToken);
+            var result = await GraphHelper.PostAsync<GraphBatchResponse>(connection, "v1.0/$batch", stringContent, accessToken);
             if (result.Responses != null && result.Responses.Any())
             {
                 foreach (var response in result.Responses)
@@ -325,7 +325,7 @@ namespace PnP.PowerShell.Commands.Utilities
             return returnValue;
         }
 
-        internal static async Task<Dictionary<string, string>> GetUserIdsBatched(HttpClient httpClient, string accessToken, string[] userPrincipalNames)
+        internal static async Task<Dictionary<string, string>> GetUserIdsBatched(PnPConnection connection, string accessToken, string[] userPrincipalNames)
         {
             Dictionary<string, string> returnValue = new Dictionary<string, string>();
 
@@ -340,7 +340,7 @@ namespace PnP.PowerShell.Commands.Utilities
             }
             var stringContent = new StringContent(JsonSerializer.Serialize(batch));
             stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-            var result = await GraphHelper.PostAsync<GraphBatchResponse>(httpClient, "v1.0/$batch", stringContent, accessToken);
+            var result = await GraphHelper.PostAsync<GraphBatchResponse>(connection, "v1.0/$batch", stringContent, accessToken);
             if (result.Responses != null && result.Responses.Any())
             {
                 foreach (var response in result.Responses)
@@ -356,9 +356,9 @@ namespace PnP.PowerShell.Commands.Utilities
             return returnValue;
         }
 
-        internal static async Task<string[]> GetUsersDataBindValueAsync(HttpClient httpClient, string accessToken, string[] users)
+        internal static async Task<string[]> GetUsersDataBindValueAsync(PnPConnection connection, string accessToken, string[] users)
         {
-            var userids = await GetUserIdsBatched(httpClient, accessToken, users);
+            var userids = await GetUserIdsBatched(connection, accessToken, users);
             if (userids.Any())
             {
                 return userids.Select(u => $"https://{PnPConnection.Current.GraphEndPoint}/v1.0/users/{u.Value}").ToArray();
@@ -366,16 +366,16 @@ namespace PnP.PowerShell.Commands.Utilities
             return null;
         }
 
-        internal static async Task<Microsoft365Group> CreateAsync(HttpClient httpClient, string accessToken, Microsoft365Group group, bool createTeam, string logoPath, string[] owners, string[] members, bool? hideFromAddressLists, bool? hideFromOutlookClients, List<string> sensitivityLabels)
+        internal static async Task<Microsoft365Group> CreateAsync(PnPConnection connection, string accessToken, Microsoft365Group group, bool createTeam, string logoPath, string[] owners, string[] members, bool? hideFromAddressLists, bool? hideFromOutlookClients, List<string> sensitivityLabels)
         {
             if (owners != null && owners.Length > 0)
             {
-                group.OwnersODataBind = await GetUsersDataBindValueAsync(httpClient, accessToken, owners);
+                group.OwnersODataBind = await GetUsersDataBindValueAsync(connection, accessToken, owners);
             }
 
             if (members != null && members.Length > 0)
             {
-                group.MembersODataBind = await GetUsersDataBindValueAsync(httpClient, accessToken, members);
+                group.MembersODataBind = await GetUsersDataBindValueAsync(connection, accessToken, members);
             }
 
             if (sensitivityLabels.Count > 0)
@@ -395,27 +395,27 @@ namespace PnP.PowerShell.Commands.Utilities
                 group.AssignedLabels = assignedLabels;
             }
 
-            var newGroup = await GraphHelper.PostAsync(httpClient, "v1.0/groups", group, accessToken);
+            var newGroup = await GraphHelper.PostAsync(connection, "v1.0/groups", group, accessToken);
 
             if (hideFromAddressLists.HasValue || hideFromOutlookClients.HasValue)
             {
-                await SetVisibilityAsync(httpClient, accessToken, newGroup.Id.Value, hideFromAddressLists, hideFromOutlookClients);
+                await SetVisibilityAsync(connection, accessToken, newGroup.Id.Value, hideFromAddressLists, hideFromOutlookClients);
             }
 
             if (!string.IsNullOrEmpty(logoPath))
             {
-                await UploadLogoAsync(httpClient, accessToken, newGroup.Id.Value, logoPath);
+                await UploadLogoAsync(connection, accessToken, newGroup.Id.Value, logoPath);
             }
 
             if (createTeam)
             {
-                await CreateTeamAsync(httpClient, accessToken, newGroup.Id.Value);
+                await CreateTeamAsync(connection, accessToken, newGroup.Id.Value);
             }
 
             return newGroup;
         }
 
-        internal static async Task UploadLogoAsync(HttpClient httpClient, string accessToken, Guid groupId, string logoPath)
+        internal static async Task UploadLogoAsync(PnPConnection connection, string accessToken, Guid groupId, string logoPath)
         {
             var fileBytes = System.IO.File.ReadAllBytes(logoPath);
 
@@ -448,7 +448,7 @@ namespace PnP.PowerShell.Commands.Utilities
                 var retryCount = 10;
                 while (retryCount > 0)
                 {
-                    var responseMessage = await GraphHelper.PutAsync(httpClient, $"/v1.0/groups/{groupId}/photo/$value", accessToken, content);
+                    var responseMessage = await GraphHelper.PutAsync(connection, $"/v1.0/groups/{groupId}/photo/$value", accessToken, content);
                     if (responseMessage.IsSuccessStatusCode)
                     {
                         updated = true;
@@ -470,7 +470,7 @@ namespace PnP.PowerShell.Commands.Utilities
             }
         }
 
-        internal static async Task CreateTeamAsync(HttpClient httpClient, string accessToken, Guid groupId)
+        internal static async Task CreateTeamAsync(PnPConnection connection, string accessToken, Guid groupId)
         {
             var createTeamEndPoint = $"v1.0/groups/{groupId}/team";
             bool wait = true;
@@ -481,7 +481,7 @@ namespace PnP.PowerShell.Commands.Utilities
                 iterations++;
                 try
                 {
-                    var teamId = await GraphHelper.PutAsync<object>(httpClient, createTeamEndPoint, new { }, accessToken);
+                    var teamId = await GraphHelper.PutAsync<object>(connection, createTeamEndPoint, new { }, accessToken);
                     if (teamId != null)
                     {
                         wait = false;
@@ -502,17 +502,17 @@ namespace PnP.PowerShell.Commands.Utilities
             }
         }
 
-        internal static async Task RenewAsync(HttpClient httpClient, string accessToken, Guid groupId)
+        internal static async Task RenewAsync(PnPConnection connection, string accessToken, Guid groupId)
         {
-            await GraphHelper.PostAsync(httpClient, $"v1.0/groups/{groupId}/renew", new { }, accessToken);
+            await GraphHelper.PostAsync(connection, $"v1.0/groups/{groupId}/renew", new { }, accessToken);
         }
 
-        internal static async Task<Microsoft365Group> UpdateAsync(HttpClient httpClient, string accessToken, Microsoft365Group group)
+        internal static async Task<Microsoft365Group> UpdateAsync(PnPConnection connection, string accessToken, Microsoft365Group group)
         {
-            return await GraphHelper.PatchAsync(httpClient, accessToken, $"v1.0/groups/{group.Id}", group);
+            return await GraphHelper.PatchAsync(connection, accessToken, $"v1.0/groups/{group.Id}", group);
         }
 
-        internal static async Task SetVisibilityAsync(HttpClient httpClient, string accessToken, Guid groupId, bool? hideFromAddressLists, bool? hideFromOutlookClients)
+        internal static async Task SetVisibilityAsync(PnPConnection connection, string accessToken, Guid groupId, bool? hideFromAddressLists, bool? hideFromOutlookClients)
         {
             var patchData = new
             {
@@ -526,7 +526,7 @@ namespace PnP.PowerShell.Commands.Utilities
             {
                 try
                 {
-                    await GraphHelper.PatchAsync<dynamic>(httpClient, accessToken, $"v1.0/groups/{groupId}", patchData);
+                    await GraphHelper.PatchAsync<dynamic>(connection, accessToken, $"v1.0/groups/{groupId}", patchData);
                     retry = false;
                 }
 
@@ -543,71 +543,71 @@ namespace PnP.PowerShell.Commands.Utilities
             }
         }
 
-        internal static async Task<Microsoft365GroupSettingValueCollection> GetGroupSettingsAsync(HttpClient httpClient, string accessToken)
+        internal static async Task<Microsoft365GroupSettingValueCollection> GetGroupSettingsAsync(PnPConnection connection, string accessToken)
         {
-            var result = await GraphHelper.GetAsync<Microsoft365GroupSettingValueCollection>(httpClient, "v1.0/groupSettings", accessToken, propertyNameCaseInsensitive: true);
+            var result = await GraphHelper.GetAsync<Microsoft365GroupSettingValueCollection>(connection, "v1.0/groupSettings", accessToken, propertyNameCaseInsensitive: true);
             return result;
         }
 
-        internal static async Task<Microsoft365GroupSettingValueCollection> GetGroupSettingsAsync(HttpClient httpClient, string accessToken, string groupId)
+        internal static async Task<Microsoft365GroupSettingValueCollection> GetGroupSettingsAsync(PnPConnection connection, string accessToken, string groupId)
         {
-            var result = await GraphHelper.GetAsync<Microsoft365GroupSettingValueCollection>(httpClient, $"v1.0/groups/{groupId}/settings", accessToken, propertyNameCaseInsensitive: true);
+            var result = await GraphHelper.GetAsync<Microsoft365GroupSettingValueCollection>(connection, $"v1.0/groups/{groupId}/settings", accessToken, propertyNameCaseInsensitive: true);
             return result;
         }
 
-        internal static async Task<Microsoft365GroupSetting> CreateGroupSetting(HttpClient httpClient, string accessToken, dynamic groupSettingObject)
+        internal static async Task<Microsoft365GroupSetting> CreateGroupSetting(PnPConnection connection, string accessToken, dynamic groupSettingObject)
         {
             var stringContent = new StringContent(JsonSerializer.Serialize(groupSettingObject));
             stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-            var result = await GraphHelper.PostAsync<Microsoft365GroupSetting>(httpClient, "v1.0/groupSettings", stringContent, accessToken, propertyNameCaseInsensitive: true);
+            var result = await GraphHelper.PostAsync<Microsoft365GroupSetting>(connection, "v1.0/groupSettings", stringContent, accessToken, propertyNameCaseInsensitive: true);
             return result;
         }
 
-        internal static async Task<Microsoft365GroupSetting> CreateGroupSetting(HttpClient httpClient, string accessToken, string groupId, dynamic groupSettingObject)
+        internal static async Task<Microsoft365GroupSetting> CreateGroupSetting(PnPConnection connection, string accessToken, string groupId, dynamic groupSettingObject)
         {
             var stringContent = new StringContent(JsonSerializer.Serialize(groupSettingObject));
             stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-            var result = await GraphHelper.PostAsync<Microsoft365GroupSetting>(httpClient, $"v1.0/groups/{groupId}/settings", stringContent, accessToken, propertyNameCaseInsensitive: true);
+            var result = await GraphHelper.PostAsync<Microsoft365GroupSetting>(connection, $"v1.0/groups/{groupId}/settings", stringContent, accessToken, propertyNameCaseInsensitive: true);
             return result;
         }
 
-        internal static async Task UpdateGroupSetting(HttpClient httpClient, string accessToken, string id, dynamic groupSettingObject)
+        internal static async Task UpdateGroupSetting(PnPConnection connection, string accessToken, string id, dynamic groupSettingObject)
         {
             var stringContent = new StringContent(JsonSerializer.Serialize(groupSettingObject));
             stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-            await GraphHelper.PatchAsync(httpClient, accessToken, stringContent, $"v1.0/groupSettings/{id}");
+            await GraphHelper.PatchAsync(connection, accessToken, stringContent, $"v1.0/groupSettings/{id}");
         }
 
-        internal static async Task UpdateGroupSetting(HttpClient httpClient, string accessToken, string id, string groupId, dynamic groupSettingObject)
+        internal static async Task UpdateGroupSetting(PnPConnection connection, string accessToken, string id, string groupId, dynamic groupSettingObject)
         {
             var stringContent = new StringContent(JsonSerializer.Serialize(groupSettingObject));
             stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-            await GraphHelper.PatchAsync(httpClient, accessToken, stringContent, $"v1.0/groups/{groupId}/settings/{id}");
+            await GraphHelper.PatchAsync(connection, accessToken, stringContent, $"v1.0/groups/{groupId}/settings/{id}");
         }
 
-        internal static async Task RemoveGroupSetting(HttpClient httpClient, string accessToken, string id)
+        internal static async Task RemoveGroupSetting(PnPConnection connection, string accessToken, string id)
         {
-            await GraphHelper.DeleteAsync(httpClient, $"v1.0/groupSettings/{id}", accessToken);
+            await GraphHelper.DeleteAsync(connection, $"v1.0/groupSettings/{id}", accessToken);
         }
 
-        internal static async Task RemoveGroupSetting(HttpClient httpClient, string accessToken, string id, string groupId)
+        internal static async Task RemoveGroupSetting(PnPConnection connection, string accessToken, string id, string groupId)
         {
-            await GraphHelper.DeleteAsync(httpClient, $"v1.0/groups/{groupId}/settings/{id}", accessToken);
+            await GraphHelper.DeleteAsync(connection, $"v1.0/groups/{groupId}/settings/{id}", accessToken);
         }
 
-        internal static async Task<Microsoft365GroupTemplateSettingValueCollection> GetGroupTemplateSettingsAsync(HttpClient httpClient, string accessToken)
+        internal static async Task<Microsoft365GroupTemplateSettingValueCollection> GetGroupTemplateSettingsAsync(PnPConnection connection, string accessToken)
         {
-            var result = await GraphHelper.GetAsync<Microsoft365GroupTemplateSettingValueCollection>(httpClient, "v1.0/groupSettingTemplates", accessToken, propertyNameCaseInsensitive: true);
+            var result = await GraphHelper.GetAsync<Microsoft365GroupTemplateSettingValueCollection>(connection, "v1.0/groupSettingTemplates", accessToken, propertyNameCaseInsensitive: true);
             return result;
         }
 
-        internal static async Task<Microsoft365GroupSettingTemplate> GetGroupTemplateSettingsAsync(HttpClient httpClient, string accessToken, string id)
+        internal static async Task<Microsoft365GroupSettingTemplate> GetGroupTemplateSettingsAsync(PnPConnection connection, string accessToken, string id)
         {
-            var result = await GraphHelper.GetAsync<Microsoft365GroupSettingTemplate>(httpClient, $"v1.0/groupSettingTemplates/{id}", accessToken, propertyNameCaseInsensitive: true);
+            var result = await GraphHelper.GetAsync<Microsoft365GroupSettingTemplate>(connection, $"v1.0/groupSettingTemplates/{id}", accessToken, propertyNameCaseInsensitive: true);
             return result;
         }
 
-        internal static async Task SetSensitivityLabelsAsync(HttpClient httpClient, string accessToken, Guid groupId, List<AssignedLabels> assignedLabels)
+        internal static async Task SetSensitivityLabelsAsync(PnPConnection connection, string accessToken, Guid groupId, List<AssignedLabels> assignedLabels)
         {
             var patchData = new
             {
@@ -620,7 +620,7 @@ namespace PnP.PowerShell.Commands.Utilities
             {
                 try
                 {
-                    await GraphHelper.PatchAsync<dynamic>(httpClient, accessToken, $"v1.0/groups/{groupId}", patchData);
+                    await GraphHelper.PatchAsync<dynamic>(connection, accessToken, $"v1.0/groups/{groupId}", patchData);
                     retry = false;
                 }
 

--- a/src/Commands/Utilities/PlannerUtility.cs
+++ b/src/Commands/Utilities/PlannerUtility.cs
@@ -1,3 +1,4 @@
+using PnP.PowerShell.Commands.Base;
 using PnP.PowerShell.Commands.Model.Graph;
 using PnP.PowerShell.Commands.Model.Planner;
 using PnP.PowerShell.Commands.Utilities.REST;
@@ -12,19 +13,19 @@ namespace PnP.PowerShell.Commands.Utilities
     internal static class PlannerUtility
     {
         #region Plans
-        public static async Task<IEnumerable<PlannerPlan>> GetPlansAsync(HttpClient httpClient, string accessToken, string groupId, bool resolveDisplayNames)
+        public static async Task<IEnumerable<PlannerPlan>> GetPlansAsync(PnPConnection connection, string accessToken, string groupId, bool resolveDisplayNames)
         {
             var returnCollection = new List<PlannerPlan>();
-            var collection = await GraphHelper.GetResultCollectionAsync<PlannerPlan>(httpClient, $"v1.0/groups/{groupId}/planner/plans", accessToken);
+            var collection = await GraphHelper.GetResultCollectionAsync<PlannerPlan>(connection, $"v1.0/groups/{groupId}/planner/plans", accessToken);
             if (collection != null && collection.Any())
             {
                 if (resolveDisplayNames)
                 {
                     foreach (var plan in collection)
                     {
-                        var fullIdentity = await ResolveIdentityAsync(httpClient, accessToken, plan.CreatedBy.User);
+                        var fullIdentity = await ResolveIdentityAsync(connection, accessToken, plan.CreatedBy.User);
                         plan.CreatedBy.User = fullIdentity;
-                        var owner = await ResolveGroupName(httpClient, accessToken, plan.Owner);
+                        var owner = await ResolveGroupName(connection, accessToken, plan.Owner);
                         plan.Owner = owner;
                         returnCollection.Add(plan);
                     }
@@ -37,33 +38,33 @@ namespace PnP.PowerShell.Commands.Utilities
             return returnCollection;
         }
 
-        public static async Task<PlannerPlan> GetPlanAsync(HttpClient httpClient, string accessToken, string planId, bool resolveDisplayNames)
+        public static async Task<PlannerPlan> GetPlanAsync(PnPConnection connection, string accessToken, string planId, bool resolveDisplayNames)
         {
-            var plan = await GraphHelper.GetAsync<PlannerPlan>(httpClient, $"v1.0/planner/plans/{planId}", accessToken);
+            var plan = await GraphHelper.GetAsync<PlannerPlan>(connection, $"v1.0/planner/plans/{planId}", accessToken);
             if (resolveDisplayNames)
             {
-                plan.CreatedBy.User = await ResolveIdentityAsync(httpClient, accessToken, plan.CreatedBy.User);
+                plan.CreatedBy.User = await ResolveIdentityAsync(connection, accessToken, plan.CreatedBy.User);
             }
             return plan;
         }
 
-        public static async Task<PlannerPlan> CreatePlanAsync(HttpClient httpClient, string accessToken, string groupId, string title)
+        public static async Task<PlannerPlan> CreatePlanAsync(PnPConnection connection, string accessToken, string groupId, string title)
         {
             var stringContent = new StringContent(JsonSerializer.Serialize(new { owner = groupId, title = title }));
             stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-            return await GraphHelper.PostAsync<PlannerPlan>(httpClient, "v1.0/planner/plans", stringContent, accessToken);
+            return await GraphHelper.PostAsync<PlannerPlan>(connection, "v1.0/planner/plans", stringContent, accessToken);
         }
 
-        public static async Task<PlannerPlan> UpdatePlanAsync(HttpClient httpClient, string accessToken, PlannerPlan plan, string title)
+        public static async Task<PlannerPlan> UpdatePlanAsync(PnPConnection connection, string accessToken, PlannerPlan plan, string title)
         {
             var stringContent = new StringContent(JsonSerializer.Serialize(new { title }));
             stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-            var responseMessage = await GraphHelper.PatchAsync(httpClient, accessToken, stringContent, $"v1.0/planner/plans/{plan.Id}", new Dictionary<string, string>() { { "IF-MATCH", plan.ETag } });
+            var responseMessage = await GraphHelper.PatchAsync(connection, accessToken, stringContent, $"v1.0/planner/plans/{plan.Id}", new Dictionary<string, string>() { { "IF-MATCH", plan.ETag } });
             while (responseMessage.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
             {
                 // retrieve the plan again
-                plan = await GraphHelper.GetAsync<PlannerPlan>(httpClient, $"v1.0/planner/plans/{plan.Id}", accessToken);
-                responseMessage = await GraphHelper.PatchAsync(httpClient, accessToken, stringContent, $"v1.0/planner/plans/{plan.Id}", new Dictionary<string, string>() { { "IF-MATCH", plan.ETag } });
+                plan = await GraphHelper.GetAsync<PlannerPlan>(connection, $"v1.0/planner/plans/{plan.Id}", accessToken);
+                responseMessage = await GraphHelper.PatchAsync(connection, accessToken, stringContent, $"v1.0/planner/plans/{plan.Id}", new Dictionary<string, string>() { { "IF-MATCH", plan.ETag } });
             }
             if (responseMessage.IsSuccessStatusCode)
             {
@@ -73,12 +74,12 @@ namespace PnP.PowerShell.Commands.Utilities
             return null;
         }
 
-        public static async Task DeletePlanAsync(HttpClient httpClient, string accessToken, string planId)
+        public static async Task DeletePlanAsync(PnPConnection connection, string accessToken, string planId)
         {
-            var plan = await GetPlanAsync(httpClient, accessToken, planId, false);
+            var plan = await GetPlanAsync(connection, accessToken, planId, false);
             if (plan != null)
             {
-                await GraphHelper.DeleteAsync(httpClient, $"v1.0/planner/plans/{planId}", accessToken, new Dictionary<string, string>() { { "IF-MATCH", plan.ETag } });
+                await GraphHelper.DeleteAsync(connection, $"v1.0/planner/plans/{planId}", accessToken, new Dictionary<string, string>() { { "IF-MATCH", plan.ETag } });
             }
         }
 
@@ -86,23 +87,23 @@ namespace PnP.PowerShell.Commands.Utilities
 
         #region Tasks
 
-        public static async Task<IEnumerable<PlannerTask>> GetTasksAsync(HttpClient httpClient, string accessToken, string planId, bool resolveDisplayNames)
+        public static async Task<IEnumerable<PlannerTask>> GetTasksAsync(PnPConnection connection, string accessToken, string planId, bool resolveDisplayNames)
         {
             var returnCollection = new List<PlannerTask>();
-            var collection = await GraphHelper.GetResultCollectionAsync<PlannerTask>(httpClient, $"v1.0/planner/plans/{planId}/tasks", accessToken);
+            var collection = await GraphHelper.GetResultCollectionAsync<PlannerTask>(connection, $"v1.0/planner/plans/{planId}/tasks", accessToken);
             if (collection != null && collection.Any())
             {
                 if (resolveDisplayNames)
                 {
                     foreach (var task in collection)
                     {
-                        var fullIdentity = await ResolveIdentityAsync(httpClient, accessToken, task.CreatedBy.User);
+                        var fullIdentity = await ResolveIdentityAsync(connection, accessToken, task.CreatedBy.User);
                         task.CreatedBy.User = fullIdentity;
                         if (task.Assignments != null)
                         {
                             foreach (var assignment in task.Assignments)
                             {
-                                assignment.Value.AssignedBy.User = await ResolveIdentityAsync(httpClient, accessToken, assignment.Value.AssignedBy.User);
+                                assignment.Value.AssignedBy.User = await ResolveIdentityAsync(connection, accessToken, assignment.Value.AssignedBy.User);
                             }
                         }
                         returnCollection.Add(task);
@@ -116,24 +117,24 @@ namespace PnP.PowerShell.Commands.Utilities
             return returnCollection;
         }
 
-        public static async Task<PlannerTask> GetTaskAsync(HttpClient httpClient, string accessToken, string taskId, bool resolveDisplayNames, bool includeDetails)
+        public static async Task<PlannerTask> GetTaskAsync(PnPConnection connection, string accessToken, string taskId, bool resolveDisplayNames, bool includeDetails)
         {
-            var task = await GraphHelper.GetAsync<PlannerTask>(httpClient, $"v1.0/planner/tasks/{taskId}", accessToken);
+            var task = await GraphHelper.GetAsync<PlannerTask>(connection, $"v1.0/planner/tasks/{taskId}", accessToken);
             if (resolveDisplayNames)
             {
-                task.CreatedBy.User = await ResolveIdentityAsync(httpClient, accessToken, task.CreatedBy.User);
+                task.CreatedBy.User = await ResolveIdentityAsync(connection, accessToken, task.CreatedBy.User);
             }
             if (includeDetails)
             {
-                var taskDetails = await GetTaskDetailsAsync(httpClient, accessToken, taskId, resolveDisplayNames);
+                var taskDetails = await GetTaskDetailsAsync(connection, accessToken, taskId, resolveDisplayNames);
                 task.Details = taskDetails;
             }
             return task;
         }
 
-        public static async Task<PlannerTaskDetails> GetTaskDetailsAsync(HttpClient httpClient, string accessToken, string taskId, bool resolveDisplayNames)
+        public static async Task<PlannerTaskDetails> GetTaskDetailsAsync(PnPConnection connection, string accessToken, string taskId, bool resolveDisplayNames)
         {
-            var taskDetails = await GraphHelper.GetAsync<PlannerTaskDetails>(httpClient, $"v1.0/planner/tasks/{taskId}/details", accessToken);
+            var taskDetails = await GraphHelper.GetAsync<PlannerTaskDetails>(connection, $"v1.0/planner/tasks/{taskId}/details", accessToken);
             if (!resolveDisplayNames) 
                 return taskDetails;
 
@@ -151,7 +152,7 @@ namespace PnP.PowerShell.Commands.Utilities
                 {
                     newCheckListItem.LastModifiedBy = new IdentitySet
                     {
-                        User = await ResolveIdentityAsync(httpClient, accessToken, checklistItem.Value.LastModifiedBy.User)
+                        User = await ResolveIdentityAsync(connection, accessToken, checklistItem.Value.LastModifiedBy.User)
                     };
                 }
                 newItems.Add(checklistItem.Key, newCheckListItem);
@@ -161,32 +162,32 @@ namespace PnP.PowerShell.Commands.Utilities
             return taskDetails;
         }
 
-        public static async Task<PlannerTask> AddTaskAsync(HttpClient httpClient, string accessToken, PlannerTask task)
+        public static async Task<PlannerTask> AddTaskAsync(PnPConnection connection, string accessToken, PlannerTask task)
         {
-            return await GraphHelper.PostAsync(httpClient, "v1.0/planner/tasks", task, accessToken);
+            return await GraphHelper.PostAsync(connection, "v1.0/planner/tasks", task, accessToken);
         }
 
-        public static async Task DeleteTaskAsync(HttpClient httpClient, string accessToken, string taskId)
+        public static async Task DeleteTaskAsync(PnPConnection connection, string accessToken, string taskId)
         {
-            var task = await GraphHelper.GetAsync<PlannerTask>(httpClient, $"v1.0/planner/tasks/{taskId}", accessToken);
+            var task = await GraphHelper.GetAsync<PlannerTask>(connection, $"v1.0/planner/tasks/{taskId}", accessToken);
             if (task != null)
             {
-                await GraphHelper.DeleteAsync(httpClient, $"v1.0/planner/tasks/{taskId}", accessToken, new Dictionary<string, string>() { { "IF-MATCH", task.ETag } });
+                await GraphHelper.DeleteAsync(connection, $"v1.0/planner/tasks/{taskId}", accessToken, new Dictionary<string, string>() { { "IF-MATCH", task.ETag } });
             }
         }
 
-        public static async Task<PlannerTask> UpdateTaskAsync(HttpClient httpClient, string accessToken, PlannerTask taskToUpdate, PlannerTask task)
+        public static async Task<PlannerTask> UpdateTaskAsync(PnPConnection connection, string accessToken, PlannerTask taskToUpdate, PlannerTask task)
         {
-            return await GraphHelper.PatchAsync(httpClient, accessToken, $"v1.0/planner/tasks/{taskToUpdate.Id}", task, new Dictionary<string, string> { { "IF-MATCH", taskToUpdate.ETag } });
+            return await GraphHelper.PatchAsync(connection, accessToken, $"v1.0/planner/tasks/{taskToUpdate.Id}", task, new Dictionary<string, string> { { "IF-MATCH", taskToUpdate.ETag } });
         }
 
-        public static async Task UpdateTaskDetailsAsync(HttpClient httpClient, string accessToken, PlannerTaskDetails taskToUpdate, string description)
+        public static async Task UpdateTaskDetailsAsync(PnPConnection connection, string accessToken, PlannerTaskDetails taskToUpdate, string description)
         {
             var body = new PlannerTaskDetails
             {
                 Description = description,
             };
-            await GraphHelper.PatchAsync(httpClient, accessToken, $"v1.0/planner/tasks/{taskToUpdate.Id}/details", body, new Dictionary<string, string> { { "IF-MATCH", taskToUpdate.ETag } });
+            await GraphHelper.PatchAsync(connection, accessToken, $"v1.0/planner/tasks/{taskToUpdate.Id}/details", body, new Dictionary<string, string> { { "IF-MATCH", taskToUpdate.ETag } });
         }
 
         #endregion
@@ -199,11 +200,11 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient instance to use to send out requests</param>
         /// <param name="accessToken">AccessToken to use to authenticate the request</param>
         /// <returns>PlannerRoster</returns>
-        public static async Task<PlannerRoster> CreateRosterAsync(HttpClient httpClient, string accessToken)
+        public static async Task<PlannerRoster> CreateRosterAsync(PnPConnection connection, string accessToken)
         {
             var stringContent = new StringContent("{ \"@odata.type\": \"#microsoft.graph.plannerRoster\" }");
             stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-            return await GraphHelper.PostAsync<PlannerRoster>(httpClient, "beta/planner/rosters", stringContent, accessToken);
+            return await GraphHelper.PostAsync<PlannerRoster>(connection, "beta/planner/rosters", stringContent, accessToken);
         }
 
         /// <summary>
@@ -213,9 +214,9 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient instance to use to send out requests</param>
         /// <param name="accessToken">AccessToken to use to authenticate the request</param>
         /// <returns>PlannerRoster</returns>
-        public static async Task<PlannerRoster> GetRosterAsync(HttpClient httpClient, string accessToken, string rosterId)
+        public static async Task<PlannerRoster> GetRosterAsync(PnPConnection connection, string accessToken, string rosterId)
         {
-            return await GraphHelper.GetAsync<PlannerRoster>(httpClient, $"beta/planner/rosters/{rosterId}", accessToken);
+            return await GraphHelper.GetAsync<PlannerRoster>(connection, $"beta/planner/rosters/{rosterId}", accessToken);
         }        
 
         /// <summary>
@@ -225,9 +226,9 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient instance to use to send out requests</param>
         /// <param name="accessToken">AccessToken to use to authenticate the request</param>
         /// <returns>HttpResponseMessage</returns>
-        public static async Task<HttpResponseMessage> DeleteRosterAsync(HttpClient httpClient, string accessToken, string rosterId)
+        public static async Task<HttpResponseMessage> DeleteRosterAsync(PnPConnection connection, string accessToken, string rosterId)
         {
-            return await GraphHelper.DeleteAsync(httpClient, $"beta/planner/rosters/{rosterId}", accessToken);
+            return await GraphHelper.DeleteAsync(connection, $"beta/planner/rosters/{rosterId}", accessToken);
         }
 
         /// <summary>
@@ -238,11 +239,11 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient instance to use to send out requests</param>
         /// <param name="accessToken">AccessToken to use to authenticate the request</param>
         /// <returns>PlannerRoster</returns>
-        public static async Task<PlannerRoster> AddRosterMemberAsync(HttpClient httpClient, string accessToken, string rosterId, string userId)
+        public static async Task<PlannerRoster> AddRosterMemberAsync(PnPConnection connection, string accessToken, string rosterId, string userId)
         {
             var stringContent = new StringContent("{ \"@odata.type\": \"#microsoft.graph.plannerRosterMember\", \"userId\": \"" + userId + "\" }");
             stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-            return await GraphHelper.PostAsync<PlannerRoster>(httpClient, $"beta/planner/rosters/{rosterId}/members", stringContent, accessToken);
+            return await GraphHelper.PostAsync<PlannerRoster>(connection, $"beta/planner/rosters/{rosterId}/members", stringContent, accessToken);
         }
 
         /// <summary>
@@ -253,9 +254,9 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient instance to use to send out requests</param>
         /// <param name="accessToken">AccessToken to use to authenticate the request</param>
         /// <returns>HttpResponseMessage</returns>
-        public static async Task<HttpResponseMessage> RemoveRosterMemberAsync(HttpClient httpClient, string accessToken, string rosterId, string userId)
+        public static async Task<HttpResponseMessage> RemoveRosterMemberAsync(PnPConnection connection, string accessToken, string rosterId, string userId)
         {
-            return await GraphHelper.DeleteAsync(httpClient, $"beta/planner/rosters/{rosterId}/members/{userId}", accessToken);
+            return await GraphHelper.DeleteAsync(connection, $"beta/planner/rosters/{rosterId}/members/{userId}", accessToken);
         } 
 
         /// <summary>
@@ -265,10 +266,10 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient instance to use to send out requests</param>
         /// <param name="accessToken">AccessToken to use to authenticate the request</param>
         /// <returns>IEnumerable<PlannerRosterMember></returns>
-        public static async Task<IEnumerable<PlannerRosterMember>> GetRosterMembersAsync(HttpClient httpClient, string accessToken, string rosterId)
+        public static async Task<IEnumerable<PlannerRosterMember>> GetRosterMembersAsync(PnPConnection connection, string accessToken, string rosterId)
         {
             var returnCollection = new List<PlannerRosterMember>();
-            var collection = await GraphHelper.GetResultCollectionAsync<PlannerRosterMember>(httpClient, $"beta/planner/rosters/{rosterId}/members", accessToken);
+            var collection = await GraphHelper.GetResultCollectionAsync<PlannerRosterMember>(connection, $"beta/planner/rosters/{rosterId}/members", accessToken);
             if (collection != null && collection.Any())
             {
                 returnCollection = collection.ToList();
@@ -283,9 +284,9 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient instance to use to send out requests</param>
         /// <param name="accessToken">AccessToken to use to authenticate the request</param>
         /// <returns>PlannerRoster</returns>
-        public static async Task<PlannerRoster> GetRosterPlansByUserAsync(HttpClient httpClient, string accessToken, string userId)
+        public static async Task<PlannerRoster> GetRosterPlansByUserAsync(PnPConnection connection, string accessToken, string userId)
         {
-            return await GraphHelper.GetAsync<PlannerRoster>(httpClient, $"beta/users/{userId}/planner/rosterPlans", accessToken);
+            return await GraphHelper.GetAsync<PlannerRoster>(connection, $"beta/users/{userId}/planner/rosterPlans", accessToken);
         }
 
         /// <summary>
@@ -295,9 +296,9 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient instance to use to send out requests</param>
         /// <param name="accessToken">AccessToken to use to authenticate the request</param>
         /// <returns>PlannerRoster</returns>
-        public static async Task<PlannerRoster> GetRosterPlansByRosterAsync(HttpClient httpClient, string accessToken, string rosterId)
+        public static async Task<PlannerRoster> GetRosterPlansByRosterAsync(PnPConnection connection, string accessToken, string rosterId)
         {
-            return await GraphHelper.GetAsync<PlannerRoster>(httpClient, $"beta/planner/rosters/{rosterId}/plans", accessToken);
+            return await GraphHelper.GetAsync<PlannerRoster>(connection, $"beta/planner/rosters/{rosterId}/plans", accessToken);
         }         
 
         #endregion
@@ -310,9 +311,9 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient instance to use to send out requests</param>
         /// <param name="accessToken">AccessToken to use to authenticate the request</param>
         /// <returns>PlannerTenantConfig</returns>
-        public static async Task<PlannerTenantConfig> GetPlannerConfigAsync(HttpClient httpClient, string accessToken)
+        public static async Task<PlannerTenantConfig> GetPlannerConfigAsync(PnPConnection connection, string accessToken)
         {
-            var result = await GraphHelper.GetAsync<PlannerTenantConfig>(httpClient, "https://tasks.office.com/taskAPI/tenantAdminSettings/Settings", accessToken);
+            var result = await GraphHelper.GetAsync<PlannerTenantConfig>(connection, "https://tasks.office.com/taskAPI/tenantAdminSettings/Settings", accessToken);
             return result;
         }
 
@@ -322,7 +323,7 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient instance to use to send out requests</param>
         /// <param name="accessToken">AccessToken to use to authenticate the request</param>
         /// <returns>PlannerTenantConfig</returns>
-        public static async Task<PlannerTenantConfig> SetPlannerConfigAsync(HttpClient httpClient, string accessToken, bool? isPlannerAllowed, bool? allowCalendarSharing, bool? allowTenantMoveWithDataLoss, bool? allowTenantMoveWithDataMigration, bool? allowRosterCreation, bool? allowPlannerMobilePushNotifications)
+        public static async Task<PlannerTenantConfig> SetPlannerConfigAsync(PnPConnection connection, string accessToken, bool? isPlannerAllowed, bool? allowCalendarSharing, bool? allowTenantMoveWithDataLoss, bool? allowTenantMoveWithDataMigration, bool? allowRosterCreation, bool? allowPlannerMobilePushNotifications)
         {
             var content = new PlannerTenantConfig
             {
@@ -333,7 +334,7 @@ namespace PnP.PowerShell.Commands.Utilities
                 AllowRosterCreation = allowRosterCreation,
                 AllowPlannerMobilePushNotifications = allowPlannerMobilePushNotifications
             };
-            var result = await GraphHelper.PatchAsync(httpClient, accessToken, "https://tasks.office.com/taskAPI/tenantAdminSettings/Settings", content);
+            var result = await GraphHelper.PatchAsync(connection, accessToken, "https://tasks.office.com/taskAPI/tenantAdminSettings/Settings", content);
             return result;
         }
 
@@ -344,9 +345,9 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient instance to use to send out requests</param>
         /// <param name="accessToken">AccessToken to use to authenticate the request</param>
         /// <returns>PlannerUserPolicy</returns>
-        public static async Task<PlannerUserPolicy> GetPlannerUserPolicyAsync(HttpClient httpClient, string accessToken, string userId)
+        public static async Task<PlannerUserPolicy> GetPlannerUserPolicyAsync(PnPConnection connection, string accessToken, string userId)
         {
-            var result = await GraphHelper.GetAsync<PlannerUserPolicy>(httpClient, $"https://tasks.office.com/taskAPI/tenantAdminSettings/UserPolicy('{userId}')", accessToken);
+            var result = await GraphHelper.GetAsync<PlannerUserPolicy>(connection, $"https://tasks.office.com/taskAPI/tenantAdminSettings/UserPolicy('{userId}')", accessToken);
             return result;
         }        
 
@@ -357,19 +358,19 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient instance to use to send out requests</param>
         /// <param name="accessToken">AccessToken to use to authenticate the request</param>
         /// <returns>PlannerUserPolicy</returns>
-        public static async Task<PlannerUserPolicy> SetPlannerUserPolicyAsync(HttpClient httpClient, string accessToken, string userId, bool? blockDeleteTasksNotCreatedBySelf)
+        public static async Task<PlannerUserPolicy> SetPlannerUserPolicyAsync(PnPConnection connection, string accessToken, string userId, bool? blockDeleteTasksNotCreatedBySelf)
         {
             var content = new PlannerUserPolicy
             {
                 BlockDeleteTasksNotCreatedBySelf = blockDeleteTasksNotCreatedBySelf
             };
-            var result = await GraphHelper.PutAsync<PlannerUserPolicy>(httpClient, $"https://tasks.office.com/taskAPI/tenantAdminSettings/UserPolicy('{userId}')", content, accessToken);
+            var result = await GraphHelper.PutAsync<PlannerUserPolicy>(connection, $"https://tasks.office.com/taskAPI/tenantAdminSettings/UserPolicy('{userId}')", content, accessToken);
             return result;
         }
 
         #endregion
 
-        private static async Task<Identity> ResolveIdentityAsync(HttpClient httpClient, string accessToken, Identity identity)
+        private static async Task<Identity> ResolveIdentityAsync(PnPConnection connection, string accessToken, Identity identity)
         {
             if (identity == null)
             {
@@ -377,7 +378,7 @@ namespace PnP.PowerShell.Commands.Utilities
             }
             if (identity.DisplayName == null)
             {
-                return await GraphHelper.GetAsync<Identity>(httpClient, $"v1.0/users/{identity.Id}", accessToken);
+                return await GraphHelper.GetAsync<Identity>(connection, $"v1.0/users/{identity.Id}", accessToken);
             }
             else
             {
@@ -385,9 +386,9 @@ namespace PnP.PowerShell.Commands.Utilities
             }
         }
 
-        private static async Task<string> ResolveGroupName(HttpClient httpClient, string accessToken, string id)
+        private static async Task<string> ResolveGroupName(PnPConnection connection, string accessToken, string id)
         {
-            var group = await GraphHelper.GetAsync<Group>(httpClient, $"v1.0/groups/{id}?$select=displayName", accessToken);
+            var group = await GraphHelper.GetAsync<Group>(connection, $"v1.0/groups/{id}?$select=displayName", accessToken);
             if (group != null)
             {
                 return group.DisplayName;
@@ -400,45 +401,45 @@ namespace PnP.PowerShell.Commands.Utilities
 
         #region Buckets
 
-        public static async Task<IEnumerable<PlannerBucket>> GetBucketsAsync(HttpClient httpClient, string accessToken, string planId)
+        public static async Task<IEnumerable<PlannerBucket>> GetBucketsAsync(PnPConnection connection, string accessToken, string planId)
         {
-            return await GraphHelper.GetResultCollectionAsync<PlannerBucket>(httpClient, $"v1.0/planner/plans/{planId}/buckets", accessToken); 
+            return await GraphHelper.GetResultCollectionAsync<PlannerBucket>(connection, $"v1.0/planner/plans/{planId}/buckets", accessToken); 
         }
 
-        public static async Task<PlannerBucket> CreateBucketAsync(HttpClient httpClient, string accessToken, string name, string planId)
+        public static async Task<PlannerBucket> CreateBucketAsync(PnPConnection connection, string accessToken, string name, string planId)
         {
             var stringContent = new StringContent(JsonSerializer.Serialize(new { name = name, planId = planId, orderHint = " !" }));
             stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-            return await GraphHelper.PostAsync<PlannerBucket>(httpClient, $"v1.0/planner/buckets", stringContent, accessToken);
+            return await GraphHelper.PostAsync<PlannerBucket>(connection, $"v1.0/planner/buckets", stringContent, accessToken);
         }
 
-        public static async System.Threading.Tasks.Task RemoveBucketAsync(HttpClient httpClient, string accessToken, string bucketId)
+        public static async System.Threading.Tasks.Task RemoveBucketAsync(PnPConnection connection, string accessToken, string bucketId)
         {
-            var bucket = GraphHelper.GetAsync<PlannerBucket>(httpClient, $"v1.0/planner/buckets/{bucketId}", accessToken).GetAwaiter().GetResult();
+            var bucket = GraphHelper.GetAsync<PlannerBucket>(connection, $"v1.0/planner/buckets/{bucketId}", accessToken).GetAwaiter().GetResult();
             if (bucket != null)
             {
-                await GraphHelper.DeleteAsync(httpClient, $"v1.0/planner/buckets/{bucketId}", accessToken, new Dictionary<string, string>() { { "IF-MATCH", bucket.ETag } });
+                await GraphHelper.DeleteAsync(connection, $"v1.0/planner/buckets/{bucketId}", accessToken, new Dictionary<string, string>() { { "IF-MATCH", bucket.ETag } });
             }
         }
 
 
-        public static async Task<IEnumerable<PlannerTask>> GetBucketTasksAsync(HttpClient httpClient, string accessToken, string bucketId, bool resolveDisplayNames)
+        public static async Task<IEnumerable<PlannerTask>> GetBucketTasksAsync(PnPConnection connection, string accessToken, string bucketId, bool resolveDisplayNames)
         {
             var returnCollection = new List<PlannerTask>();
-            var collection = await GraphHelper.GetAsync<RestResultCollection<PlannerTask>>(httpClient, $"v1.0/planner/buckets/{bucketId}/tasks", accessToken);
+            var collection = await GraphHelper.GetAsync<RestResultCollection<PlannerTask>>(connection, $"v1.0/planner/buckets/{bucketId}/tasks", accessToken);
             if (collection != null && collection.Items.Any())
             {
                 if (resolveDisplayNames)
                 {
                     foreach (var task in collection.Items)
                     {
-                        var fullIdentity = await ResolveIdentityAsync(httpClient, accessToken, task.CreatedBy.User);
+                        var fullIdentity = await ResolveIdentityAsync(connection, accessToken, task.CreatedBy.User);
                         task.CreatedBy.User = fullIdentity;
                         if (task.Assignments != null)
                         {
                             foreach (var assignment in task.Assignments)
                             {
-                                assignment.Value.AssignedBy.User = await ResolveIdentityAsync(httpClient, accessToken, assignment.Value.AssignedBy.User);
+                                assignment.Value.AssignedBy.User = await ResolveIdentityAsync(connection, accessToken, assignment.Value.AssignedBy.User);
                             }
                         }
                         returnCollection.Add(task);
@@ -455,13 +456,13 @@ namespace PnP.PowerShell.Commands.Utilities
                     {
                         foreach (var task in collection.Items)
                         {
-                            var fullIdentity = await ResolveIdentityAsync(httpClient, accessToken, task.CreatedBy.User);
+                            var fullIdentity = await ResolveIdentityAsync(connection, accessToken, task.CreatedBy.User);
                             task.CreatedBy.User = fullIdentity;
                             if (task.Assignments != null)
                             {
                                 foreach (var assignment in task.Assignments)
                                 {
-                                    assignment.Value.AssignedBy.User = await ResolveIdentityAsync(httpClient, accessToken, assignment.Value.AssignedBy.User);
+                                    assignment.Value.AssignedBy.User = await ResolveIdentityAsync(connection, accessToken, assignment.Value.AssignedBy.User);
                                 }
                             }
                             returnCollection.Add(task);
@@ -477,14 +478,14 @@ namespace PnP.PowerShell.Commands.Utilities
             return returnCollection;
         }
 
-        public static async Task<PlannerBucket> UpdateBucketAsync(HttpClient httpClient, string accessToken, string name, string bucketId)
+        public static async Task<PlannerBucket> UpdateBucketAsync(PnPConnection connection, string accessToken, string name, string bucketId)
         {
-            var bucket = await GraphHelper.GetAsync<PlannerBucket>(httpClient, $"v1.0/planner/buckets/{bucketId}", accessToken);
+            var bucket = await GraphHelper.GetAsync<PlannerBucket>(connection, $"v1.0/planner/buckets/{bucketId}", accessToken);
             if (bucket != null)
             {
                 var stringContent = new StringContent(JsonSerializer.Serialize(new { name = name }));
                 stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-                return await GraphHelper.PatchAsync<PlannerBucket>(httpClient, accessToken, $"v1.0/planner/buckets/{bucketId}", stringContent, new Dictionary<string, string>() { { "IF-MATCH", bucket.ETag } });
+                return await GraphHelper.PatchAsync<PlannerBucket>(connection, accessToken, $"v1.0/planner/buckets/{bucketId}", stringContent, new Dictionary<string, string>() { { "IF-MATCH", bucket.ETag } });
             }
             return null;
         }

--- a/src/Commands/Utilities/REST/GraphBatch.cs
+++ b/src/Commands/Utilities/REST/GraphBatch.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using PnP.PowerShell.Commands.Base;
 
 namespace PnP.PowerShell.Commands.Utilities.REST
 {
@@ -20,7 +21,7 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             }
         }
 
-        internal static async Task<Dictionary<string, string>> GetPropertyBatchedAsync(HttpClient httpClient, string accessToken, string[] lookupData, string urlTemplate, string property)
+        internal static async Task<Dictionary<string, string>> GetPropertyBatchedAsync(PnPConnection connection, string accessToken, string[] lookupData, string urlTemplate, string property)
         {
             Dictionary<string, string> returnValue = new Dictionary<string, string>();
 
@@ -36,7 +37,7 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             }
             var stringContent = new StringContent(JsonSerializer.Serialize(batch));
             stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-            var result = await GraphHelper.PostAsync<GraphBatchResponse>(httpClient, "v1.0/$batch", stringContent, accessToken);
+            var result = await GraphHelper.PostAsync<GraphBatchResponse>(connection, "v1.0/$batch", stringContent, accessToken);
             if (result.Responses != null && result.Responses.Any())
             {
                 foreach (var response in result.Responses)
@@ -52,7 +53,7 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             return returnValue;
         }
 
-        internal static async Task<Dictionary<string, IEnumerable<T>>> GetObjectCollectionBatchedAsync<T>(HttpClient httpClient, string accessToken, string[] lookupData, string urlTemplate)
+        internal static async Task<Dictionary<string, IEnumerable<T>>> GetObjectCollectionBatchedAsync<T>(PnPConnection connection, string accessToken, string[] lookupData, string urlTemplate)
         {
             Dictionary<string, IEnumerable<T>> returnValue = new Dictionary<string, IEnumerable<T>>();
 
@@ -68,7 +69,7 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             }
             var stringContent = new StringContent(JsonSerializer.Serialize(batch));
             stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-            var result = await GraphHelper.PostAsync<GraphBatchResponse>(httpClient, "v1.0/$batch", stringContent, accessToken);
+            var result = await GraphHelper.PostAsync<GraphBatchResponse>(connection, "v1.0/$batch", stringContent, accessToken);
             if (result.Responses != null && result.Responses.Any())
             {
                 var options = new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase};

--- a/src/Commands/Utilities/REST/GraphHelper.cs
+++ b/src/Commands/Utilities/REST/GraphHelper.cs
@@ -48,7 +48,7 @@ namespace PnP.PowerShell.Commands.Utilities.REST
 
             var message = new HttpRequestMessage();
             message.Method = method;
-            message.RequestUri = !url.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ? new Uri($"https://{PnPConnection.Current.GraphEndPoint}/{url}") : new Uri(url);
+            message.RequestUri = !url.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ? new Uri($"https://{connection.GraphEndPoint}/{url}") : new Uri(url);
             message.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
             if (additionalHeaders != null)
             {

--- a/src/Commands/Utilities/REST/GraphHelper.cs
+++ b/src/Commands/Utilities/REST/GraphHelper.cs
@@ -12,6 +12,9 @@ using System.Threading.Tasks;
 
 namespace PnP.PowerShell.Commands.Utilities.REST
 {
+    /// <summary>
+    /// Helper class that aids in making calls towards the Microsoft Graph API
+    /// </summary>
     internal static class GraphHelper
     {
         public static bool TryGetGraphException(HttpResponseMessage responseMessage, out GraphException exception)
@@ -39,7 +42,7 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             }
         }
 
-        private static HttpRequestMessage GetMessage(string url, HttpMethod method, string accessToken, HttpContent content = null, IDictionary<string, string> additionalHeaders = null)
+        private static HttpRequestMessage GetMessage(string url, HttpMethod method, PnPConnection connection, string accessToken, HttpContent content = null, IDictionary<string, string> additionalHeaders = null)
         {
             if (url.StartsWith("/"))
             {
@@ -66,39 +69,39 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             return message;
         }
 
-        public static async Task<string> GetAsync(HttpClient httpClient, string url, string accessToken, IDictionary<string, string> additionalHeaders = null)
+        public static async Task<string> GetAsync(PnPConnection connection, string url, string accessToken, IDictionary<string, string> additionalHeaders = null)
         {
-            var message = GetMessage(url, HttpMethod.Get, accessToken, null, additionalHeaders);
-            return await SendMessageAsync(httpClient, message, accessToken);
+            var message = GetMessage(url, HttpMethod.Get, connection, accessToken, null, additionalHeaders);
+            return await SendMessageAsync(connection, message, accessToken);
         }
 
-        public static async Task<HttpResponseMessage> GetResponseAsync(HttpClient httpClient, string url, string accessToken)
+        public static async Task<HttpResponseMessage> GetResponseAsync(PnPConnection connection, string url, string accessToken)
         {
-            var message = GetMessage(url, HttpMethod.Get, accessToken);
-            return await GetResponseMessageAsync(httpClient, message);
+            var message = GetMessage(url, HttpMethod.Get, connection, accessToken);
+            return await GetResponseMessageAsync(connection, message);
         }
 
         /// <summary>
         /// Queries the provided URL and looks for the NextLink in the results to fetch all the results
         /// </summary>
         /// <typeparam name="T">Type of object to cast the response items to</typeparam>
-        /// <param name="httpClient">HttpClient to use to make the request</param>
+        /// <param name="connection">Connection to use to make the request</param>
         /// <param name="url">Url to query</param>
         /// <param name="accessToken">AccessToken to use for authorizing the request</param>
         /// <param name="camlCasePolicy">Policy indicating the CamlCase that should be applied when mapping results to typed objects</param>
         /// <param name="propertyNameCaseInsensitive">Indicates if the response be mapped to the typed object ignoring different casing</param>
         /// <returns>List with objects of type T returned by the request</returns>
-        public static async Task<IEnumerable<T>> GetResultCollectionAsync<T>(HttpClient httpClient, string url, string accessToken, bool camlCasePolicy = true, bool propertyNameCaseInsensitive = false)
+        public static async Task<IEnumerable<T>> GetResultCollectionAsync<T>(PnPConnection connection, string url, string accessToken, bool camlCasePolicy = true, bool propertyNameCaseInsensitive = false)
         {
             var results = new List<T>();
-            var request = await GetAsync<RestResultCollection<T>>(httpClient, url, accessToken, camlCasePolicy, propertyNameCaseInsensitive);
+            var request = await GetAsync<RestResultCollection<T>>(connection, url, accessToken, camlCasePolicy, propertyNameCaseInsensitive);
 
             if (request.Items.Any())
             {
                 results.AddRange(request.Items);
                 while (!string.IsNullOrEmpty(request.NextLink))
                 {
-                    request = await GetAsync<RestResultCollection<T>>(httpClient, request.NextLink, accessToken, camlCasePolicy, propertyNameCaseInsensitive);
+                    request = await GetAsync<RestResultCollection<T>>(connection, request.NextLink, accessToken, camlCasePolicy, propertyNameCaseInsensitive);
                     if (request.Items.Any())
                     {
                         results.AddRange(request.Items);
@@ -113,15 +116,15 @@ namespace PnP.PowerShell.Commands.Utilities.REST
         /// Queries the provided URL and returns the results as typed objects. It does NOT follow NextLink pages, use GetResultCollectionAsync instead for that.
         /// </summary>
         /// <typeparam name="T">Type of object to cast the response items to</typeparam>
-        /// <param name="httpClient">HttpClient to use to make the request</param>
+        /// <param name="connection">Connection to use to make the request</param>
         /// <param name="url">Url to query</param>
         /// <param name="accessToken">AccessToken to use for authorizing the request</param>
         /// <param name="camlCasePolicy">Policy indicating the CamlCase that should be applied when mapping results to typed objects</param>
         /// <param name="propertyNameCaseInsensitive">Indicates if the response be mapped to the typed object ignoring different casing</param>
         /// <returns>List with objects of type T returned by the request</returns>
-        public static async Task<T> GetAsync<T>(HttpClient httpClient, string url, string accessToken, bool camlCasePolicy = true, bool propertyNameCaseInsensitive = false)
+        public static async Task<T> GetAsync<T>(PnPConnection connection, string url, string accessToken, bool camlCasePolicy = true, bool propertyNameCaseInsensitive = false)
         {
-            var stringContent = await GetAsync(httpClient, url, accessToken);
+            var stringContent = await GetAsync(connection, url, accessToken);
             if (stringContent != null)
             {
                 var options = new JsonSerializerOptions { IgnoreNullValues = true };
@@ -147,28 +150,28 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             return default(T);
         }
 
-        public static async Task<HttpResponseMessage> PostAsync(HttpClient httpClient, string url, string accessToken, HttpContent content, IDictionary<string, string> additionalHeaders = null)
+        public static async Task<HttpResponseMessage> PostAsync(PnPConnection connection, string url, string accessToken, HttpContent content, IDictionary<string, string> additionalHeaders = null)
         {
-            var message = GetMessage(url, HttpMethod.Post, accessToken, content, additionalHeaders);
-            return await GetResponseMessageAsync(httpClient, message);
+            var message = GetMessage(url, HttpMethod.Post, connection, accessToken, content, additionalHeaders);
+            return await GetResponseMessageAsync(connection, message);
         }
 
-        public static async Task<HttpResponseMessage> PutAsync(HttpClient httpClient, string url, string accessToken, HttpContent content, IDictionary<string, string> additionalHeaders = null)
+        public static async Task<HttpResponseMessage> PutAsync(PnPConnection connection, string url, string accessToken, HttpContent content, IDictionary<string, string> additionalHeaders = null)
         {
-            var message = GetMessage(url, HttpMethod.Put, accessToken, content, additionalHeaders);
-            return await GetResponseMessageAsync(httpClient, message);
+            var message = GetMessage(url, HttpMethod.Put, connection, accessToken, content, additionalHeaders);
+            return await GetResponseMessageAsync(connection, message);
         }
 
         #region DELETE
-        public static async Task<HttpResponseMessage> DeleteAsync(HttpClient httpClient, string url, string accessToken, IDictionary<string, string> additionalHeaders = null)
+        public static async Task<HttpResponseMessage> DeleteAsync(PnPConnection connection, string url, string accessToken, IDictionary<string, string> additionalHeaders = null)
         {
-            var message = GetMessage(url, HttpMethod.Delete, accessToken, null, additionalHeaders);
-            return await GetResponseMessageAsync(httpClient, message);
+            var message = GetMessage(url, HttpMethod.Delete, connection, accessToken, null, additionalHeaders);
+            return await GetResponseMessageAsync(connection, message);
         }
 
-        public static async Task<T> DeleteAsync<T>(HttpClient httpClient, string url, string accessToken, bool camlCasePolicy = true, IDictionary<string, string> additionalHeaders = null)
+        public static async Task<T> DeleteAsync<T>(PnPConnection connection, string url, string accessToken, bool camlCasePolicy = true, IDictionary<string, string> additionalHeaders = null)
         {
-            var response = await DeleteAsync(httpClient, url, accessToken, additionalHeaders);
+            var response = await DeleteAsync(connection, url, accessToken, additionalHeaders);
             if (response.IsSuccessStatusCode)
             {
                 var stringContent = await response.Content.ReadAsStringAsync();
@@ -195,7 +198,7 @@ namespace PnP.PowerShell.Commands.Utilities.REST
         #endregion
 
         #region PATCH
-        public static async Task<T> PatchAsync<T>(HttpClient httpClient, string accessToken, string url, T content, IDictionary<string, string> additionalHeaders = null, bool camlCasePolicy = true)
+        public static async Task<T> PatchAsync<T>(PnPConnection connection, string accessToken, string url, T content, IDictionary<string, string> additionalHeaders = null, bool camlCasePolicy = true)
         {
             var serializerSettings = new JsonSerializerOptions() { IgnoreNullValues = true };
             if (camlCasePolicy)
@@ -205,11 +208,11 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             var requestContent = new StringContent(JsonSerializer.Serialize(content, serializerSettings));
             requestContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
 #if NETFRAMEWORK
-            var message = GetMessage(url,  new HttpMethod("PATCH"), accessToken, requestContent, additionalHeaders);
+            var message = GetMessage(url, new HttpMethod("PATCH"), connection, accessToken, requestContent, additionalHeaders);
 #else
-            var message = GetMessage(url, HttpMethod.Patch, accessToken, requestContent, additionalHeaders);
+            var message = GetMessage(url, HttpMethod.Patch, connection, accessToken, requestContent, additionalHeaders);
 #endif
-            var returnValue = await SendMessageAsync(httpClient, message, accessToken);
+            var returnValue = await SendMessageAsync(connection, message, accessToken);
             if (!string.IsNullOrEmpty(returnValue))
             {
                 return JsonSerializer.Deserialize<T>(returnValue);
@@ -220,14 +223,14 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             }
         }
 
-        public static async Task<T> PatchAsync<T>(HttpClient httpClient, string accessToken, string url, HttpContent content, IDictionary<string, string> additionalHeaders = null)
+        public static async Task<T> PatchAsync<T>(PnPConnection connection, string accessToken, string url, HttpContent content, IDictionary<string, string> additionalHeaders = null)
         {
 #if NETFRAMEWORK
-            var message = GetMessage(url, new HttpMethod("PATCH"), accessToken, content, additionalHeaders);
+            var message = GetMessage(url, new HttpMethod("PATCH"), connection, accessToken, content, additionalHeaders);
 #else
-            var message = GetMessage(url, HttpMethod.Patch, accessToken, content, additionalHeaders);
+            var message = GetMessage(url, HttpMethod.Patch, connection, accessToken, content, additionalHeaders);
 #endif
-            var returnValue = await SendMessageAsync(httpClient, message, accessToken);
+            var returnValue = await SendMessageAsync(connection, message, accessToken);
             if (!string.IsNullOrEmpty(returnValue))
             {
                 return JsonSerializer.Deserialize<T>(returnValue);
@@ -238,27 +241,27 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             }
         }
 
-        public static async Task<HttpResponseMessage> PatchAsync(HttpClient httpClient, string accessToken, HttpContent content, string url, IDictionary<string, string> additionalHeaders = null)
+        public static async Task<HttpResponseMessage> PatchAsync(PnPConnection connection, string accessToken, HttpContent content, string url, IDictionary<string, string> additionalHeaders = null)
         {
 #if NETFRAMEWORK
-            var message = GetMessage(url, new HttpMethod("PATCH"), accessToken, content, additionalHeaders);
+            var message = GetMessage(url, new HttpMethod("PATCH"), connection, accessToken, content, additionalHeaders);
 #else
-            var message = GetMessage(url, HttpMethod.Patch, accessToken, content, additionalHeaders);
+            var message = GetMessage(url, HttpMethod.Patch, connection, accessToken, content, additionalHeaders);
 #endif
-            return await GetResponseMessageAsync(httpClient, message);
+            return await GetResponseMessageAsync(connection, message);
         }
 
         #endregion
 
-        public static async Task<T> PostAsync<T>(HttpClient httpClient, string url, HttpContent content, string accessToken, IDictionary<string, string> additionalHeaders = null, bool propertyNameCaseInsensitive = false)
+        public static async Task<T> PostAsync<T>(PnPConnection connection, string url, HttpContent content, string accessToken, IDictionary<string, string> additionalHeaders = null, bool propertyNameCaseInsensitive = false)
         {
-            return await PostInternalAsync<T>(httpClient, url, accessToken, content, additionalHeaders, propertyNameCaseInsensitive);
+            return await PostInternalAsync<T>(connection, url, accessToken, content, additionalHeaders, propertyNameCaseInsensitive);
         }
 
-        public static async Task<T> PutAsync<T>(HttpClient httpClient, string url, string accessToken, HttpContent content, IDictionary<string, string> additionalHeaders = null)
+        public static async Task<T> PutAsync<T>(PnPConnection connection, string url, string accessToken, HttpContent content, IDictionary<string, string> additionalHeaders = null)
         {
-            var message = GetMessage(url, HttpMethod.Put, accessToken, content, additionalHeaders);
-            var stringContent = await SendMessageAsync(httpClient, message, accessToken);
+            var message = GetMessage(url, HttpMethod.Put, connection, accessToken, content, additionalHeaders);
+            var stringContent = await SendMessageAsync(connection, message, accessToken);
             if (stringContent != null)
             {
                 try
@@ -273,23 +276,23 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             return default;
         }
 
-        public static async Task<T> PostAsync<T>(HttpClient httpClient, string url, T content, string accessToken)
+        public static async Task<T> PostAsync<T>(PnPConnection connection, string url, T content, string accessToken)
         {
             var requestContent = new StringContent(JsonSerializer.Serialize(content, new JsonSerializerOptions() { IgnoreNullValues = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
             requestContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
 
-            return await PostInternalAsync<T>(httpClient, url, accessToken, requestContent);
+            return await PostInternalAsync<T>(connection, url, accessToken, requestContent);
         }
 
-        public static async Task<T> PostAsync<T>(HttpClient httpClient, string url, string accessToken)
+        public static async Task<T> PostAsync<T>(PnPConnection connection, string url, string accessToken)
         {
-            return await PostInternalAsync<T>(httpClient, url, accessToken, null);
+            return await PostInternalAsync<T>(connection, url, accessToken, null);
         }
 
-        private static async Task<T> PostInternalAsync<T>(HttpClient httpClient, string url, string accessToken, HttpContent content, IDictionary<string, string> additionalHeaders = null, bool propertyNameCaseInsensitive = false)
+        private static async Task<T> PostInternalAsync<T>(PnPConnection connection, string url, string accessToken, HttpContent content, IDictionary<string, string> additionalHeaders = null, bool propertyNameCaseInsensitive = false)
         {
-            var message = GetMessage(url, HttpMethod.Post, accessToken, content, additionalHeaders);
-            var stringContent = await SendMessageAsync(httpClient, message, accessToken);
+            var message = GetMessage(url, HttpMethod.Post, connection, accessToken, content, additionalHeaders);
+            var stringContent = await SendMessageAsync(connection, message, accessToken);
             if (stringContent != null)
             {
                 try
@@ -304,12 +307,12 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             return default;
         }
 
-        public static async Task<T> PutAsync<T>(HttpClient httpClient, string url, T content, string accessToken)
+        public static async Task<T> PutAsync<T>(PnPConnection connection, string url, T content, string accessToken)
         {
             var requestContent = new StringContent(JsonSerializer.Serialize(content, new JsonSerializerOptions() { IgnoreNullValues = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
             requestContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-            var message = GetMessage(url, HttpMethod.Put, accessToken, requestContent);
-            var returnValue = await SendMessageAsync(httpClient, message, accessToken);
+            var message = GetMessage(url, HttpMethod.Put, connection, accessToken, requestContent);
+            var returnValue = await SendMessageAsync(connection, message, accessToken);
             if (!string.IsNullOrEmpty(returnValue))
             {
                 return JsonSerializer.Deserialize<T>(returnValue, new JsonSerializerOptions() { IgnoreNullValues = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
@@ -320,22 +323,22 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             }
         }
 
-        public static async Task<HttpResponseMessage> DeleteAsync(HttpClient httpClient, string url, string accessToken)
+        public static async Task<HttpResponseMessage> DeleteAsync(PnPConnection connection, string url, string accessToken)
         {
-            var message = GetMessage(url, HttpMethod.Delete, accessToken);
-            var response = await GetResponseMessageAsync(httpClient, message);
+            var message = GetMessage(url, HttpMethod.Delete, connection, accessToken);
+            var response = await GetResponseMessageAsync(connection, message);
             return response;
         }
 
-        private static async Task<string> SendMessageAsync(HttpClient httpClient, HttpRequestMessage message, string accessToken)
+        private static async Task<string> SendMessageAsync(PnPConnection connection, HttpRequestMessage message, string accessToken)
         {
-            var response = await httpClient.SendAsync(message);
+            var response = await connection.HttpClient.SendAsync(message);
             while (response.StatusCode == (HttpStatusCode)429)
             {
                 // throttled
                 var retryAfter = response.Headers.RetryAfter;
                 await Task.Delay(retryAfter.Delta.Value.Seconds * 1000);
-                response = await httpClient.SendAsync(CloneMessage(message));
+                response = await connection.HttpClient.SendAsync(CloneMessage(message));
             }
             if (response.IsSuccessStatusCode)
             {
@@ -350,15 +353,15 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             }
         }
 
-        public static async Task<HttpResponseMessage> GetResponseMessageAsync(HttpClient httpClient, HttpRequestMessage message)
+        public static async Task<HttpResponseMessage> GetResponseMessageAsync(PnPConnection connection, HttpRequestMessage message)
         {
-            var response = await httpClient.SendAsync(message);
+            var response = await connection.HttpClient.SendAsync(message);
             while (response.StatusCode == (HttpStatusCode)429)
             {
                 // throttled
                 var retryAfter = response.Headers.RetryAfter;
                 await Task.Delay(retryAfter.Delta.Value.Seconds * 1000);
-                response = await httpClient.SendAsync(CloneMessage(message));
+                response = await connection.HttpClient.SendAsync(CloneMessage(message));
             }
 
             // Validate if the response was successful, if not throw an exception

--- a/src/Commands/Utilities/ServiceHealthUtility.cs
+++ b/src/Commands/Utilities/ServiceHealthUtility.cs
@@ -1,8 +1,7 @@
+using PnP.PowerShell.Commands.Base;
 using PnP.PowerShell.Commands.Model.ServiceHealth;
 using PnP.PowerShell.Commands.Utilities.REST;
 using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace PnP.PowerShell.Commands.Utilities
@@ -14,12 +13,12 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <summary>
         /// Retrieves all Service Update Messages
         /// </summary>
-        /// <param name="httpClient">HttpClient to use for retrieval of the data</param>
+        /// <param name="connection">Connection to use for retrieval of the data</param>
         /// <param name="accessToken">AccessToken to use for authentication of the request</param>
         /// <returns>List with <see cref="ServiceUpdateMessage"> objects</returns>
-        public static async Task<IEnumerable<ServiceUpdateMessage>> GetServiceUpdateMessagesAsync(HttpClient httpClient, string accessToken)
+        public static async Task<IEnumerable<ServiceUpdateMessage>> GetServiceUpdateMessagesAsync(PnPConnection connection, string accessToken)
         {
-            var collection = await GraphHelper.GetResultCollectionAsync<ServiceUpdateMessage>(httpClient, $"v1.0/admin/serviceAnnouncement/messages", accessToken);            
+            var collection = await GraphHelper.GetResultCollectionAsync<ServiceUpdateMessage>(connection, $"v1.0/admin/serviceAnnouncement/messages", accessToken);            
             return collection;
         }
 
@@ -27,12 +26,12 @@ namespace PnP.PowerShell.Commands.Utilities
         /// Retrieves a specific Service Update Message
         /// </summary>
         /// <param name="id">Identifier of the service update message</param>
-        /// <param name="httpClient">HttpClient to use for retrieval of the data</param>
+        /// <param name="connection">Connection to use for retrieval of the data</param>
         /// <param name="accessToken">AccessToken to use for authentication of the request</param>
         /// <returns><see cref="ServiceUpdateMessage"> containing the requested information</returns>
-        public static async Task<ServiceUpdateMessage> GetServiceUpdateMessageByIdAsync(string id, HttpClient httpClient, string accessToken)
+        public static async Task<ServiceUpdateMessage> GetServiceUpdateMessageByIdAsync(string id, PnPConnection connection, string accessToken)
         {
-            var item = await GraphHelper.GetAsync<ServiceUpdateMessage>(httpClient, $"v1.0/admin/serviceAnnouncement/messages/{id}", accessToken);
+            var item = await GraphHelper.GetAsync<ServiceUpdateMessage>(connection, $"v1.0/admin/serviceAnnouncement/messages/{id}", accessToken);
             return item;
         }
 
@@ -43,9 +42,9 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient to use for updating the data</param>
         /// <param name="accessToken">AccessToken to use for authentication of the request</param>
         /// <returns>Boolean indicating whether the request succeeded</returns>
-        public static async Task<bool> SetServiceUpdateMessageAsReadByIdAsync(string id, HttpClient httpClient, string accessToken)
+        public static async Task<bool> SetServiceUpdateMessageAsReadByIdAsync(string id, PnPConnection connection, string accessToken)
         {
-            return await SetServiceUpdateMessageAsReadByIdAsync(new [] { id }, httpClient, accessToken);
+            return await SetServiceUpdateMessageAsReadByIdAsync(new [] { id }, connection, accessToken);
         }
 
         /// <summary>
@@ -55,10 +54,10 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient to use for updating the data</param>
         /// <param name="accessToken">AccessToken to use for authentication of the request</param>
         /// <returns>Boolean indicating whether the request succeeded</returns>
-        public static async Task<bool> SetServiceUpdateMessageAsReadByIdAsync(string[] id, HttpClient httpClient, string accessToken)
+        public static async Task<bool> SetServiceUpdateMessageAsReadByIdAsync(string[] id, PnPConnection connection, string accessToken)
         {
             var postBody = new PnP.PowerShell.Commands.Model.ServiceHealth.ServiceUpdateMessageReadStatusBody { MessageIds = id };
-            var item = await GraphHelper.PostAsync<PnP.PowerShell.Commands.Model.ServiceHealth.ServiceUpdateMessageReadStatusBody>(httpClient, "v1.0/admin/serviceAnnouncement/messages/markRead", postBody, accessToken);
+            var item = await GraphHelper.PostAsync<PnP.PowerShell.Commands.Model.ServiceHealth.ServiceUpdateMessageReadStatusBody>(connection, "v1.0/admin/serviceAnnouncement/messages/markRead", postBody, accessToken);
             return true;
         }
 
@@ -69,9 +68,9 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient to use for updating the data</param>
         /// <param name="accessToken">AccessToken to use for authentication of the request</param>
         /// <returns>Boolean indicating whether the request succeeded</returns>
-        public static async Task<bool> SetServiceUpdateMessageAsUnreadByIdAsync(string id, HttpClient httpClient, string accessToken)
+        public static async Task<bool> SetServiceUpdateMessageAsUnreadByIdAsync(string id, PnPConnection connection, string accessToken)
         {
-            return await SetServiceUpdateMessageAsUnreadByIdAsync(new [] { id }, httpClient, accessToken);
+            return await SetServiceUpdateMessageAsUnreadByIdAsync(new [] { id }, connection, accessToken);
         }
 
         /// <summary>
@@ -81,10 +80,10 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient to use for updating the data</param>
         /// <param name="accessToken">AccessToken to use for authentication of the request</param>
         /// <returns>Boolean indicating whether the request succeeded</returns>
-        public static async Task<bool> SetServiceUpdateMessageAsUnreadByIdAsync(string[] id, HttpClient httpClient, string accessToken)
+        public static async Task<bool> SetServiceUpdateMessageAsUnreadByIdAsync(string[] id, PnPConnection connection, string accessToken)
         {
             var postBody = new PnP.PowerShell.Commands.Model.ServiceHealth.ServiceUpdateMessageReadStatusBody { MessageIds = id };
-            var item = await GraphHelper.PostAsync<PnP.PowerShell.Commands.Model.ServiceHealth.ServiceUpdateMessageReadStatusBody>(httpClient, "v1.0/admin/serviceAnnouncement/messages/markUnread", postBody, accessToken);
+            var item = await GraphHelper.PostAsync<PnP.PowerShell.Commands.Model.ServiceHealth.ServiceUpdateMessageReadStatusBody>(connection, "v1.0/admin/serviceAnnouncement/messages/markUnread", postBody, accessToken);
             return true;
         }       
 
@@ -95,9 +94,9 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient to use for updating the data</param>
         /// <param name="accessToken">AccessToken to use for authentication of the request</param>
         /// <returns>Boolean indicating whether the request succeeded</returns>
-        public static async Task<bool> SetServiceUpdateMessageAsArchivedByIdAsync(string id, HttpClient httpClient, string accessToken)
+        public static async Task<bool> SetServiceUpdateMessageAsArchivedByIdAsync(string id, PnPConnection connection, string accessToken)
         {
-            return await SetServiceUpdateMessageAsArchivedByIdAsync(new [] { id }, httpClient, accessToken);
+            return await SetServiceUpdateMessageAsArchivedByIdAsync(new [] { id }, connection, accessToken);
         }
 
         /// <summary>
@@ -107,10 +106,10 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient to use for updating the data</param>
         /// <param name="accessToken">AccessToken to use for authentication of the request</param>
         /// <returns>Boolean indicating whether the request succeeded</returns>
-        public static async Task<bool> SetServiceUpdateMessageAsArchivedByIdAsync(string[] id, HttpClient httpClient, string accessToken)
+        public static async Task<bool> SetServiceUpdateMessageAsArchivedByIdAsync(string[] id, PnPConnection connection, string accessToken)
         {
             var postBody = new PnP.PowerShell.Commands.Model.ServiceHealth.ServiceUpdateMessageReadStatusBody { MessageIds = id };
-            var item = await GraphHelper.PostAsync<PnP.PowerShell.Commands.Model.ServiceHealth.ServiceUpdateMessageReadStatusBody>(httpClient, "v1.0/admin/serviceAnnouncement/messages/archive", postBody, accessToken);
+            var item = await GraphHelper.PostAsync<PnP.PowerShell.Commands.Model.ServiceHealth.ServiceUpdateMessageReadStatusBody>(connection, "v1.0/admin/serviceAnnouncement/messages/archive", postBody, accessToken);
             return true;
         }
 
@@ -121,9 +120,9 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient to use for updating the data</param>
         /// <param name="accessToken">AccessToken to use for authentication of the request</param>
         /// <returns>Boolean indicating whether the request succeeded</returns>
-        public static async Task<bool> SetServiceUpdateMessageAsUnarchivedByIdAsync(string id, HttpClient httpClient, string accessToken)
+        public static async Task<bool> SetServiceUpdateMessageAsUnarchivedByIdAsync(string id, PnPConnection connection, string accessToken)
         {
-            return await SetServiceUpdateMessageAsUnarchivedByIdAsync(new [] { id }, httpClient, accessToken);
+            return await SetServiceUpdateMessageAsUnarchivedByIdAsync(new [] { id }, connection, accessToken);
         }
 
         /// <summary>
@@ -133,10 +132,10 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient to use for updating the data</param>
         /// <param name="accessToken">AccessToken to use for authentication of the request</param>
         /// <returns>Boolean indicating whether the request succeeded</returns>
-        public static async Task<bool> SetServiceUpdateMessageAsUnarchivedByIdAsync(string[] id, HttpClient httpClient, string accessToken)
+        public static async Task<bool> SetServiceUpdateMessageAsUnarchivedByIdAsync(string[] id, PnPConnection connection, string accessToken)
         {
             var postBody = new PnP.PowerShell.Commands.Model.ServiceHealth.ServiceUpdateMessageReadStatusBody { MessageIds = id };
-            var item = await GraphHelper.PostAsync<PnP.PowerShell.Commands.Model.ServiceHealth.ServiceUpdateMessageReadStatusBody>(httpClient, "v1.0/admin/serviceAnnouncement/messages/unarchive", postBody, accessToken);
+            var item = await GraphHelper.PostAsync<PnP.PowerShell.Commands.Model.ServiceHealth.ServiceUpdateMessageReadStatusBody>(connection, "v1.0/admin/serviceAnnouncement/messages/unarchive", postBody, accessToken);
             return true;
         }
 
@@ -147,9 +146,9 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient to use for updating the data</param>
         /// <param name="accessToken">AccessToken to use for authentication of the request</param>
         /// <returns>Boolean indicating whether the request succeeded</returns>
-        public static async Task<bool> SetServiceUpdateMessageAsFavoriteByIdAsync(string id, HttpClient httpClient, string accessToken)
+        public static async Task<bool> SetServiceUpdateMessageAsFavoriteByIdAsync(string id, PnPConnection connection, string accessToken)
         {
-            return await SetServiceUpdateMessageAsFavoriteByIdAsync(new [] { id }, httpClient, accessToken);
+            return await SetServiceUpdateMessageAsFavoriteByIdAsync(new [] { id }, connection, accessToken);
         }
 
         /// <summary>
@@ -159,10 +158,10 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient to use for updating the data</param>
         /// <param name="accessToken">AccessToken to use for authentication of the request</param>
         /// <returns>Boolean indicating whether the request succeeded</returns>
-        public static async Task<bool> SetServiceUpdateMessageAsFavoriteByIdAsync(string[] id, HttpClient httpClient, string accessToken)
+        public static async Task<bool> SetServiceUpdateMessageAsFavoriteByIdAsync(string[] id, PnPConnection connection, string accessToken)
         {
             var postBody = new PnP.PowerShell.Commands.Model.ServiceHealth.ServiceUpdateMessageReadStatusBody { MessageIds = id };
-            var item = await GraphHelper.PostAsync<PnP.PowerShell.Commands.Model.ServiceHealth.ServiceUpdateMessageReadStatusBody>(httpClient, "v1.0/admin/serviceAnnouncement/messages/favorite", postBody, accessToken);
+            var item = await GraphHelper.PostAsync<PnP.PowerShell.Commands.Model.ServiceHealth.ServiceUpdateMessageReadStatusBody>(connection, "v1.0/admin/serviceAnnouncement/messages/favorite", postBody, accessToken);
             return true;
         }    
 
@@ -173,9 +172,9 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient to use for updating the data</param>
         /// <param name="accessToken">AccessToken to use for authentication of the request</param>
         /// <returns>Boolean indicating whether the request succeeded</returns>
-        public static async Task<bool> SetServiceUpdateMessageAsNotfavoriteByIdAsync(string id, HttpClient httpClient, string accessToken)
+        public static async Task<bool> SetServiceUpdateMessageAsNotfavoriteByIdAsync(string id, PnPConnection connection, string accessToken)
         {
-            return await SetServiceUpdateMessageAsNotfavoriteByIdAsync(new [] { id }, httpClient, accessToken);
+            return await SetServiceUpdateMessageAsNotfavoriteByIdAsync(new [] { id }, connection, accessToken);
         }
 
         /// <summary>
@@ -185,10 +184,10 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="httpClient">HttpClient to use for updating the data</param>
         /// <param name="accessToken">AccessToken to use for authentication of the request</param>
         /// <returns>Boolean indicating whether the request succeeded</returns>
-        public static async Task<bool> SetServiceUpdateMessageAsNotfavoriteByIdAsync(string[] id, HttpClient httpClient, string accessToken)
+        public static async Task<bool> SetServiceUpdateMessageAsNotfavoriteByIdAsync(string[] id, PnPConnection connection, string accessToken)
         {
             var postBody = new PnP.PowerShell.Commands.Model.ServiceHealth.ServiceUpdateMessageReadStatusBody { MessageIds = id };
-            var item = await GraphHelper.PostAsync<PnP.PowerShell.Commands.Model.ServiceHealth.ServiceUpdateMessageReadStatusBody>(httpClient, "v1.0/admin/serviceAnnouncement/messages/unfavorite", postBody, accessToken);
+            var item = await GraphHelper.PostAsync<PnP.PowerShell.Commands.Model.ServiceHealth.ServiceUpdateMessageReadStatusBody>(connection, "v1.0/admin/serviceAnnouncement/messages/unfavorite", postBody, accessToken);
             return true;
         }
 
@@ -199,12 +198,12 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <summary>
         /// Retrieves all Service Health Issues
         /// </summary>
-        /// <param name="httpClient">HttpClient to use for retrieval of the data</param>
+        /// <param name="connection">Connection to use for retrieval of the data</param>
         /// <param name="accessToken">AccessToken to use for authentication of the request</param>
         /// <returns>List with <see cref="ServiceHealthIssue"> objects</returns>
-        public static async Task<IEnumerable<ServiceHealthIssue>> GetServiceHealthIssuesAsync(HttpClient httpClient, string accessToken)
+        public static async Task<IEnumerable<ServiceHealthIssue>> GetServiceHealthIssuesAsync(PnPConnection connection, string accessToken)
         {
-            var collection = await GraphHelper.GetResultCollectionAsync<ServiceHealthIssue>(httpClient, $"v1.0/admin/serviceAnnouncement/issues", accessToken);            
+            var collection = await GraphHelper.GetResultCollectionAsync<ServiceHealthIssue>(connection, $"v1.0/admin/serviceAnnouncement/issues", accessToken);            
             return collection;
         }
 
@@ -212,12 +211,12 @@ namespace PnP.PowerShell.Commands.Utilities
         /// Retrieves a specific Service Health Issue
         /// </summary>
         /// <param name="id">Identifier of the service health issue</param>
-        /// <param name="httpClient">HttpClient to use for retrieval of the data</param>
+        /// <param name="connection">Connection to use for retrieval of the data</param>
         /// <param name="accessToken">AccessToken to use for authentication of the request</param>
         /// <returns><see cref="ServiceHealthIssue"> containing the requested information</returns>
-        public static async Task<ServiceHealthIssue> GetServiceHealthIssueByIdAsync(string id, HttpClient httpClient, string accessToken)
+        public static async Task<ServiceHealthIssue> GetServiceHealthIssueByIdAsync(string id, PnPConnection connection, string accessToken)
         {
-            var item = await GraphHelper.GetAsync<ServiceHealthIssue>(httpClient, $"v1.0/admin/serviceAnnouncement/issues/{id}", accessToken);
+            var item = await GraphHelper.GetAsync<ServiceHealthIssue>(connection, $"v1.0/admin/serviceAnnouncement/issues/{id}", accessToken);
             return item;
         }
 
@@ -228,12 +227,12 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <summary>
         /// Retrieves the current health of all services
         /// </summary>
-        /// <param name="httpClient">HttpClient to use for retrieval of the data</param>
+        /// <param name="connection">Connection to use for retrieval of the data</param>
         /// <param name="accessToken">AccessToken to use for authentication of the request</param>
         /// <returns>List with <see cref="ServiceHealthCurrent"> objects</returns>
-        public static async Task<IEnumerable<ServiceHealthCurrent>> GetServiceCurrentHealthAsync(HttpClient httpClient, string accessToken)
+        public static async Task<IEnumerable<ServiceHealthCurrent>> GetServiceCurrentHealthAsync(PnPConnection connection, string accessToken)
         {
-            var collection = await GraphHelper.GetResultCollectionAsync<ServiceHealthCurrent>(httpClient, $"v1.0/admin/serviceAnnouncement/healthOverviews", accessToken);            
+            var collection = await GraphHelper.GetResultCollectionAsync<ServiceHealthCurrent>(connection, $"v1.0/admin/serviceAnnouncement/healthOverviews", accessToken);            
             return collection;
         }
 
@@ -241,12 +240,12 @@ namespace PnP.PowerShell.Commands.Utilities
         /// Retrieves the current health of a specific service
         /// </summary>
         /// <param name="id">Full name of the service, i.e. Microsoft Forms</param>
-        /// <param name="httpClient">HttpClient to use for retrieval of the data</param>
+        /// <param name="connection">Connection to use for retrieval of the data</param>
         /// <param name="accessToken">AccessToken to use for authentication of the request</param>
         /// <returns><see cref="ServiceHealthIssue"> containing the requested information</returns>
-        public static async Task<ServiceHealthCurrent> GetServiceCurrentHealthByIdAsync(string id, HttpClient httpClient, string accessToken)
+        public static async Task<ServiceHealthCurrent> GetServiceCurrentHealthByIdAsync(string id, PnPConnection connection, string accessToken)
         {
-            var item = await GraphHelper.GetAsync<ServiceHealthCurrent>(httpClient, $"v1.0/admin/serviceAnnouncement/healthOverviews/{id}", accessToken);
+            var item = await GraphHelper.GetAsync<ServiceHealthCurrent>(connection, $"v1.0/admin/serviceAnnouncement/healthOverviews/{id}", accessToken);
             return item;
         }        
 

--- a/src/Commands/Utilities/SiteTemplates.cs
+++ b/src/Commands/Utilities/SiteTemplates.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using Microsoft.Online.SharePoint.TenantAdministration;
 using PnP.PowerShell.Commands.Model.SharePoint;
 using System.Collections.Generic;
+using PnP.PowerShell.Commands.Base;
 
 namespace PnP.PowerShell.Commands.Utilities
 {
@@ -18,25 +19,25 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <summary>
         /// Invokes the provided site script on the provided site
         /// </summary>
-        /// <param name="httpClient">HttpClient that can be used to make HTTP requests</param>
+        /// <param name="connection">Connection that can be used to make HTTP requests</param>
         /// <param name="accessToken">Access Token that can be used to authorize HTTP requests</param>
         /// <param name="script">The Site Script to invoke</param>
         /// <param name="siteUrl">The URL of the SharePoint site to invoke the Site Script on</param>
         /// <returns>HttpResponseMessage with the</returns>
-        public static async Task<RestResultCollection<InvokeSiteScriptActionResponse>> InvokeSiteScript(HttpClient httpClient, string accessToken, TenantSiteScript script, string siteUrl)
+        public static async Task<RestResultCollection<InvokeSiteScriptActionResponse>> InvokeSiteScript(PnPConnection connection, string accessToken, TenantSiteScript script, string siteUrl)
         {
-            return await InvokeSiteScript(httpClient, accessToken, script.Content, siteUrl);
+            return await InvokeSiteScript(connection, accessToken, script.Content, siteUrl);
         }
 
         /// <summary>
         /// Invokes the provided site script on the provided site
         /// </summary>
-        /// <param name="httpClient">HttpClient that can be used to make HTTP requests</param>
+        /// <param name="connection">Connection that can be used to make HTTP requests</param>
         /// <param name="accessToken">Access Token that can be used to authorize HTTP requests</param>
         /// <param name="scriptContent">The Site Script content to invoke</param>
         /// <param name="siteUrl">The URL of the SharePoint site to invoke the Site Script on</param>
         /// <returns></returns>
-        public static async Task<RestResultCollection<InvokeSiteScriptActionResponse>> InvokeSiteScript(HttpClient httpClient, string accessToken, string scriptContent, string siteUrl)
+        public static async Task<RestResultCollection<InvokeSiteScriptActionResponse>> InvokeSiteScript(PnPConnection connection, string accessToken, string scriptContent, string siteUrl)
         {
             // Properly encode the contents of the provided site script
             var escapedScript = Regex.Replace(scriptContent.Replace("\\\"", "\\\\\\\""), "(?<!\\\\)\"", "\\\"", RegexOptions.Singleline);
@@ -46,7 +47,7 @@ namespace PnP.PowerShell.Commands.Utilities
             postBody.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
 
             // Execute the request to apply the site script
-            var results = await GraphHelper.PostAsync<RestResultCollection<InvokeSiteScriptActionResponse>>(httpClient, $"{siteUrl.TrimEnd('/')}/_api/Microsoft.Sharepoint.Utilities.WebTemplateExtensions.SiteScriptUtility.ExecuteTemplateScript()", postBody, accessToken, new Dictionary<string, string>{{ "Accept", "application/json" }});
+            var results = await GraphHelper.PostAsync<RestResultCollection<InvokeSiteScriptActionResponse>>(connection, $"{siteUrl.TrimEnd('/')}/_api/Microsoft.Sharepoint.Utilities.WebTemplateExtensions.SiteScriptUtility.ExecuteTemplateScript()", postBody, accessToken, new Dictionary<string, string>{{ "Accept", "application/json" }});
             return results;
         }
 

--- a/src/Commands/Utilities/TeamsUtility.cs
+++ b/src/Commands/Utilities/TeamsUtility.cs
@@ -24,25 +24,25 @@ namespace PnP.PowerShell.Commands.Utilities
         private const int PageSize = 100;
 
         #region Team
-        public static async Task<List<Group>> GetGroupsWithTeamAsync(HttpClient httpClient, string accessToken)
+        public static async Task<List<Group>> GetGroupsWithTeamAsync(PnPConnection connection, string accessToken)
         {
-            var collection = await GraphHelper.GetResultCollectionAsync<Group>(httpClient, $"beta/groups?$filter=resourceProvisioningOptions/Any(x:x eq 'Team')&$select=Id,DisplayName,MailNickName,Description,Visibility&$top={PageSize}", accessToken);
+            var collection = await GraphHelper.GetResultCollectionAsync<Group>(connection, $"beta/groups?$filter=resourceProvisioningOptions/Any(x:x eq 'Team')&$select=Id,DisplayName,MailNickName,Description,Visibility&$top={PageSize}", accessToken);
             return collection.ToList();
         }
 
-        public static async Task<Group> GetGroupWithTeamAsync(HttpClient httpClient, string accessToken, string mailNickname)
+        public static async Task<Group> GetGroupWithTeamAsync(PnPConnection connection, string accessToken, string mailNickname)
         {
-            return await GraphHelper.GetAsync<Group>(httpClient, $"beta/groups?$filter=(resourceProvisioningOptions/Any(x:x eq 'Team') and mailNickname eq '{mailNickname}')&$select=Id,DisplayName,MailNickName,Description,Visibility", accessToken);
+            return await GraphHelper.GetAsync<Group>(connection, $"beta/groups?$filter=(resourceProvisioningOptions/Any(x:x eq 'Team') and mailNickname eq '{mailNickname}')&$select=Id,DisplayName,MailNickName,Description,Visibility", accessToken);
         }
 
-        public static async Task<List<Team>> GetTeamsAsync(string accessToken, HttpClient httpClient)
+        public static async Task<List<Team>> GetTeamsAsync(string accessToken, PnPConnection connection)
         {
             List<Team> teams = new List<Team>();
 
-            var groups = await GetGroupsWithTeamAsync(httpClient, accessToken);
+            var groups = await GetGroupsWithTeamAsync(connection, accessToken);
             foreach (var group in groups)
             {
-                Team team = await ParseTeamJsonAsync(accessToken, httpClient, group.Id);
+                Team team = await ParseTeamJsonAsync(accessToken, connection, group.Id);
 
                 if (team != null)
                 {
@@ -55,12 +55,12 @@ namespace PnP.PowerShell.Commands.Utilities
             return teams;
         }
 
-        public static async Task<Team> GetTeamAsync(string accessToken, HttpClient httpClient, string groupId)
+        public static async Task<Team> GetTeamAsync(string accessToken, PnPConnection connection, string groupId)
         {
             // get the group
-            var group = await GraphHelper.GetAsync<Group>(httpClient, $"v1.0/groups/{groupId}?$select=Id,DisplayName,MailNickName,Description,Visibility", accessToken);
+            var group = await GraphHelper.GetAsync<Group>(connection, $"v1.0/groups/{groupId}?$select=Id,DisplayName,MailNickName,Description,Visibility", accessToken);
 
-            Team team = await ParseTeamJsonAsync(accessToken, httpClient, group.Id);
+            Team team = await ParseTeamJsonAsync(accessToken, connection, group.Id);
             if (team != null)
             {
                 team.DisplayName = group.DisplayName;
@@ -74,11 +74,11 @@ namespace PnP.PowerShell.Commands.Utilities
             }
         }
 
-        public static async Task<HttpResponseMessage> DeleteTeamAsync(string accessToken, HttpClient httpClient, string groupId)
+        public static async Task<HttpResponseMessage> DeleteTeamAsync(string accessToken, PnPConnection connection, string groupId)
         {
-            return await GraphHelper.DeleteAsync(httpClient, $"v1.0/groups/{groupId}", accessToken);
+            return await GraphHelper.DeleteAsync(connection, $"v1.0/groups/{groupId}", accessToken);
         }
-        public static async Task<HttpResponseMessage> CloneTeamAsync(string accessToken, HttpClient httpClient, string groupId, TeamCloneInformation teamClone)
+        public static async Task<HttpResponseMessage> CloneTeamAsync(string accessToken, PnPConnection connection, string groupId, TeamCloneInformation teamClone)
         {
             StringContent content = new StringContent(JsonSerializer.Serialize( new { displayName = teamClone.DisplayName , 
                     classification = teamClone.Classification , 
@@ -88,14 +88,14 @@ namespace PnP.PowerShell.Commands.Utilities
                     partsToClone = String.Join(",", teamClone.PartsToClone)
             }));
             content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-            return await GraphHelper.PostAsync(httpClient, $"v1.0/teams/{groupId}/clone", accessToken, content);
+            return await GraphHelper.PostAsync(connection, $"v1.0/teams/{groupId}/clone", accessToken, content);
         }
-        private static async Task<Team> ParseTeamJsonAsync(string accessToken, HttpClient httpClient, string groupId)
+        private static async Task<Team> ParseTeamJsonAsync(string accessToken, PnPConnection connection, string groupId)
         {
             // Get Settings
             try
             {
-                var team = await GraphHelper.GetAsync<Team>(httpClient, $"v1.0/teams/{groupId}", accessToken, false, true);
+                var team = await GraphHelper.GetAsync<Team>(connection, $"v1.0/teams/{groupId}", accessToken, false, true);
                 if (team != null)
                 {
                     team.GroupId = groupId;
@@ -121,7 +121,7 @@ namespace PnP.PowerShell.Commands.Utilities
             }
         }
 
-        public static async Task<Team> NewTeamAsync(string accessToken, HttpClient httpClient, string groupId, string displayName, string description, string classification, string mailNickname, GroupVisibility visibility, TeamCreationInformation teamCI, string[] owners, string[] members, Guid[] sensitivityLabels, TeamsTemplateType templateType = TeamsTemplateType.None, TeamResourceBehaviorOptions?[] resourceBehaviorOptions = null)
+        public static async Task<Team> NewTeamAsync(string accessToken, PnPConnection connection, string groupId, string displayName, string description, string classification, string mailNickname, GroupVisibility visibility, TeamCreationInformation teamCI, string[] owners, string[] members, Guid[] sensitivityLabels, TeamsTemplateType templateType = TeamsTemplateType.None, TeamResourceBehaviorOptions?[] resourceBehaviorOptions = null)
         {
             Group group = null;
             Team returnTeam = null;
@@ -129,7 +129,7 @@ namespace PnP.PowerShell.Commands.Utilities
             // Create the Group
             if (string.IsNullOrEmpty(groupId))
             {
-                group = await CreateGroupAsync(accessToken, httpClient, displayName, description, classification, mailNickname, visibility, owners, sensitivityLabels, templateType, resourceBehaviorOptions);
+                group = await CreateGroupAsync(accessToken, connection, displayName, description, classification, mailNickname, visibility, owners, sensitivityLabels, templateType, resourceBehaviorOptions);
                 bool wait = true;
                 int iterations = 0;
                 while (wait)
@@ -138,7 +138,7 @@ namespace PnP.PowerShell.Commands.Utilities
 
                     try
                     {
-                        var createdGroup = await GraphHelper.GetAsync<Group>(httpClient, $"v1.0/groups/{group.Id}", accessToken);
+                        var createdGroup = await GraphHelper.GetAsync<Group>(connection, $"v1.0/groups/{group.Id}", accessToken);
                         if (!string.IsNullOrEmpty(createdGroup.DisplayName))
                         {
                             wait = false;
@@ -159,7 +159,7 @@ namespace PnP.PowerShell.Commands.Utilities
             }
             else
             {
-                group = await GraphHelper.GetAsync<Group>(httpClient, $"v1.0/groups/{groupId}", accessToken);
+                group = await GraphHelper.GetAsync<Group>(connection, $"v1.0/groups/{groupId}", accessToken);
                 if (group == null)
                 {
                     throw new PSArgumentException($"Cannot find group with id {groupId}");
@@ -176,10 +176,10 @@ namespace PnP.PowerShell.Commands.Utilities
                 {
                     try
                     {
-                        var teamSettings = await GraphHelper.PutAsync(httpClient, $"v1.0/groups/{group.Id}/team", team, accessToken);
+                        var teamSettings = await GraphHelper.PutAsync(connection, $"v1.0/groups/{group.Id}/team", team, accessToken);
                         if (teamSettings != null)
                         {
-                            returnTeam = await GetTeamAsync(accessToken, httpClient, group.Id);
+                            returnTeam = await GetTeamAsync(accessToken, connection, group.Id);
                         }
                         retry = false;
                     }
@@ -219,7 +219,7 @@ namespace PnP.PowerShell.Commands.Utilities
                     var ownersAndMembers = BatchUtility.Chunk(teamOwnersAndMembers, 200);
                     foreach (var chunk in ownersAndMembers)
                     {
-                        await GraphHelper.PostAsync(httpClient, $"v1.0/teams/{group.Id}/members/add", new { values = chunk.ToList() }, accessToken);
+                        await GraphHelper.PostAsync(connection, $"v1.0/teams/{group.Id}/members/add", new { values = chunk.ToList() }, accessToken);
                     }
                 }
 
@@ -237,14 +237,14 @@ namespace PnP.PowerShell.Commands.Utilities
             return $"users/{escapedUpn}";
         }
 
-        private static async Task<Group> CreateGroupAsync(string accessToken, HttpClient httpClient, string displayName, string description, string classification, string mailNickname, GroupVisibility visibility, string[] owners, Guid[] sensitivityLabels, TeamsTemplateType templateType = TeamsTemplateType.None, TeamResourceBehaviorOptions?[] resourceBehaviorOptions = null)
+        private static async Task<Group> CreateGroupAsync(string accessToken, PnPConnection connection, string displayName, string description, string classification, string mailNickname, GroupVisibility visibility, string[] owners, Guid[] sensitivityLabels, TeamsTemplateType templateType = TeamsTemplateType.None, TeamResourceBehaviorOptions?[] resourceBehaviorOptions = null)
         {
             // When creating a group, we always need an owner, thus we'll try to define it from the passed in owners array
             string ownerId = null;
             if (owners != null && owners.Length > 0)
             {
                 // Owner(s) have been provided, use the first owner as the initial owner. The other owners will be added later.
-                var user = await GraphHelper.GetAsync<User>(httpClient, $"v1.0/{GetUserGraphUrlForUPN(owners[0])}?$select=Id", accessToken);
+                var user = await GraphHelper.GetAsync<User>(connection, $"v1.0/{GetUserGraphUrlForUPN(owners[0])}?$select=Id", accessToken);
 
                 if (user != null)
                 {
@@ -254,7 +254,7 @@ namespace PnP.PowerShell.Commands.Utilities
                 else
                 {
                     // Unable to find the owner by its user principal name, try looking for it on its email address
-                    var collection = await GraphHelper.GetResultCollectionAsync<User>(httpClient, $"v1.0/users?$filter=mail eq '{owners[0]}'&$select=Id", accessToken);
+                    var collection = await GraphHelper.GetResultCollectionAsync<User>(connection, $"v1.0/users?$filter=mail eq '{owners[0]}'&$select=Id", accessToken);
                     if (collection != null && collection.Any())
                     {
                         // User found on its email address
@@ -272,7 +272,7 @@ namespace PnP.PowerShell.Commands.Utilities
                 if (contextSettings.Type != Framework.Utilities.Context.ClientContextType.AzureADCertificate)
                 {
                     // A delegate context is available, make the user part of the delegate token the owner
-                    var user = await GraphHelper.GetAsync<User>(httpClient, "v1.0/me?$select=Id", accessToken);
+                    var user = await GraphHelper.GetAsync<User>(connection, "v1.0/me?$select=Id", accessToken);
 
                     if (user != null)
                     {
@@ -289,7 +289,7 @@ namespace PnP.PowerShell.Commands.Utilities
                 Description = description,
                 Classification = classification,
                 MailEnabled = true,
-                MailNickname = mailNickname ?? await CreateAliasAsync(httpClient, accessToken),
+                MailNickname = mailNickname ?? await CreateAliasAsync(connection, accessToken),
                 GroupTypes = new List<string>() { "Unified" },
                 SecurityEnabled = false,
                 Visibility = visibility == GroupVisibility.NotSpecified ? GroupVisibility.Private : visibility
@@ -347,7 +347,7 @@ namespace PnP.PowerShell.Commands.Utilities
             }
             try
             {
-                return await GraphHelper.PostAsync<Group>(httpClient, "v1.0/groups", group, accessToken);
+                return await GraphHelper.PostAsync<Group>(connection, "v1.0/groups", group, accessToken);
             }
             catch (GraphException ex)
             {
@@ -362,7 +362,7 @@ namespace PnP.PowerShell.Commands.Utilities
             }
         }
 
-        private static async Task<string> CreateAliasAsync(HttpClient httpClient, string accessToken)
+        private static async Task<string> CreateAliasAsync(PnPConnection connection, string accessToken)
         {
             var guid = Guid.NewGuid().ToString();
             var teamName = string.Empty;
@@ -370,7 +370,7 @@ namespace PnP.PowerShell.Commands.Utilities
             do
             {
                 var teamNameTemp = $"msteams_{guid.Substring(0, 8)}{guid.Substring(9, 4)}";
-                var collection = await GraphHelper.GetAsync<RestResultCollection<Group>>(httpClient, $"v1.0/groups?$filter=groupTypes/any(c:c+eq+'Unified') and (mailNickname eq '{teamNameTemp}')", accessToken);
+                var collection = await GraphHelper.GetAsync<RestResultCollection<Group>>(connection, $"v1.0/groups?$filter=groupTypes/any(c:c+eq+'Unified') and (mailNickname eq '{teamNameTemp}')", accessToken);
                 if (collection != null)
                 {
                     if (!collection.Items.Any()) teamName = teamNameTemp;
@@ -380,44 +380,44 @@ namespace PnP.PowerShell.Commands.Utilities
             return teamName;
         }
 
-        public static async Task<Team> UpdateTeamAsync(HttpClient httpClient, string accessToken, string groupId, Team team)
+        public static async Task<Team> UpdateTeamAsync(PnPConnection connection, string accessToken, string groupId, Team team)
         {
-            return await GraphHelper.PatchAsync<Team>(httpClient, accessToken, $"v1.0/teams/{groupId}", team);
+            return await GraphHelper.PatchAsync<Team>(connection, accessToken, $"v1.0/teams/{groupId}", team);
         }
 
-        public static async Task<Group> UpdateGroupAsync(HttpClient httpClient, string accessToken, string groupId, Group group)
+        public static async Task<Group> UpdateGroupAsync(PnPConnection connection, string accessToken, string groupId, Group group)
         {
-            return await GraphHelper.PatchAsync<Group>(httpClient, accessToken, $"v1.0/groups/{groupId}", group);
+            return await GraphHelper.PatchAsync<Group>(connection, accessToken, $"v1.0/groups/{groupId}", group);
         }
 
-        public static async Task SetTeamPictureAsync(HttpClient httpClient, string accessToken, string groupId, byte[] bytes, string contentType)
+        public static async Task SetTeamPictureAsync(PnPConnection connection, string accessToken, string groupId, byte[] bytes, string contentType)
         {
             var byteArrayContent = new ByteArrayContent(bytes);
             byteArrayContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(contentType);
-            await GraphHelper.PutAsync<string>(httpClient, $"v1.0/groups/{groupId}/photo/$value", accessToken, byteArrayContent);
+            await GraphHelper.PutAsync<string>(connection, $"v1.0/groups/{groupId}/photo/$value", accessToken, byteArrayContent);
         }
 
-        public static async Task<HttpResponseMessage> SetTeamArchivedStateAsync(HttpClient httpClient, string accessToken, string groupId, bool archived, bool? setSiteReadOnly)
+        public static async Task<HttpResponseMessage> SetTeamArchivedStateAsync(PnPConnection connection, string accessToken, string groupId, bool archived, bool? setSiteReadOnly)
         {
             if (archived)
             {
                 StringContent content = new StringContent(JsonSerializer.Serialize(setSiteReadOnly.HasValue ? new { shouldSetSpoSiteReadOnlyForMembers = setSiteReadOnly } : null));
                 content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-                return await GraphHelper.PostAsync(httpClient, $"v1.0/teams/{groupId}/archive", accessToken, content);
+                return await GraphHelper.PostAsync(connection, $"v1.0/teams/{groupId}/archive", accessToken, content);
             }
             else
             {
                 StringContent content = new StringContent("");
                 content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-                return await GraphHelper.PostAsync(httpClient, $"v1.0/teams/{groupId}/unarchive", accessToken, content);
+                return await GraphHelper.PostAsync(connection, $"v1.0/teams/{groupId}/unarchive", accessToken, content);
             }
         }
         #endregion
 
         #region Users
-        public static async Task AddUserAsync(HttpClient httpClient, string accessToken, string groupId, string upn, string role)
+        public static async Task AddUserAsync(PnPConnection connection, string accessToken, string groupId, string upn, string role)
         {
-            var userIdResult = await GraphHelper.GetAsync(httpClient, $"v1.0/{GetUserGraphUrlForUPN(upn)}?$select=Id", accessToken);
+            var userIdResult = await GraphHelper.GetAsync(connection, $"v1.0/{GetUserGraphUrlForUPN(upn)}?$select=Id", accessToken);
             var resultElement = JsonSerializer.Deserialize<JsonElement>(userIdResult);
             if (resultElement.TryGetProperty("id", out JsonElement idProperty))
             {
@@ -429,11 +429,11 @@ namespace PnP.PowerShell.Commands.Utilities
                 var stringContent = new StringContent(JsonSerializer.Serialize(postData));
                 stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
 
-                await GraphHelper.PostAsync(httpClient, $"v1.0/groups/{groupId}/{role.ToLower()}s/$ref", accessToken, stringContent);
+                await GraphHelper.PostAsync(connection, $"v1.0/groups/{groupId}/{role.ToLower()}s/$ref", accessToken, stringContent);
             }
         }
 
-        public static async Task AddUsersAsync(HttpClient httpClient, string accessToken, string groupId, string[] upn, string role)
+        public static async Task AddUsersAsync(PnPConnection connection, string accessToken, string groupId, string[] upn, string role)
         {
             var teamChannelMember = new List<TeamChannelMember>();
             if(upn != null && upn.Length > 0)
@@ -447,13 +447,13 @@ namespace PnP.PowerShell.Commands.Utilities
                     var chunks = BatchUtility.Chunk(teamChannelMember, 200);
                     foreach (var chunk in chunks.ToList())
                     {
-                        await GraphHelper.PostAsync(httpClient, $"v1.0/teams/{groupId}/members/add", new { values = chunk.ToList() }, accessToken);
+                        await GraphHelper.PostAsync(connection, $"v1.0/teams/{groupId}/members/add", new { values = chunk.ToList() }, accessToken);
                     }
                 }
             }            
         }
 
-        public static async Task<List<User>> GetUsersAsync(HttpClient httpClient, string accessToken, string groupId, string role)
+        public static async Task<List<User>> GetUsersAsync(PnPConnection connection, string accessToken, string groupId, string role)
         {
             var selectedRole = role != null ? role.ToLower() : null;
             var owners = new List<User>();
@@ -461,7 +461,7 @@ namespace PnP.PowerShell.Commands.Utilities
             var members = new List<User>();
             if (selectedRole != "guest")
             {
-                owners = (await GraphHelper.GetResultCollectionAsync<User>(httpClient, $"v1.0/groups/{groupId}/owners?$select=Id,displayName,userPrincipalName,userType", accessToken)).Select(t => new User()
+                owners = (await GraphHelper.GetResultCollectionAsync<User>(connection, $"v1.0/groups/{groupId}/owners?$select=Id,displayName,userPrincipalName,userType", accessToken)).Select(t => new User()
                 {
                     Id = t.Id,
                     DisplayName = t.DisplayName,
@@ -471,7 +471,7 @@ namespace PnP.PowerShell.Commands.Utilities
             }
             if (selectedRole != "owner")
             {
-                var users = (await GraphHelper.GetResultCollectionAsync<User>(httpClient, $"v1.0/groups/{groupId}/members?$select=Id,displayName,userPrincipalName,userType", accessToken));
+                var users = (await GraphHelper.GetResultCollectionAsync<User>(connection, $"v1.0/groups/{groupId}/members?$select=Id,displayName,userPrincipalName,userType", accessToken));
                 HashSet<string> hashSet = new HashSet<string>(owners.Select(u => u.Id));
                 foreach (var user in users)
                 {
@@ -510,12 +510,12 @@ namespace PnP.PowerShell.Commands.Utilities
             return finalList;
         }
 
-        public static async Task<IEnumerable<User>> GetUsersAsync(HttpClient httpClient, string accessToken, string groupId, string channelId, string role)
+        public static async Task<IEnumerable<User>> GetUsersAsync(PnPConnection connection, string accessToken, string groupId, string channelId, string role)
         {
             List<User> users = new List<User>();
             var selectedRole = role != null ? role.ToLower() : null;
 
-            var collection = await GraphHelper.GetResultCollectionAsync<TeamChannelMember>(httpClient, $"v1.0/teams/{groupId}/channels/{channelId}/members", accessToken);
+            var collection = await GraphHelper.GetResultCollectionAsync<TeamChannelMember>(connection, $"v1.0/teams/{groupId}/channels/{channelId}/members", accessToken);
             if (collection != null && collection.Any())
             {
                 users.AddRange(collection.Select(m => new User() { DisplayName = m.DisplayName, Id = m.UserId, UserPrincipalName = m.Email, UserType = m.Roles.Count > 0 ? m.Roles[0].ToLower() : "" }));
@@ -531,34 +531,34 @@ namespace PnP.PowerShell.Commands.Utilities
             }
         }
 
-        public static async Task DeleteUserAsync(HttpClient httpClient, string accessToken, string groupId, string upn, string role)
+        public static async Task DeleteUserAsync(PnPConnection connection, string accessToken, string groupId, string upn, string role)
         {
-            var user = await GraphHelper.GetAsync<User>(httpClient, $"v1.0/{GetUserGraphUrlForUPN(upn)}?$select=Id", accessToken);
+            var user = await GraphHelper.GetAsync<User>(connection, $"v1.0/{GetUserGraphUrlForUPN(upn)}?$select=Id", accessToken);
             if (user != null)
             {
                 // check if the user is an owner
-                var owners = await GraphHelper.GetResultCollectionAsync<User>(httpClient, $"v1.0/groups/{groupId}/owners?$select=Id", accessToken);
+                var owners = await GraphHelper.GetResultCollectionAsync<User>(connection, $"v1.0/groups/{groupId}/owners?$select=Id", accessToken);
                 if (owners.Any() && owners.FirstOrDefault(u => u.Id.Equals(user.Id, StringComparison.OrdinalIgnoreCase)) != null)
                 {
                     if (owners.Count() == 1)
                     {
                         throw new PSInvalidOperationException("Last owner cannot be removed");
                     }
-                    await GraphHelper.DeleteAsync(httpClient, $"v1.0/groups/{groupId}/owners/{user.Id}/$ref", accessToken);
+                    await GraphHelper.DeleteAsync(connection, $"v1.0/groups/{groupId}/owners/{user.Id}/$ref", accessToken);
                 }
                 if (!role.Equals("owner", StringComparison.OrdinalIgnoreCase))
                 {
-                    await GraphHelper.DeleteAsync(httpClient, $"v1.0/groups/{groupId}/members/{user.Id}/$ref", accessToken);
+                    await GraphHelper.DeleteAsync(connection, $"v1.0/groups/{groupId}/members/{user.Id}/$ref", accessToken);
                 }
             }
         }
 
-        public static async Task<List<TeamUser>> GetTeamUsersWithDisplayNameAsync(HttpClient httpClient, string accessToken, string groupId, string userDisplayName)
+        public static async Task<List<TeamUser>> GetTeamUsersWithDisplayNameAsync(PnPConnection connection, string accessToken, string groupId, string userDisplayName)
         {
             // multiple users can have same display name, so using list
             var teamUserWithDisplayName = new List<TeamUser>();
 
-            teamUserWithDisplayName = (await GraphHelper.GetResultCollectionAsync<TeamUser>(httpClient, $"v1.0/teams/{groupId}/members?$filter=displayname eq '{userDisplayName}'", accessToken)).Select(t => new TeamUser()
+            teamUserWithDisplayName = (await GraphHelper.GetResultCollectionAsync<TeamUser>(connection, $"v1.0/teams/{groupId}/members?$filter=displayname eq '{userDisplayName}'", accessToken)).Select(t => new TeamUser()
             {
                 Id = t.Id,
                 DisplayName = t.DisplayName,
@@ -569,7 +569,7 @@ namespace PnP.PowerShell.Commands.Utilities
             return teamUserWithDisplayName;
         }
 
-        public static async Task<TeamUser> UpdateTeamUserRole(HttpClient httpClient, string accessToken, string groupId, string teamMemberId, string role)
+        public static async Task<TeamUser> UpdateTeamUserRole(PnPConnection connection, string accessToken, string groupId, string teamMemberId, string role)
         {
             var teamUser = new TeamUser
             {
@@ -579,7 +579,7 @@ namespace PnP.PowerShell.Commands.Utilities
 
             var updateUserEndpoint = $"v1.0/teams/{groupId}/members/{teamMemberId}";
 
-            var result = await GraphHelper.PatchAsync(httpClient, accessToken, updateUserEndpoint, teamUser);
+            var result = await GraphHelper.PatchAsync(connection, accessToken, updateUserEndpoint, teamUser);
             
             return result;
         }
@@ -587,22 +587,22 @@ namespace PnP.PowerShell.Commands.Utilities
         #endregion
 
         #region Channel
-        public static async Task<IEnumerable<TeamChannel>> GetChannelsAsync(string accessToken, HttpClient httpClient, string groupId)
+        public static async Task<IEnumerable<TeamChannel>> GetChannelsAsync(string accessToken, PnPConnection connection, string groupId)
         {
-            var collection = await GraphHelper.GetResultCollectionAsync<TeamChannel>(httpClient, $"v1.0/teams/{groupId}/channels", accessToken);
+            var collection = await GraphHelper.GetResultCollectionAsync<TeamChannel>(connection, $"v1.0/teams/{groupId}/channels", accessToken);
             return collection;
         }
-        public static async Task<TeamChannel> GetPrimaryChannelAsync(string accessToken, HttpClient httpClient, string groupId)
+        public static async Task<TeamChannel> GetPrimaryChannelAsync(string accessToken, PnPConnection connection, string groupId)
         {
-            var collection = await GraphHelper.GetAsync<TeamChannel>(httpClient, $"v1.0/teams/{groupId}/primaryChannel", accessToken);
+            var collection = await GraphHelper.GetAsync<TeamChannel>(connection, $"v1.0/teams/{groupId}/primaryChannel", accessToken);
             return collection;
         }
-        public static async Task<HttpResponseMessage> DeleteChannelAsync(string accessToken, HttpClient httpClient, string groupId, string channelId)
+        public static async Task<HttpResponseMessage> DeleteChannelAsync(string accessToken, PnPConnection connection, string groupId, string channelId)
         {
-            return await GraphHelper.DeleteAsync(httpClient, $"v1.0/teams/{groupId}/channels/{channelId}", accessToken);
+            return await GraphHelper.DeleteAsync(connection, $"v1.0/teams/{groupId}/channels/{channelId}", accessToken);
         }
 
-        public static async Task<TeamChannel> AddChannelAsync(string accessToken, HttpClient httpClient, string groupId, string displayName, string description, bool isPrivate, string ownerUPN, bool isFavoriteByDefault)
+        public static async Task<TeamChannel> AddChannelAsync(string accessToken, PnPConnection connection, string groupId, string displayName, string description, bool isPrivate, string ownerUPN, bool isFavoriteByDefault)
         {
             var channel = new TeamChannel()
             {
@@ -616,32 +616,32 @@ namespace PnP.PowerShell.Commands.Utilities
             if (isPrivate)
             {
                 channel.Type = "#Microsoft.Graph.channel";
-                var user = await GraphHelper.GetAsync<User>(httpClient, $"v1.0/{GetUserGraphUrlForUPN(ownerUPN)}", accessToken);
+                var user = await GraphHelper.GetAsync<User>(connection, $"v1.0/{GetUserGraphUrlForUPN(ownerUPN)}", accessToken);
                 channel.Members = new List<TeamChannelMember>();
                 channel.Members.Add(new TeamChannelMember() { Roles = new List<string> { "owner" }, UserIdentifier = $"https://{PnPConnection.Current.GraphEndPoint}/v1.0/users('{user.Id}')" });
-                return await GraphHelper.PostAsync<TeamChannel>(httpClient, $"v1.0/teams/{groupId}/channels", channel, accessToken);
+                return await GraphHelper.PostAsync<TeamChannel>(connection, $"v1.0/teams/{groupId}/channels", channel, accessToken);
             }
             else
             {
                 channel.IsFavoriteByDefault = isFavoriteByDefault;
-                return await GraphHelper.PostAsync<TeamChannel>(httpClient, $"v1.0/teams/{groupId}/channels", channel, accessToken);
+                return await GraphHelper.PostAsync<TeamChannel>(connection, $"v1.0/teams/{groupId}/channels", channel, accessToken);
             }
         }
 
-        public static async Task PostMessageAsync(HttpClient httpClient, string accessToken, string groupId, string channelId, TeamChannelMessage message)
+        public static async Task PostMessageAsync(PnPConnection connection, string accessToken, string groupId, string channelId, TeamChannelMessage message)
         {
-            await GraphHelper.PostAsync(httpClient, $"v1.0/teams/{groupId}/channels/{channelId}/messages", message, accessToken);
+            await GraphHelper.PostAsync(connection, $"v1.0/teams/{groupId}/channels/{channelId}/messages", message, accessToken);
         }
 
-        public static async Task<TeamChannelMessage> GetMessageAsync(HttpClient httpClient, string accessToken, string groupId, string channelId, string messageId)
+        public static async Task<TeamChannelMessage> GetMessageAsync(PnPConnection connection, string accessToken, string groupId, string channelId, string messageId)
         {
-            return await GraphHelper.GetAsync<TeamChannelMessage>(httpClient, $"v1.0/teams/{groupId}/channels/{channelId}/messages/{messageId}", accessToken);
+            return await GraphHelper.GetAsync<TeamChannelMessage>(connection, $"v1.0/teams/{groupId}/channels/{channelId}/messages/{messageId}", accessToken);
         }
 
-        public static async Task<List<TeamChannelMessage>> GetMessagesAsync(HttpClient httpClient, string accessToken, string groupId, string channelId, bool includeDeleted = false)
+        public static async Task<List<TeamChannelMessage>> GetMessagesAsync(PnPConnection connection, string accessToken, string groupId, string channelId, bool includeDeleted = false)
         {
             List<TeamChannelMessage> messages = new List<TeamChannelMessage>();
-            var collection = await GraphHelper.GetResultCollectionAsync<TeamChannelMessage>(httpClient, $"v1.0/teams/{groupId}/channels/{channelId}/messages", accessToken);
+            var collection = await GraphHelper.GetResultCollectionAsync<TeamChannelMessage>(connection, $"v1.0/teams/{groupId}/channels/{channelId}/messages", accessToken);
             messages.AddRange(collection);
 
             if (includeDeleted)
@@ -657,9 +657,9 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <summary>
         /// List all the replies to a message in a channel of a team.
         /// </summary>
-        public static async Task<List<TeamChannelMessageReply>> GetMessageRepliesAsync(HttpClient httpClient, string accessToken, string groupId, string channelId, string messageId, bool includeDeleted = false)
+        public static async Task<List<TeamChannelMessageReply>> GetMessageRepliesAsync(PnPConnection connection, string accessToken, string groupId, string channelId, string messageId, bool includeDeleted = false)
         {
-            var replies = await GraphHelper.GetResultCollectionAsync<TeamChannelMessageReply>(httpClient, $"v1.0/teams/{groupId}/channels/{channelId}/messages/{messageId}/replies", accessToken);
+            var replies = await GraphHelper.GetResultCollectionAsync<TeamChannelMessageReply>(connection, $"v1.0/teams/{groupId}/channels/{channelId}/messages/{messageId}/replies", accessToken);
 
             return includeDeleted ? replies.ToList() : replies.Where(r => r.DeletedDateTime.HasValue).ToList();
         }
@@ -667,14 +667,14 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <summary>
         /// Get a specific reply of a message in a channel of a team.
         /// </summary>
-        public static async Task<TeamChannelMessageReply> GetMessageReplyAsync(HttpClient httpClient, string accessToken, string groupId, string channelId, string messageId, string replyId)
+        public static async Task<TeamChannelMessageReply> GetMessageReplyAsync(PnPConnection connection, string accessToken, string groupId, string channelId, string messageId, string replyId)
         {
-            return await GraphHelper.GetAsync<TeamChannelMessageReply>(httpClient, $"v1.0/teams/{groupId}/channels/{channelId}/messages/{messageId}/replies/{replyId}", accessToken);
+            return await GraphHelper.GetAsync<TeamChannelMessageReply>(connection, $"v1.0/teams/{groupId}/channels/{channelId}/messages/{messageId}/replies/{replyId}", accessToken);
         }
 
-        public static async Task<TeamChannel> UpdateChannelAsync(HttpClient httpClient, string accessToken, string groupId, string channelId, TeamChannel channel)
+        public static async Task<TeamChannel> UpdateChannelAsync(PnPConnection connection, string accessToken, string groupId, string channelId, TeamChannel channel)
         {
-            return await GraphHelper.PatchAsync(httpClient, accessToken, $"v1.0/teams/{groupId}/channels/{channelId}", channel);
+            return await GraphHelper.PatchAsync(connection, accessToken, $"v1.0/teams/{groupId}/channels/{channelId}", channel);
         }
         #endregion
 
@@ -684,12 +684,12 @@ namespace PnP.PowerShell.Commands.Utilities
         /// Get specific memberbership of user who has access to a certain Microsoft Teams channel.
         /// </summary>
         /// <returns>User channel membership.</returns>
-        public static async Task<TeamChannelMember> GetChannelMemberAsync(HttpClient httpClient, string accessToken, string groupId, string channelId, string membershipId)
+        public static async Task<TeamChannelMember> GetChannelMemberAsync(PnPConnection connection, string accessToken, string groupId, string channelId, string membershipId)
         {
             // Currently the Graph request to get a membership by id fails (v1.0/teams/{groupId}/channels/{channelId}/members/{membershipId}).
             // This is why the method below is used.
 
-            var memberships = await GetChannelMembersAsync(httpClient, accessToken, groupId, channelId);
+            var memberships = await GetChannelMembersAsync(connection, accessToken, groupId, channelId);
             return memberships.FirstOrDefault(m => membershipId.Equals(m.Id));
         }
 
@@ -697,9 +697,9 @@ namespace PnP.PowerShell.Commands.Utilities
         /// Get list of all memberships of a certain Microsoft Teams channel.
         /// </summary>
         /// <returns>List of memberships.</returns>
-        public static async Task<IEnumerable<TeamChannelMember>> GetChannelMembersAsync(HttpClient httpClient, string accessToken, string groupId, string channelId, string role = null)
+        public static async Task<IEnumerable<TeamChannelMember>> GetChannelMembersAsync(PnPConnection connection, string accessToken, string groupId, string channelId, string role = null)
         {
-            var collection = await GraphHelper.GetResultCollectionAsync<TeamChannelMember>(httpClient, $"v1.0/teams/{groupId}/channels/{channelId}/members", accessToken);
+            var collection = await GraphHelper.GetResultCollectionAsync<TeamChannelMember>(connection, $"v1.0/teams/{groupId}/channels/{channelId}/members", accessToken);
 
             if (!string.IsNullOrEmpty(role))
             {
@@ -715,7 +715,7 @@ namespace PnP.PowerShell.Commands.Utilities
         /// </summary>
         /// <param name="role">User role, valid values: Owner, Member</param>
         /// <returns>Added membership.</returns>
-        public static async Task<TeamChannelMember> AddChannelMemberAsync(HttpClient httpClient, string accessToken, string groupId, string channelId, string upn, string role)
+        public static async Task<TeamChannelMember> AddChannelMemberAsync(PnPConnection connection, string accessToken, string groupId, string channelId, string upn, string role)
         {
             var channelMember = new TeamChannelMember
             {
@@ -726,23 +726,23 @@ namespace PnP.PowerShell.Commands.Utilities
             if (role.Equals("owner", StringComparison.OrdinalIgnoreCase))
                 channelMember.Roles.Add("owner");
 
-            return await GraphHelper.PostAsync(httpClient, $"v1.0/teams/{groupId}/channels/{channelId}/members", channelMember, accessToken);
+            return await GraphHelper.PostAsync(connection, $"v1.0/teams/{groupId}/channels/{channelId}/members", channelMember, accessToken);
         }
 
         /// <summary>
         /// Remove specified member of a specified Microsoft Teams channel.
         /// </summary>
         /// <returns>True when removal succeeded, else false.</returns>
-        public static async Task<HttpResponseMessage> DeleteChannelMemberAsync(HttpClient httpClient, string accessToken, string groupId, string channelId, string membershipId)
+        public static async Task<HttpResponseMessage> DeleteChannelMemberAsync(PnPConnection connection, string accessToken, string groupId, string channelId, string membershipId)
         {
-            return await GraphHelper.DeleteAsync(httpClient, $"v1.0/teams/{groupId}/channels/{channelId}/members/{membershipId}", accessToken);
+            return await GraphHelper.DeleteAsync(connection, $"v1.0/teams/{groupId}/channels/{channelId}/members/{membershipId}", accessToken);
         }
 
         /// <summary>
         /// Update the role of a specific member of a Microsoft Teams channel.
         /// </summary>
         /// <returns>Updated membership object.</returns>
-        public static async Task<TeamChannelMember> UpdateChannelMemberAsync(HttpClient httpClient, string accessToken, string groupId, string channelId, string membershipId, string role)
+        public static async Task<TeamChannelMember> UpdateChannelMemberAsync(PnPConnection connection, string accessToken, string groupId, string channelId, string membershipId, string role)
         {
             var channelMember = new TeamChannelMember();
 
@@ -750,41 +750,41 @@ namespace PnP.PowerShell.Commands.Utilities
             if (role.Equals("owner", StringComparison.OrdinalIgnoreCase))
                 channelMember.Roles.Add("owner");
 
-            return await GraphHelper.PatchAsync(httpClient, accessToken, $"v1.0/teams/{groupId}/channels/{channelId}/members/{membershipId}", channelMember);
+            return await GraphHelper.PatchAsync(connection, accessToken, $"v1.0/teams/{groupId}/channels/{channelId}/members/{membershipId}", channelMember);
         }
 
-        public static async Task<TeamsChannelFilesFolder> GetChannelsFilesFolderAsync(HttpClient httpClient, string accessToken, string groupId, string channelId)
+        public static async Task<TeamsChannelFilesFolder> GetChannelsFilesFolderAsync(PnPConnection connection, string accessToken, string groupId, string channelId)
         {
-            var collection = await GraphHelper.GetAsync<TeamsChannelFilesFolder>(httpClient, $"v1.0/teams/{groupId}/channels/{channelId}/filesFolder", accessToken);
+            var collection = await GraphHelper.GetAsync<TeamsChannelFilesFolder>(connection, $"v1.0/teams/{groupId}/channels/{channelId}/filesFolder", accessToken);
             return collection;
         }
 
         #endregion
 
         #region Tabs
-        public static async Task<IEnumerable<TeamTab>> GetTabsAsync(string accessToken, HttpClient httpClient, string groupId, string channelId)
+        public static async Task<IEnumerable<TeamTab>> GetTabsAsync(string accessToken, PnPConnection connection, string groupId, string channelId)
         {
-            var collection = await GraphHelper.GetResultCollectionAsync<TeamTab>(httpClient, $"v1.0/teams/{groupId}/channels/{channelId}/tabs", accessToken);
+            var collection = await GraphHelper.GetResultCollectionAsync<TeamTab>(connection, $"v1.0/teams/{groupId}/channels/{channelId}/tabs", accessToken);
             return collection;
         }
 
-        public static async Task<TeamTab> GetTabAsync(string accessToken, HttpClient httpClient, string groupId, string channelId, string tabId)
+        public static async Task<TeamTab> GetTabAsync(string accessToken, PnPConnection connection, string groupId, string channelId, string tabId)
         {
-            return await GraphHelper.GetAsync<TeamTab>(httpClient, $"v1.0/teams/{groupId}/channels/{channelId}/tabs/{tabId}?$expand=teamsApp", accessToken, propertyNameCaseInsensitive: true);
+            return await GraphHelper.GetAsync<TeamTab>(connection, $"v1.0/teams/{groupId}/channels/{channelId}/tabs/{tabId}?$expand=teamsApp", accessToken, propertyNameCaseInsensitive: true);
         }
 
-        public static async Task<HttpResponseMessage> DeleteTabAsync(string accessToken, HttpClient httpClient, string groupId, string channelId, string tabId)
+        public static async Task<HttpResponseMessage> DeleteTabAsync(string accessToken, PnPConnection connection, string groupId, string channelId, string tabId)
         {
-            return await GraphHelper.DeleteAsync(httpClient, $"v1.0/teams/{groupId}/channels/{channelId}/tabs/{tabId}", accessToken);
+            return await GraphHelper.DeleteAsync(connection, $"v1.0/teams/{groupId}/channels/{channelId}/tabs/{tabId}", accessToken);
         }
 
-        public static async Task UpdateTabAsync(HttpClient httpClient, string accessToken, string groupId, string channelId, TeamTab tab)
+        public static async Task UpdateTabAsync(PnPConnection connection, string accessToken, string groupId, string channelId, TeamTab tab)
         {
             tab.Configuration = null;
-            await GraphHelper.PatchAsync(httpClient, accessToken, $"v1.0/teams/{groupId}/channels/{channelId}/tabs/{tab.Id}", tab);
+            await GraphHelper.PatchAsync(connection, accessToken, $"v1.0/teams/{groupId}/channels/{channelId}/tabs/{tab.Id}", tab);
         }
 
-        public static async Task<TeamTab> AddTabAsync(HttpClient httpClient, string accessToken, string groupId, string channelId, string displayName, TeamTabType tabType, string teamsAppId, string entityId, string contentUrl, string removeUrl, string websiteUrl)
+        public static async Task<TeamTab> AddTabAsync(PnPConnection connection, string accessToken, string groupId, string channelId, string displayName, TeamTabType tabType, string teamsAppId, string entityId, string contentUrl, string removeUrl, string websiteUrl)
         {
             TeamTab tab = new TeamTab();
             switch (tabType)
@@ -897,36 +897,36 @@ namespace PnP.PowerShell.Commands.Utilities
             }
             tab.DisplayName = displayName;
             tab.TeamsAppOdataBind = $"https://{PnPConnection.Current.GraphEndPoint}/v1.0/appCatalogs/teamsApps/{tab.TeamsAppId}";
-            return await GraphHelper.PostAsync<TeamTab>(httpClient, $"v1.0/teams/{groupId}/channels/{channelId}/tabs", tab, accessToken);
+            return await GraphHelper.PostAsync<TeamTab>(connection, $"v1.0/teams/{groupId}/channels/{channelId}/tabs", tab, accessToken);
         }
         #endregion
 
         #region Apps
-        public static async Task<IEnumerable<TeamApp>> GetAppsAsync(string accessToken, HttpClient httpClient)
+        public static async Task<IEnumerable<TeamApp>> GetAppsAsync(string accessToken, PnPConnection connection)
         {
-            var collection = await GraphHelper.GetResultCollectionAsync<TeamApp>(httpClient, $"v1.0/appCatalogs/teamsApps", accessToken);
+            var collection = await GraphHelper.GetResultCollectionAsync<TeamApp>(connection, $"v1.0/appCatalogs/teamsApps", accessToken);
             return collection;
         }
 
-        public static async Task<TeamApp> AddAppAsync(HttpClient httpClient, string accessToken, byte[] bytes)
+        public static async Task<TeamApp> AddAppAsync(PnPConnection connection, string accessToken, byte[] bytes)
         {
             var byteArrayContent = new ByteArrayContent(bytes);
             byteArrayContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/zip");
-            var response = await GraphHelper.PostAsync(httpClient, "v1.0/appCatalogs/teamsApps", accessToken, byteArrayContent);
+            var response = await GraphHelper.PostAsync(connection, "v1.0/appCatalogs/teamsApps", accessToken, byteArrayContent);
             var content = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
             return JsonSerializer.Deserialize<TeamApp>(content, new JsonSerializerOptions() { IgnoreNullValues = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
         }
 
-        public static async Task<HttpResponseMessage> UpdateAppAsync(HttpClient httpClient, string accessToken, byte[] bytes, string appId)
+        public static async Task<HttpResponseMessage> UpdateAppAsync(PnPConnection connection, string accessToken, byte[] bytes, string appId)
         {
             var byteArrayContent = new ByteArrayContent(bytes);
             byteArrayContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/zip");
-            return await GraphHelper.PutAsync(httpClient, $"v1.0/appCatalogs/teamsApps/{appId}", accessToken, byteArrayContent);
+            return await GraphHelper.PutAsync(connection, $"v1.0/appCatalogs/teamsApps/{appId}", accessToken, byteArrayContent);
         }
 
-        public static async Task<HttpResponseMessage> DeleteAppAsync(HttpClient httpClient, string accessToken, string appId)
+        public static async Task<HttpResponseMessage> DeleteAppAsync(PnPConnection connection, string accessToken, string appId)
         {
-            return await GraphHelper.DeleteAsync(httpClient, $"v1.0/appCatalogs/teamsApps/{appId}", accessToken);
+            return await GraphHelper.DeleteAsync(connection, $"v1.0/appCatalogs/teamsApps/{appId}", accessToken);
         }
         #endregion
     }

--- a/src/Commands/Web/SetWebHeader.cs
+++ b/src/Commands/Web/SetWebHeader.cs
@@ -46,7 +46,7 @@ namespace PnP.PowerShell.Commands
                 var stringContent = new StringContent("{\"relativeLogoUrl\":\"" + SiteLogoUrl + "\",\"type\":0,\"aspect\":1}");
                 stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
                 CurrentWeb.EnsureProperties(p => p.Url);
-                var result = GraphHelper.PostAsync(HttpClient, $"{CurrentWeb.Url.TrimEnd('/')}/_api/siteiconmanager/setsitelogo", AccessToken, stringContent).GetAwaiter().GetResult();
+                var result = GraphHelper.PostAsync(Connection, $"{CurrentWeb.Url.TrimEnd('/')}/_api/siteiconmanager/setsitelogo", AccessToken, stringContent).GetAwaiter().GetResult();
                 WriteVerbose($"Response from setsitelogo request: {result.StatusCode}");
             }  
 
@@ -108,7 +108,7 @@ namespace PnP.PowerShell.Commands
                     var stringContent = new StringContent("{" + string.Join(",", setSiteBackgroundImageInstructions) + ",\"type\":2,\"aspect\":0}");
                     stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
                     CurrentWeb.EnsureProperties(p => p.Url);
-                    var result = GraphHelper.PostAsync(HttpClient, $"{CurrentWeb.Url.TrimEnd('/')}/_api/siteiconmanager/setsitelogo", AccessToken, stringContent).GetAwaiter().GetResult();
+                    var result = GraphHelper.PostAsync(Connection, $"{CurrentWeb.Url.TrimEnd('/')}/_api/siteiconmanager/setsitelogo", AccessToken, stringContent).GetAwaiter().GetResult();
                     WriteVerbose($"Response from setsitelogo request: {result.StatusCode}");
                 }
             }


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample
- [X] Refactoring

## Related Issues? ##
Partially fixes #1949

## What is in this Pull Request ? ##
- Large refactoring of all PnP cmdlets to allow all of them to get a specific connection passed in using `-Connection`
- The GraphHelper now requires a PnPConnection instance instead of a HttpClient instance so we can utilize the Graph Endpoint definition from the connection to support special cloud environments (i.e. GCC/GCCH/DoD/etc). The RestHelper still allows HTTP calls to be made without an active connection.
- The HttpClient is now part of the PnPConnection. Meaning every instance of a connection will have its own HttpClient. This keeps things better separated and prevents us from having to pass in both a connection and httpclient which may be from different connections.