### PR TITLE
Fixes `Copy-PnPList` throwing unauthorized exception when used with a non SPO admin user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Add-PnPListItem` not showing field name when it has an improper value assigned to it [#2002](https://github.com/pnp/powershell/pull/2002)
 - Fixed connecting using `Connect-PnPOnline -Interactive -ClientId` not working well when already having an App-Only connection using the same ClientId [#2035](https://github.com/pnp/powershell/pull/2035)
 - Fixed cmdlets inheriting from PnPAdminCmdlet not working well on vanity domain SharePoint Online tenants [#2052](https://github.com/pnp/powershell/pull/2052)
-- Fixed `Copy-PnPList` throwing an unauthorized exception when using it with a non SharePoint Online administrator user
+- Fixed `Copy-PnPList` throwing an unauthorized exception when using it with a non SharePoint Online administrator user [#2054](https://github.com/pnp/powershell/pull/2054)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Add-PnPListItem` not showing field name when it has an improper value assigned to it [#2002](https://github.com/pnp/powershell/pull/2002)
 - Fixed connecting using `Connect-PnPOnline -Interactive -ClientId` not working well when already having an App-Only connection using the same ClientId [#2035](https://github.com/pnp/powershell/pull/2035)
 - Fixed cmdlets inheriting from PnPAdminCmdlet not working well on vanity domain SharePoint Online tenants [#2052](https://github.com/pnp/powershell/pull/2052)
+- Fixed `Copy-PnPList` throwing an unauthorized exception when using it with a non SharePoint Online administrator user
 
 ### Removed
 

--- a/src/Commands/Base/PnPWebCmdlet.cs
+++ b/src/Commands/Base/PnPWebCmdlet.cs
@@ -3,7 +3,6 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 using System.Management.Automation;
 using Microsoft.SharePoint.Client;
 
-
 namespace PnP.PowerShell.Commands
 {
     public abstract class PnPWebCmdlet : PnPSharePointCmdlet

--- a/src/Commands/Model/SharePoint/SiteScriptFromList.cs
+++ b/src/Commands/Model/SharePoint/SiteScriptFromList.cs
@@ -1,0 +1,13 @@
+namespace PnP.PowerShell.Commands.Model.SharePoint
+{
+    /// <summary>
+    /// Contains the information regarding a site script which was generated from an existing list
+    /// </summary>
+    public class SiteScriptFromList
+    {
+        /// <summary>
+        /// The site script
+        /// </summary>
+        public string GetSiteScriptFromList { get; set; }
+    }
+}

--- a/src/Commands/Utilities/REST/RestHelper.cs
+++ b/src/Commands/Utilities/REST/RestHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -223,7 +224,7 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             HttpRequestMessage message = null;
             if (payload != null)
             {
-                var content = new StringContent(JsonSerializer.Serialize(payload, new JsonSerializerOptions() { IgnoreNullValues = true }));
+                var content = new StringContent(JsonSerializer.Serialize(payload, new JsonSerializerOptions { IgnoreNullValues = true }));
                 content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
                 message = GetMessage(url, HttpMethod.Post, accessToken, accept, content);
             }
@@ -591,7 +592,7 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             var message = new HttpRequestMessage();
             message.Method = method;
             message.RequestUri = new Uri(url);
-            message.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue(accept));
+            message.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(accept));
             PnP.Framework.Http.PnPHttpClient.AuthenticateRequestAsync(message, clientContext).GetAwaiter().GetResult();
             if (method == HttpMethod.Post || method == HttpMethod.Put || method.Method == "PATCH")
             {

--- a/src/Commands/Utilities/REST/RestResult.cs
+++ b/src/Commands/Utilities/REST/RestResult.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.Json.Serialization;
+
+namespace PnP.PowerShell.Commands.Utilities.REST
+{
+    /// <summary>
+    /// Contains a single result
+    /// </summary>
+    /// <typeparam name="T">Model type to map the content to</typeparam>
+    public class RestResult<T>
+    {
+        /// <summary>
+        /// The content contained in the results
+        /// </summary>
+        [JsonPropertyName("value")]
+        public T Content { get; set; }
+    }
+}


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #1927

## What is in this Pull Request ? ##
Elevating to the Tenant object to request a list site script to be generated requires the SharePoint Online Administrator permissions. Code has been changed to call into the SharePoint Online API instead, which also supports normal user accounts which are not administrators.