### PR TITLE
Added Microsoft 365 Group Endpoint cmdlets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,9 +60,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added optional `-SensitivityLabel` to `Set-PnPSite` which allows for a Microsoft Purview sensitivitylabel to be set [#2024](https://github.com/pnp/powershell/pull/2024)
 - Added `-UpdateChildren` parameter to `Add-PnPFieldToContentType` cmdlet. This allows users to skip pushing the fields to child content types. [#1092](https://github.com/pnp/powershell/pull/1992)
 - Added `Get-PnPSensitivityLabel` cmdlet to retrieve Microsoft Purview sensitivity labels available on the tenant [#2023](https://github.com/pnp/powershell/pull/2023)
-- Added `Get-Microsoft365GroupYammerCommunity` cmdlet to retrieve details on the Yammer Community connected to a Microsoft 365 Group
-- Added `Get-Microsoft365GroupTeam` cmdlet to retrieve details on the Microsoft Teams team connected to a Microsoft 365 Group
-- Added `Get-Microsoft365GroupEndpoints` cmdlet to retrieve details on all endpoints connected to a Microsoft 365 Group
+- Added `Get-Microsoft365GroupYammerCommunity` cmdlet to retrieve details on the Yammer Community connected to a Microsoft 365 Group [#2038](https://github.com/pnp/powershell/pull/2038)
+- Added `Get-Microsoft365GroupTeam` cmdlet to retrieve details on the Microsoft Teams team connected to a Microsoft 365 Group [#2038](https://github.com/pnp/powershell/pull/2038)
+- Added `Get-Microsoft365GroupEndpoints` cmdlet to retrieve details on all endpoints connected to a Microsoft 365 Group [#2038](https://github.com/pnp/powershell/pull/2038)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added optional `-SensitivityLabel` to `Set-PnPSite` which allows for a Microsoft Purview sensitivitylabel to be set [#2024](https://github.com/pnp/powershell/pull/2024)
 - Added `-UpdateChildren` parameter to `Add-PnPFieldToContentType` cmdlet. This allows users to skip pushing the fields to child content types. [#1092](https://github.com/pnp/powershell/pull/1992)
 - Added `Get-PnPSensitivityLabel` cmdlet to retrieve Microsoft Purview sensitivity labels available on the tenant [#2023](https://github.com/pnp/powershell/pull/2023)
+- Added `Get-Microsoft365GroupYammerCommunity` cmdlet to retrieve details on the Yammer Community connected to a Microsoft 365 Group
+- Added `Get-Microsoft365GroupTeam` cmdlet to retrieve details on the Microsoft Teams team connected to a Microsoft 365 Group
+- Added `Get-Microsoft365GroupEndpoints` cmdlet to retrieve details on all endpoints connected to a Microsoft 365 Group
 
 ### Changed
 

--- a/documentation/Get-PnPMicrosoft365GroupEndpoint.md
+++ b/documentation/Get-PnPMicrosoft365GroupEndpoint.md
@@ -1,0 +1,98 @@
+---
+Module Name: PnP.PowerShell
+schema: 2.0.0
+applicable: SharePoint Online
+online version: https://pnp.github.io/powershell/cmdlets/Get-PnPMicrosoft365GroupEndpoint.html
+external help file: PnP.PowerShell.dll-Help.xml
+title: Get-PnPMicrosoft365GroupEndpoint
+---
+  
+# Get-PnPMicrosoft365GroupEndpoint
+
+## SYNOPSIS
+
+**Required Permissions**
+
+  * Microsoft Graph API : Group.Read.All
+
+Returns the endpoints behind a particular Microsoft 365 Group
+
+## SYNTAX
+
+```powershell
+Get-PnPMicrosoft365GroupEndpoint -Identity <Microsoft365GroupPipeBind> [-Connection] [-Verbose] [<CommonParameters>]
+```
+
+## DESCRIPTION
+This cmdlet allows retrieval of details on the endpoints connected to a Microsoft 365 Group
+
+## EXAMPLES
+
+### EXAMPLE 2
+```powershell
+Get-PnPMicrosoft365GroupEndpoint
+```
+
+Retrieves the endpoints behind the Microsoft 365 Group of the currently connected to site
+
+### EXAMPLE 2
+```powershell
+Get-PnPMicrosoft365GroupEndpoint -Identity "IT Team"
+```
+
+Retrieves the endpoints behind the Microsoft 365 Group named "IT Team"
+
+### EXAMPLE 3
+```powershell
+Get-PnPMicrosoft365GroupEndpoint -Identity e6212531-7f09-4c3b-bc2e-12cae26fb409
+```
+
+Retrieves the endpoints behind the Microsoft 365 Group with the provided Id
+
+## PARAMETERS
+
+### -Identity
+The Identity of the Microsoft 365 Group
+
+```yaml
+Type: Microsoft365GroupPipeBind
+Parameter Sets: (All)
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Verbose
+When provided, additional debug statements will be shown while executing the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/documentation/Get-PnPMicrosoft365GroupTeam.md
+++ b/documentation/Get-PnPMicrosoft365GroupTeam.md
@@ -1,0 +1,98 @@
+---
+Module Name: PnP.PowerShell
+schema: 2.0.0
+applicable: SharePoint Online
+online version: https://pnp.github.io/powershell/cmdlets/Get-PnPMicrosoft365GroupTeam.html
+external help file: PnP.PowerShell.dll-Help.xml
+title: Get-PnPMicrosoft365GroupTeam
+---
+  
+# Get-PnPMicrosoft365GroupTeam
+
+## SYNOPSIS
+
+**Required Permissions**
+
+  * Microsoft Graph API : Group.Read.All
+
+Returns the Microsoft Teams team behind a particular Microsoft 365 Group
+
+## SYNTAX
+
+```powershell
+Get-PnPMicrosoft365GroupTeam -Identity <Microsoft365GroupPipeBind> [-Connection] [-Verbose] [<CommonParameters>]
+```
+
+## DESCRIPTION
+This cmdlet allows retrieval of details on the Microsoft Teams team connected to a Microsoft 365 Group
+
+## EXAMPLES
+
+### EXAMPLE 2
+```powershell
+Get-PnPMicrosoft365GroupTeam
+```
+
+Retrieves the Microsoft Teams team details behind the Microsoft 365 Group of the currently connected to site
+
+### EXAMPLE 2
+```powershell
+Get-PnPMicrosoft365GroupTeam -Identity "IT Team"
+```
+
+Retrieves the Microsoft Teams team details behind the Microsoft 365 Group named "IT Team"
+
+### EXAMPLE 3
+```powershell
+Get-PnPMicrosoft365GroupTeam -Identity e6212531-7f09-4c3b-bc2e-12cae26fb409
+```
+
+Retrieves the Microsoft Teams team details behind the Microsoft 365 Group with the provided Id
+
+## PARAMETERS
+
+### -Identity
+The Identity of the Microsoft 365 Group
+
+```yaml
+Type: Microsoft365GroupPipeBind
+Parameter Sets: (All)
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Verbose
+When provided, additional debug statements will be shown while executing the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/documentation/Get-PnPMicrosoft365GroupYammerCommunity.md
+++ b/documentation/Get-PnPMicrosoft365GroupYammerCommunity.md
@@ -1,0 +1,98 @@
+---
+Module Name: PnP.PowerShell
+schema: 2.0.0
+applicable: SharePoint Online
+online version: https://pnp.github.io/powershell/cmdlets/Get-PnPMicrosoft365GroupYammerCommunity.html
+external help file: PnP.PowerShell.dll-Help.xml
+title: Get-PnPMicrosoft365GroupYammerCommunity
+---
+  
+# Get-PnPMicrosoft365GroupYammerCommunity
+
+## SYNOPSIS
+
+**Required Permissions**
+
+  * Microsoft Graph API : Group.Read.All
+
+Returns the Yammer Community behind a particular Microsoft 365 Group
+
+## SYNTAX
+
+```powershell
+Get-PnPMicrosoft365GroupYammerCommunity -Identity <Microsoft365GroupPipeBind> [-Connection] [-Verbose] [<CommonParameters>]
+```
+
+## DESCRIPTION
+This cmdlet allows retrieval of details on the Yammer Community connected to a Microsoft 365 Group
+
+## EXAMPLES
+
+### EXAMPLE 2
+```powershell
+Get-PnPMicrosoft365GroupYammerCommunity
+```
+
+Retrieves the Yammer Community details behind the Microsoft 365 Group of the currently connected to site
+
+### EXAMPLE 2
+```powershell
+Get-PnPMicrosoft365GroupYammerCommunity -Identity "IT Community"
+```
+
+Retrieves the Yammer Community details behind the Microsoft 365 Group named "IT Community"
+
+### EXAMPLE 3
+```powershell
+Get-PnPMicrosoft365GroupYammerCommunity -Identity e6212531-7f09-4c3b-bc2e-12cae26fb409
+```
+
+Retrieves the Yammer Community details behind the Microsoft 365 Group with the provided Id
+
+## PARAMETERS
+
+### -Identity
+The Identity of the Microsoft 365 Group
+
+```yaml
+Type: Microsoft365GroupPipeBind
+Parameter Sets: (All)
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Verbose
+When provided, additional debug statements will be shown while executing the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/src/Commands/Base/PipeBinds/Microsoft365GroupPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/Microsoft365GroupPipeBind.cs
@@ -1,11 +1,7 @@
-﻿using PnP.Framework.Entities;
-using PnP.Framework.Graph;
-using PnP.PowerShell.Commands.Model;
+﻿using PnP.PowerShell.Commands.Model;
 using PnP.PowerShell.Commands.Utilities;
 using System;
-using System.Linq;
 using System.Management.Automation;
-using System.Net.Http;
 
 namespace PnP.PowerShell.Commands.Base.PipeBinds
 {
@@ -85,7 +81,6 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
                 }
             }
             throw new PSInvalidOperationException("Group not found");
-            //return Guid.Empty;
         }
 
         public Microsoft365Group GetDeletedGroup(PnPConnection connection, string accessToken)

--- a/src/Commands/Microsoft365Groups/GetMicrosoft365GroupEndpoint.cs
+++ b/src/Commands/Microsoft365Groups/GetMicrosoft365GroupEndpoint.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.SharePoint.Client;
+using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Base.PipeBinds;
+using PnP.PowerShell.Commands.Utilities.REST;
+using System;
+using System.Linq;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Microsoft365Groups
+{
+    [Cmdlet(VerbsCommon.Get, "PnPMicrosoft365GroupEndpoint")]
+    [RequiredMinimalApiPermissions("Group.Read.All")]
+    public class GetMicrosoft365GroupEndpoint : PnPGraphCmdlet
+    {
+        [Parameter(Mandatory = false, ValueFromPipeline = true, Position = 0)]
+        public Microsoft365GroupPipeBind Identity;
+
+        protected override void ExecuteCmdlet()
+        {
+            Guid groupId;
+            if (ParameterSpecified(nameof(Identity)))
+            {
+                WriteVerbose($"Defining Microsoft 365 Group based on {nameof(Identity)} parameter");
+                groupId = Identity.GetGroupId(Connection, AccessToken);
+            }
+            else
+            {
+                WriteVerbose($"Validating if the current site at {Connection.Url} has a Microsoft 365 Group behind it");
+                ClientContext.Load(ClientContext.Site, s => s.GroupId);
+                ClientContext.ExecuteQueryRetry();
+
+                groupId = ClientContext.Site.GroupId;
+
+                if(groupId == Guid.Empty)
+                {
+                    WriteWarning("Current site is not backed by a Microsoft 365 Group");
+                }
+                else
+                {
+                    WriteVerbose($"Current site at {Connection.Url} is backed by the Microsoft 365 Group with Id {groupId}");
+                }
+            }
+
+            WriteVerbose($"Requesting endpoints of Microsoft 365 Group with Id {groupId}");
+            var endpoints = GraphHelper.GetResultCollectionAsync<Model.AzureAD.AzureADGroupEndPoint>(Connection, $"/beta/groups/{groupId}/endpoints", AccessToken).GetAwaiter().GetResult();
+            WriteVerbose($"{endpoints.Count()} endpoint(s) found in total");
+            WriteObject(endpoints, true);
+        }
+    }
+}

--- a/src/Commands/Microsoft365Groups/GetMicrosoft365GroupEndpoint.cs
+++ b/src/Commands/Microsoft365Groups/GetMicrosoft365GroupEndpoint.cs
@@ -34,7 +34,7 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
 
                 if(groupId == Guid.Empty)
                 {
-                    WriteWarning("Current site is not backed by a Microsoft 365 Group");
+                    throw new PSArgumentException("Current site is not backed by a Microsoft 365 Group", nameof(Identity));
                 }
                 else
                 {

--- a/src/Commands/Microsoft365Groups/GetMicrosoft365GroupTeam.cs
+++ b/src/Commands/Microsoft365Groups/GetMicrosoft365GroupTeam.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.SharePoint.Client;
+using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Base.PipeBinds;
+using PnP.PowerShell.Commands.Utilities.REST;
+using System;
+using System.Linq;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Microsoft365Groups
+{
+    [Cmdlet(VerbsCommon.Get, "PnPMicrosoft365GroupTeam")]
+    [RequiredMinimalApiPermissions("Group.Read.All")]
+    public class GetMicrosoft365GroupTeam : PnPGraphCmdlet
+    {
+        [Parameter(Mandatory = false, ValueFromPipeline = true, Position = 0)]
+        public Microsoft365GroupPipeBind Identity;
+
+        protected override void ExecuteCmdlet()
+        {
+            Guid groupId;
+            if (ParameterSpecified(nameof(Identity)))
+            {
+                WriteVerbose($"Defining Microsoft 365 Group based on {nameof(Identity)} parameter");
+                groupId = Identity.GetGroupId(Connection, AccessToken);
+            }
+            else
+            {
+                WriteVerbose($"Validating if the current site at {Connection.Url} has a Microsoft 365 Group behind it");
+                ClientContext.Load(ClientContext.Site, s => s.GroupId);
+                ClientContext.ExecuteQueryRetry();
+
+                groupId = ClientContext.Site.GroupId;
+
+                if(groupId == Guid.Empty)
+                {
+                    WriteWarning("Current site is not backed by a Microsoft 365 Group");
+                }
+                else
+                {
+                    WriteVerbose($"Current site at {Connection.Url} is backed by the Microsoft 365 Group with Id {groupId}");
+                }
+            }
+
+            WriteVerbose($"Requesting endpoints of Microsoft 365 Group with Id {groupId}");
+            var endpoints = GraphHelper.GetResultCollectionAsync<Model.AzureAD.AzureADGroupEndPoint>(Connection, $"/beta/groups/{groupId}/endpoints", AccessToken).GetAwaiter().GetResult();
+            WriteVerbose($"{endpoints.Count()} endpoint(s) found in total");
+
+            var yammerEndpoint = endpoints.Where(e => e.ProviderName.Equals("Microsoft Teams", StringComparison.InvariantCultureIgnoreCase));
+            WriteVerbose($"{yammerEndpoint.Count()} Teams endpoint(s) found");
+
+            WriteObject(yammerEndpoint, true);
+        }
+    }
+}

--- a/src/Commands/Microsoft365Groups/GetMicrosoft365GroupTeam.cs
+++ b/src/Commands/Microsoft365Groups/GetMicrosoft365GroupTeam.cs
@@ -34,7 +34,7 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
 
                 if(groupId == Guid.Empty)
                 {
-                    WriteWarning("Current site is not backed by a Microsoft 365 Group");
+                    throw new PSArgumentException("Current site is not backed by a Microsoft 365 Group", nameof(Identity));
                 }
                 else
                 {

--- a/src/Commands/Microsoft365Groups/GetMicrosoft365GroupYammerCommunity.cs
+++ b/src/Commands/Microsoft365Groups/GetMicrosoft365GroupYammerCommunity.cs
@@ -34,7 +34,7 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
 
                 if(groupId == Guid.Empty)
                 {
-                    WriteWarning("Current site is not backed by a Microsoft 365 Group");
+                    throw new PSArgumentException("Current site is not backed by a Microsoft 365 Group", nameof(Identity));
                 }
                 else
                 {

--- a/src/Commands/Microsoft365Groups/GetMicrosoft365GroupYammerCommunity.cs
+++ b/src/Commands/Microsoft365Groups/GetMicrosoft365GroupYammerCommunity.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.SharePoint.Client;
+using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Base.PipeBinds;
+using PnP.PowerShell.Commands.Utilities.REST;
+using System;
+using System.Linq;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Microsoft365Groups
+{
+    [Cmdlet(VerbsCommon.Get, "PnPMicrosoft365GroupYammerCommunity")]
+    [RequiredMinimalApiPermissions("Group.Read.All")]
+    public class GetMicrosoft365GroupYammerCommunity : PnPGraphCmdlet
+    {
+        [Parameter(Mandatory = false, ValueFromPipeline = true, Position = 0)]
+        public Microsoft365GroupPipeBind Identity;
+
+        protected override void ExecuteCmdlet()
+        {
+            Guid groupId;
+            if (ParameterSpecified(nameof(Identity)))
+            {
+                WriteVerbose($"Defining Microsoft 365 Group based on {nameof(Identity)} parameter");
+                groupId = Identity.GetGroupId(Connection, AccessToken);
+            }
+            else
+            {
+                WriteVerbose($"Validating if the current site at {Connection.Url} has a Microsoft 365 Group behind it");
+                ClientContext.Load(ClientContext.Site, s => s.GroupId);
+                ClientContext.ExecuteQueryRetry();
+
+                groupId = ClientContext.Site.GroupId;
+
+                if(groupId == Guid.Empty)
+                {
+                    WriteWarning("Current site is not backed by a Microsoft 365 Group");
+                }
+                else
+                {
+                    WriteVerbose($"Current site at {Connection.Url} is backed by the Microsoft 365 Group with Id {groupId}");
+                }
+            }
+
+            WriteVerbose($"Requesting endpoints of Microsoft 365 Group with Id {groupId}");
+            var endpoints = GraphHelper.GetResultCollectionAsync<Model.AzureAD.AzureADGroupEndPoint>(Connection, $"/beta/groups/{groupId}/endpoints", AccessToken).GetAwaiter().GetResult();
+            WriteVerbose($"{endpoints.Count()} endpoint(s) found in total");
+
+            var yammerEndpoint = endpoints.Where(e => e.ProviderName.Equals("Yammer", StringComparison.InvariantCultureIgnoreCase));
+            WriteVerbose($"{yammerEndpoint.Count()} Yammer endpoint(s) found");
+
+            WriteObject(yammerEndpoint, true);
+        }
+    }
+}

--- a/src/Commands/Model/AzureAD/AzureADGroupEndPoint.cs
+++ b/src/Commands/Model/AzureAD/AzureADGroupEndPoint.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace PnP.PowerShell.Commands.Model.AzureAD
+{
+    /// <summary>
+    /// Definition of a Microsoft 365 Group Endpoint such as Yammer or Teams
+    /// </summary>
+    public class AzureADGroupEndPoint
+    {
+        [JsonPropertyName("id")]
+        public Guid? Id { get; set; }
+
+        [JsonPropertyName("deletedDateTime")]
+        public DateTime? DeletedDateTime { get; set; }
+
+        [JsonPropertyName("capability")]
+        public string Capability { get; set; }
+
+        [JsonPropertyName("providerId")]
+        public string ProviderId { get; set; }
+
+        [JsonPropertyName("providerName")]
+        public string ProviderName { get; set; }
+
+        [JsonPropertyName("uri")]
+        public string Uri { get; set; }
+
+        [JsonPropertyName("providerResourceId")]
+        public string ProviderResourceId { get; set; }
+    }
+}


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
- Added `Get-Microsoft365GroupYammerCommunity` cmdlet to retrieve details on the Yammer Community connected to a Microsoft 365 Group
- Added `Get-Microsoft365GroupTeam` cmdlet to retrieve details on the Microsoft Teams team connected to a Microsoft 365 Group
- Added `Get-Microsoft365GroupEndpoints` cmdlet to retrieve details on all endpoints connected to a Microsoft 365 Group