### PR TITLE
Update Set-PnPGroup.md

### DIFF
--- a/documentation/Set-PnPGroup.md
+++ b/documentation/Set-PnPGroup.md
@@ -10,7 +10,7 @@ online version: https://pnp.github.io/powershell/cmdlets/Set-PnPGroup.html
 # Set-PnPGroup
 
 ## SYNOPSIS
-Updates a group
+Updates a group.
 
 ## SYNTAX
 
@@ -23,6 +23,7 @@ Set-PnPGroup -Identity <GroupPipeBind> [-SetAssociatedGroup <AssociatedGroupType
 ```
 
 ## DESCRIPTION
+This cmdlet updates the roles and settings of the specified group.
 
 ## EXAMPLES
 
@@ -31,19 +32,19 @@ Set-PnPGroup -Identity <GroupPipeBind> [-SetAssociatedGroup <AssociatedGroupType
 Set-PnPGroup -Identity 'My Site Members' -SetAssociatedGroup Members
 ```
 
-Sets the SharePoint group with the name 'My Site Members' as the associated members group
+Sets the SharePoint group with the name 'My Site Members' as the associated members group.
 
 ### EXAMPLE 2
 ```powershell
 Set-PnPGroup -Identity 'My Site Members' -Owner 'site owners'
 ```
 
-Sets the SharePoint group with the name 'site owners' as the owner of the SharePoint group with the name 'My Site Members'
+Sets the SharePoint group with the name 'site owners' as the owner of the SharePoint group with the name 'My Site Members'.
 
 ## PARAMETERS
 
 ### -AddRole
-Name of the permission set to add to this SharePoint group
+Name of the role (permission level) to add to the SharePoint group.
 
 ```yaml
 Type: String
@@ -57,7 +58,7 @@ Accept wildcard characters: False
 ```
 
 ### -AllowMembersEditMembership
-A switch parameter that specifies whether group members can modify membership in the group
+Specifies whether group members can modify membership in the group.
 
 ```yaml
 Type: Boolean
@@ -71,7 +72,7 @@ Accept wildcard characters: False
 ```
 
 ### -AllowRequestToJoinLeave
-A switch parameter that specifies whether to allow users to request membership in the group and to allow users to request to leave the group
+Specifies whether users are allowed to request membership in the group or to request to leave the group.
 
 ```yaml
 Type: Boolean
@@ -85,7 +86,7 @@ Accept wildcard characters: False
 ```
 
 ### -AutoAcceptRequestToJoinLeave
-A switch parameter that specifies whether users are automatically added or removed when they make a request
+Specifies whether users are automatically added or removed when they make a request.
 
 ```yaml
 Type: Boolean
@@ -113,7 +114,7 @@ Accept wildcard characters: False
 ```
 
 ### -Description
-The description for the group
+The description of the group.
 
 ```yaml
 Type: String
@@ -127,7 +128,7 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-A group object, an ID or a name of a group
+A group object, an ID or a name of a group.
 
 ```yaml
 Type: GroupPipeBind
@@ -141,7 +142,7 @@ Accept wildcard characters: False
 ```
 
 ### -OnlyAllowMembersViewMembership
-A switch parameter that specifies whether only group members are allowed to view the list of members in the group
+Specifies whether only group members are allowed to view the list of members in the group.
 
 ```yaml
 Type: Boolean
@@ -155,7 +156,7 @@ Accept wildcard characters: False
 ```
 
 ### -Owner
-The owner for the group, which can be a user or another group
+The owner of the group. It can be a user or another group.
 
 ```yaml
 Type: String
@@ -169,7 +170,7 @@ Accept wildcard characters: False
 ```
 
 ### -RemoveRole
-Name of the permission set to remove from this SharePoint group
+Name of the role (permission level) to remove from the SharePoint group.
 
 ```yaml
 Type: String
@@ -183,7 +184,7 @@ Accept wildcard characters: False
 ```
 
 ### -RequestToJoinEmail
-The e-mail address to which membership requests are sent
+The e-mail address to which membership requests are sent.
 
 ```yaml
 Type: String
@@ -197,7 +198,7 @@ Accept wildcard characters: False
 ```
 
 ### -SetAssociatedGroup
-One of the associated group types (Visitors, Members, Owners)
+One of the associated group types (Visitors, Members, Owners).
 
 ```yaml
 Type: AssociatedGroupType
@@ -212,7 +213,7 @@ Accept wildcard characters: False
 ```
 
 ### -Title
-The title for the group
+The title of the group.
 
 ```yaml
 Type: String


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample
- [x] Parameter description

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
* Removed 'switch parameter' because it neither behaves like one, nor is it in the [source](https://github.com/pnp/powershell/blob/6713d2d9496b68e4fb22c561b34239a881bc14ef/src/Commands/Principals/SetGroup.cs)
* Updated 'permission set'. While it makes sense, it doesn't seem to be used by MS outside of Dynamics (I did a web search for the phrase). Replaced with 'role (permission level)'.
* Added cmdlet description