### PR TITLE
Update Set-PnPListRecordDeclaration.md

### DIFF
--- a/documentation/Set-PnPListRecordDeclaration.md
+++ b/documentation/Set-PnPListRecordDeclaration.md
@@ -10,11 +10,7 @@ online version: https://pnp.github.io/powershell/cmdlets/Set-PnPListRecordDeclar
 # Set-PnPListRecordDeclaration
 
 ## SYNOPSIS
-The RecordDeclaration parameter supports 4 values:
-
-AlwaysAllowManualDeclaration
-NeverAllowManualDeclaration
-UseSiteCollectionDefaults
+Updates record declaration settings of a list.
 
 ## SYNTAX
 
@@ -24,6 +20,12 @@ Set-PnPListRecordDeclaration -List <ListPipeBind> [-ManualRecordDeclaration <Ecm
 ```
 
 ## DESCRIPTION
+The RecordDeclaration parameter supports 3 values:
+
+* AlwaysAllowManualDeclaration
+* NeverAllowManualDeclaration
+* UseSiteCollectionDefaults
+
 
 ## EXAMPLES
 
@@ -32,19 +34,19 @@ Set-PnPListRecordDeclaration -List <ListPipeBind> [-ManualRecordDeclaration <Ecm
 Set-PnPListRecordDeclaration -List "Documents" -ManualRecordDeclaration NeverAllowManualDeclaration
 ```
 
-Sets the manual record declaration to never allow
+Sets the manual record declaration to never allow.
 
 ### EXAMPLE 2
 ```powershell
 Set-PnPListRecordDeclaration -List "Documents" -AutoRecordDeclaration $true
 ```
 
-Turns on auto record declaration for the list
+Turns on auto record declaration for the list.
 
 ## PARAMETERS
 
 ### -AutoRecordDeclaration
-Defines if you want to set auto record declaration on the list
+Turns on or off auto record declaration on the list.
 
 ```yaml
 Type: Boolean
@@ -72,7 +74,7 @@ Accept wildcard characters: False
 ```
 
 ### -List
-The List to set the manual record declaration settings for
+The list to set the manual record declaration settings for. Specify title, list id, or list object.
 
 ```yaml
 Type: ListPipeBind
@@ -86,12 +88,12 @@ Accept wildcard characters: False
 ```
 
 ### -ManualRecordDeclaration
-Defines the manual record declaration setting for the lists
+Defines the manual record declaration setting for the lists.
 
 ```yaml
 Type: EcmListManualRecordDeclaration
 Parameter Sets: (All)
-Accepted values: Unknown, UseSiteCollectionDefaults, AlwaysAllowManualDeclaration, NeverAllowManualDeclaration
+Accepted values: UseSiteCollectionDefaults, AlwaysAllowManualDeclaration, NeverAllowManualDeclaration
 
 Required: False
 Position: Named


### PR DESCRIPTION

## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample
- [x] Parameter description

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Removed one of the accepted values. Although the [enum](https://github.com/pnp/pnpframework/blob/ac4dc39f564fcaa55e140bd7d778149360a265f7/src/lib/PnP.Framework/Enums/EcmListManualRecordDeclaration.cs) accepts four, in the actual code, if you use anything beside the three I left in the documentation you get:
[throw new ArgumentOutOfRangeException(nameof(settings)); ](https://github.com/pnp/pnpframework/blob/e5062f86302e20cef94fc1662b03536f079fc235/src/lib/PnP.Framework/Extensions/RecordsManagementExtensions.cs#L305).

And that's exactly what happens:
```powershell
Set-PnPListRecordDeclaration -List test46 -ManualRecordDeclaration Unknown
Set-PnPListRecordDeclaration: Specified argument was out of the range of valid values. (Parameter 'settings')
```