### PR TITLE
Fixing `-Connection` on `Disconnect-PnPOnline` throwing an exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Removed
 
 ### Fixed
+- Fixed issue where passing in `-Connection` to `Disconnect-PnPOnline` woud throw an exception
 
 ### Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Removed
 
 ### Fixed
-- Fixed issue where passing in `-Connection` to `Disconnect-PnPOnline` woud throw an exception
+- Fixed issue where passing in `-Connection` to `Disconnect-PnPOnline` woud throw an exception [#2093](https://github.com/pnp/powershell/pull/2093)
 
 ### Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Removed
 
 ### Fixed
-- Fixed issue where passing in `-Connection` to `Disconnect-PnPOnline` woud throw an exception [#2093](https://github.com/pnp/powershell/pull/2093)
+- Fixed issue where passing in `-Connection` to `Disconnect-PnPOnline` would throw an exception [#2093](https://github.com/pnp/powershell/pull/2093)
 
 ### Contributors
+- Koen Zomers [koenzomers]
 
 ## [1.11.0]
 

--- a/src/Commands/Base/DisconnectOnline.cs
+++ b/src/Commands/Base/DisconnectOnline.cs
@@ -17,6 +17,11 @@ namespace PnP.PowerShell.Commands.Base
 
         protected override void ProcessRecord()
         {
+            // As parameters are passed in by value, there's no use in doing anything with the connection object here, so we'll simply exit.
+            #pragma warning disable CS0618 
+            if(Connection != null) return;
+            #pragma warning restore CS6018
+
             if(PnPConnection.Current == null)
             {
                 throw new InvalidOperationException(Properties.Resources.NoConnectionToDisconnect);


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Since 1.11, when passing in `-Connection` to `Disconnect-PnPOnline`, it would throw an exception if the current context was not connected. In this update we'll explicitly not do anything when a connection is being passed in. This is for backwards compatibility.