### PR TITLE
PnPAdminCmdlet fix for vanity domain tenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Get-PnPHubSiteChild` throwing an exception when passing in a URL that is actually not a hub site [#2033](https://github.com/pnp/powershell/pull/2033)
 - Fixed `Add-PnPListItem` not showing field name when it has an improper value assigned to it [#2002](https://github.com/pnp/powershell/pull/2002)
 - Fixed connecting using `Connect-PnPOnline -Interactive -ClientId` not working well when already having an App-Only connection using the same ClientId [#2035](https://github.com/pnp/powershell/pull/2035)
-- Fixed cmdlets inheriting from PnPAdminCmdlet not working well on vanity domain SharePoint Online tenants
+- Fixed cmdlets inheriting from PnPAdminCmdlet not working well on vanity domain SharePoint Online tenants [#2052](https://github.com/pnp/powershell/pull/2052)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Get-PnPTeamsTeam`, the cmdlet now also returns additional properties like `WebUrl, CreatedDateTime, InternalId`. [#1825](https://github.com/pnp/powershell/pull/1825)
 - Fixed `Set-PnPListPermission`, it will now throw error if the list does not exist. [#1891](https://github.com/pnp/powershell/pull/1891)
 - Fixed `Invoke-PnPSPRestMethod` invalid parsing for SharePoint number columns. [#1877](https://github.com/pnp/powershell/pull/1879)
-- Fix issue with `Add/Set-PnPListItem` not throwing correct exception for invalid taxonomy values. [#1870](https://github.com/pnp/powershell/pull/1870)
+- Fixed issue with `Add/Set-PnPListItem` not throwing correct exception for invalid taxonomy values. [#1870](https://github.com/pnp/powershell/pull/1870)
 - Fixed `Sync-PnPSharePointUserProfilesFromAzureActiveDirectory` throwing an "Object reference not set to an instance of an object" exception when providing an empty users collection or incorrect user mapping [#1896](https://github.com/pnp/powershell/pull/1896)
 - Fixed `Connect-PnPOnline -ReturnConnection` also setting the current connection instead of just the returned connection [#1919](https://github.com/pnp/powershell/pull/1919)
 - Fixed `Disconnect-PnPOnline -Connection` also disconnecting other connections next to the provided connection [#1919](https://github.com/pnp/powershell/pull/1919)
@@ -112,6 +112,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Get-PnPHubSiteChild` throwing an exception when passing in a URL that is actually not a hub site [#2033](https://github.com/pnp/powershell/pull/2033)
 - Fixed `Add-PnPListItem` not showing field name when it has an improper value assigned to it [#2002](https://github.com/pnp/powershell/pull/2002)
 - Fixed connecting using `Connect-PnPOnline -Interactive -ClientId` not working well when already having an App-Only connection using the same ClientId [#2035](https://github.com/pnp/powershell/pull/2035)
+- Fixed cmdlets inheriting from PnPAdminCmdlet not working well on vanity domain SharePoint Online tenants
 
 ### Removed
 

--- a/src/Commands/Admin/GetTenantTheme.cs
+++ b/src/Commands/Admin/GetTenantTheme.cs
@@ -1,11 +1,7 @@
 ﻿using Microsoft.Online.SharePoint.TenantAdministration;
 using Microsoft.SharePoint.Client;
-
 using PnP.PowerShell.Commands.Base;
 using System.Management.Automation;
-using PnP.Framework.Sites;
-using PnP.PowerShell.Commands.Base.PipeBinds;
-using System;
 using System.Linq;
 using PnP.PowerShell.Commands.Model;
 using System.Text.Json;
@@ -51,7 +47,6 @@ namespace PnP.PowerShell.Commands.Admin
                     WriteObject(themes.Select(t => new SPOTheme(t.Name, t.Palette, t.IsInverted)), true);
                 }
             }
-
         }
     }
 }

--- a/src/Commands/Base/PnPAdminCmdlet.cs
+++ b/src/Commands/Base/PnPAdminCmdlet.cs
@@ -108,23 +108,23 @@ namespace PnP.PowerShell.Commands.Base
             }
 
             // Check if a connection has been made using DeviceLogin, in this case we cannot clone the context to the admin URL and will throw an exception
-            IsDeviceLogin(Connection.TenantAdminUrl);
+            IsDeviceLogin(tenantAdminUrl);
 
             // Set up a temporary context to the SharePoint Online Admin Center URL to allow this cmdlet to execute
-            WriteVerbose($"Connecting to the SharePoint Online Admin Center at '{Connection.TenantAdminUrl}' to run this cmdlet");
+            WriteVerbose($"Connecting to the SharePoint Online Admin Center at '{tenantAdminUrl}' to run this cmdlet");
             try
             {
-                Connection.Context = Connection.CloneContext(Connection.TenantAdminUrl);
+                Connection.Context = Connection.CloneContext(tenantAdminUrl);
             }
             catch(WebException e) when (e.Status == WebExceptionStatus.NameResolutionFailure)
             {
-                throw new PSInvalidOperationException($"The hostname '{Connection.TenantAdminUrl}' which you have passed in your Connect-PnPOnline -TenantAdminUrl is invalid. Please connect again using the proper hostname.", e);
+                throw new PSInvalidOperationException($"The hostname '{tenantAdminUrl}' which you have passed in your Connect-PnPOnline -TenantAdminUrl is invalid. Please connect again using the proper hostname.", e);
             }
             catch(Exception e)
             {
                 throw new PSInvalidOperationException($"Unable to connect to the SharePoint Online Admin Center at '{Connection.TenantAdminUrl}' to run this cmdlet. Please ensure you pass in the correct Admin Center URL using Connect-PnPOnline -TenantAdminUrl and you have access to it. Error message: {e.Message}.", e);
             }
-            WriteVerbose($"Connected to the SharePoint Online Admin Center at '{Connection.TenantAdminUrl}' to run this cmdlet");
+            WriteVerbose($"Connected to the SharePoint Online Admin Center at '{tenantAdminUrl}' to run this cmdlet");
         }
 
         /// <summary>


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #2029

## What is in this Pull Request ? ##
Bugfix in PnPAdminCmdlet which caused the context not to be set to the TenandAdminUrl provided in Connect-PnPOnline. This caused all cmdlets inheriting from PnPAdminCmdlet not to work on vanity domain tenants.