### PR TITLE
Removed mentioning limitation in `Copy-PnPFolder`

### DIFF
--- a/documentation/Copy-PnPFolder.md
+++ b/documentation/Copy-PnPFolder.md
@@ -21,7 +21,7 @@ Copy-PnPFolder [-SourceUrl] <String> [-TargetUrl] <String> [-Overwrite] [-Force]
 
 ## DESCRIPTION
 
-Copies a folder or file to a different location. This location can be within the same document library, same site, same site collection or even to another site collection on the same tenant. Currently there is a 200MB file size limit for the file or folder to be copied. Notice that if copying between sites or to a subsite you cannot specify a target filename, only a folder name.
+Copies a folder or file to a different location. This location can be within the same document library, same site, same site collection or even to another site collection on the same tenant. Notice that if copying between sites or to a subsite you cannot specify a target filename, only a folder name.
 
 Copying files and folders is bound to some restrictions. You can find more on it here: https://docs.microsoft.com/office365/servicedescriptions/sharepoint-online-service-description/sharepoint-online-limits#moving-and-copying-across-sites
 


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample
- [X] Documentation update

## Related Issues? ##
Fixes #2057 

## What is in this Pull Request ? ##
Removed mentioning limitation in `Copy-PnPFolder` as it can change at any time. The documentation links to docs.microsoft for the actual values.