### PR TITLE
Added optional `-IncludeAllLists` to `Get-PnPSiteScriptFromWeb`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `-ExemptFromBlockDownloadOfNonViewableFiles` parameter to `Set-PnPList` cmdlet to configure access capabilites for unmanaged devices at list level. [#1973](https://github.com/pnp/powershell/pull/1973)
 - Added `-PercentComplete`, `-Priority`, `-StartDateTime`, `-DueDateTime` and `-Description` to `Add-PnPPlannerTask` [#1964](https://github.com/pnp/powershell/pull/1964)
 - Added `Set-PnPContentType` cmdlet to update the properties of the Content Types in a list or a web. [#1981](https://github.com/pnp/powershell/pull/1981)
+- Added optional `-IncludeAllLists` to `Get-PnPSiteScriptFromWeb` which will include the JSON definition of all custom lists of the current site in the output
 
 ### Changed
 

--- a/documentation/Get-PnPSiteScriptFromWeb.md
+++ b/documentation/Get-PnPSiteScriptFromWeb.md
@@ -39,50 +39,43 @@ This command allows a Site Script to be generated off of an existing site on you
 
 ### EXAMPLE 1
 ```powershell
+Get-PnPSiteScriptFromWeb -IncludeAll
+```
+
+Returns the generated Site Script JSON containing all supported components from the currently connected to site
+
+### EXAMPLE 2
+```powershell
 Get-PnPSiteScriptFromWeb -Url "https://contoso.sharepoint.com/sites/teamsite" -IncludeAll
 ```
 
 Returns the generated Site Script JSON containing all supported components from the site at the provided Url
 
-### EXAMPLE 2
+### EXAMPLE 3
 ```powershell
 Get-PnPSiteScriptFromWeb -Url "https://contoso.sharepoint.com/sites/teamsite" -IncludeAll -Lists "Shared Documents","Lists\MyList"
 ```
 
 Returns the generated Site Script JSON containing all supported components from the site at the provided Url including the lists "Shared Documents" and "MyList"
 
-### EXAMPLE 3
+### EXAMPLE 5
 ```powershell
 Get-PnPSiteScriptFromWeb -Url "https://contoso.sharepoint.com/sites/teamsite" -IncludeBranding -IncludeLinksToExportedItems
 ```
 
 Returns the generated Site Script JSON containing the branding and navigation links from the site at the provided Url
 
-### EXAMPLE 4
+### EXAMPLE 6
 ```powershell
-Get-PnPSiteScriptFromWeb -IncludeAll
+Get-PnPSiteScriptFromWeb -IncludeAllLists
 ```
 
-Returns the generated Site Script JSON containing all the components from the currently connected to site
+Returns the generated Site Script JSON containing all lists from the currently connected to site
 
 ## PARAMETERS
 
-### -Connection
-Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.
-
-```yaml
-Type: PnPConnection
-Parameter Sets: (All)
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -IncludeAll
-If specified will include all supported components into the Site Script except for the lists and document libraries, these need to be explicitly be specified through -Lists
+If specified will include all supported components into the Site Script including all self lists, branding, navigation links, regional settings, external sharing capability and theme.
 
 ```yaml
 Type: SwitchParameter
@@ -100,7 +93,7 @@ If specified will include the branding of the site into the Site Script
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Specific components
+Parameter Sets: Specific components, All lists
 
 Required: False
 Position: Named
@@ -114,7 +107,7 @@ If specified will include navigation links into the Site Script
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Specific components
+Parameter Sets: Specific components, All lists
 
 Required: False
 Position: Named
@@ -128,7 +121,7 @@ If specified will include the regional settings into the Site Script
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Specific components
+Parameter Sets: Specific components, All lists
 
 Required: False
 Position: Named
@@ -142,7 +135,7 @@ If specified will include the external sharing configuration into the Site Scrip
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Specific components
+Parameter Sets: Specific components, All lists
 
 Required: False
 Position: Named
@@ -156,7 +149,21 @@ If specified will include the branding of the site into the Site Script
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Specific components
+Parameter Sets: Specific components, All lists
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeAllLists
+If specified, all lists that are not hidden, private, internal or catalogs will be included into the Site Script. It cannot be combined with the -Lists nor the -IncludeAll parameters as both will already include all lists.
+
+```yaml
+Type: String[]
+Parameter Sets: All lists
 
 Required: False
 Position: Named
@@ -166,11 +173,11 @@ Accept wildcard characters: False
 ```
 
 ### -Lists
-Allows specifying one or more site relative URLs of lists that should be included into the Site Script, i.e. "Shared Documents","List\MyList"
+Allows specifying one or more site relative URLs of lists that should be included into the Site Script, i.e. "Shared Documents","Lists\MyList"
 
 ```yaml
 Type: String[]
-Parameter Sets: (All)
+Parameter Sets: Basic components, All components, Specific components
 
 Required: False
 Position: Named
@@ -193,13 +200,12 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -WhatIf
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.
 
 ```yaml
-Type: SwitchParameter
+Type: PnPConnection
 Parameter Sets: (All)
-Aliases: wi
 
 Required: False
 Position: Named


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Added optional `-IncludeAllLists` to `Get-PnPSiteScriptFromWeb` which will include the JSON definition of all custom lists of the current site in the output