### PR TITLE
Excluded the plus sign from getting decoded in `Get-PnPFile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Add-PnPTeamsUser`, the parameter `-Channel` is now not required. [#1953](https://github.com/pnp/powershell/pull/1953)
 - Fixed `Get-PnPPlannerTask` throwing an object reference exception for completed tasks [#1956](https://github.com/pnp/powershell/issues/1956)
 - Fixed `Get-PnPUserOneDriveQuota` returning the maximum possible quota instead of the actual configured quota on a OneDrive for Business site [#1902](https://github.com/pnp/powershell/pull/1902)
-- Fixed `Get-PnPFile` throwing an exception when trying to download a file containing the plus character
+- Fixed `Get-PnPFile` throwing an exception when trying to download a file containing the plus character [#1990](https://github.com/pnp/powershell/pull/1990)
 - Fixed `Get-PnPTeamsChannel` not working correctly with PowerShell select. [#1988](https://github.com/pnp/powershell/pull/1988)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Add-PnPTeamsUser`, the parameter `-Channel` is now not required. [#1953](https://github.com/pnp/powershell/pull/1953)
 - Fixed `Get-PnPPlannerTask` throwing an object reference exception for completed tasks [#1956](https://github.com/pnp/powershell/issues/1956)
 - Fixed `Get-PnPUserOneDriveQuota` returning the maximum possible quota instead of the actual configured quota on a OneDrive for Business site [#1902](https://github.com/pnp/powershell/pull/1902)
+- Fixed `Get-PnPFile` throwing an exception when trying to download a file containing the plus character
 
 ### Removed
 

--- a/src/Commands/Files/GetFile.cs
+++ b/src/Commands/Files/GetFile.cs
@@ -2,7 +2,6 @@
 using PnP.Core.Model.SharePoint;
 using PnP.Core.Services;
 using PnP.Framework.Utilities;
-using System;
 using System.IO;
 using System.Management.Automation;
 using System.Threading.Tasks;
@@ -68,8 +67,8 @@ namespace PnP.PowerShell.Commands.Files
                 }
             }
 
-            // Remove URL decoding from the Url as that will not work
-            Url = Utilities.UrlUtilities.UrlDecode(Url);
+            // Remove URL decoding from the Url as that will not work. We will encode the + character specifically, because if that is part of the filename, it needs to stay and not be decoded.
+            Url = Utilities.UrlUtilities.UrlDecode(Url.Replace("+", "%2B"));
 
             var webUrl = CurrentWeb.EnsureProperty(w => w.ServerRelativeUrl);
 


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #1864

## What is in this Pull Request ? ##
Addresses the issue reported through #1864 where trying to use `Get-PnPFile` for a file containing a plus character in its filename would throw an exception. Explicitly added a fix for the plus character. Hopefully that's the only character thats problematic here. We cannot remove the decoding as a whole as that would cripple special characters in filenames.