### PR TITLE
Update Set-PnPBrowserIdleSignout.md

### DIFF
--- a/documentation/Set-PnPBrowserIdleSignout.md
+++ b/documentation/Set-PnPBrowserIdleSignout.md
@@ -14,18 +14,24 @@ Sets the current configuration values for Idle session sign-out policy.
 
 ## SYNTAX
 
+### Enable
 ```powershell
-Set-PnPBrowserIdleSignOut [-Enabled] <Boolean> [[-WarnAfter] <TimeSpan>] [[-SignOutAfter] <TimeSpan>]
+Set-PnPBrowserIdleSignOut -Enabled:$true -WarnAfter <TimeSpan> -SignOutAfter <TimeSpan>
+```
+
+### Disable
+```powershell
+Set-PnPBrowserIdleSignOut -Enabled:$false
 ```
 
 ## DESCRIPTION
-Use this cmdlet to set the current configuration values for Idle session sign-out, the time at which users are warned and subsequently signed out of Microsoft 365 after a period of browser inactivity in SharePoint and OneDrive.
+Use this cmdlet to set the current configuration values for Idle session sign-out, the time at which users are warned and subsequently signed out of Microsoft 365 after a period of browser inactivity in SharePoint Online and OneDrive.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```powershell
-Set-PnPBrowserIdleSignOut -Enabled:$true -WarnAfter  "0.00:45:00" -SignOutAfter  "0.01:00:00"
+Set-PnPBrowserIdleSignOut -Enabled:$true -WarnAfter "0.00:45:00" -SignOutAfter "0.01:00:00"
 ```
 This example enables the browser idle sign-out policy, sets a warning at 45 minutes and signs out users after a period of 60 minutes of browser inactivity.
 
@@ -35,6 +41,12 @@ Set-PnPBrowserIdleSignOut -Enabled:$true -WarnAfter (New-TimeSpan -Minutes 45) -
 ```
 This example enables the browser idle sign-out policy, sets a warning at 45 minutes and signs out users after a period of 60 minutes of browser inactivity.
 
+### EXAMPLE 3
+```powershell
+Set-PnPBrowserIdleSignOut -Enabled:$false
+```
+This example disables the browser idle sign-out policy.
+
 ## PARAMETERS
 
 ### -Enabled
@@ -43,7 +55,7 @@ Enables the browser idle sign-out policy.
 
 ```yaml
 Type: Boolean
-Parameter Sets: (All)
+Parameter Sets: DisableBrowserIdleSignout, EnableBrowserIdleSignout
 
 Required: True
 Position: Named
@@ -70,7 +82,7 @@ where:
 
 ```yaml
 Type: TimeSpan
-Parameter Sets: (All)
+Parameter Sets: EnableBrowserIdleSignout
 
 Required: True
 Position: Named
@@ -97,7 +109,7 @@ where:
 
 ```yaml
 Type: TimeSpan
-Parameter Sets: (All)
+Parameter Sets: EnableBrowserIdleSignout
 
 Required: True
 Position: Named
@@ -109,4 +121,3 @@ Accept wildcard characters: False
 ## RELATED LINKS
 
 [Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)
-

--- a/documentation/Set-PnPBrowserIdleSignout.md
+++ b/documentation/Set-PnPBrowserIdleSignout.md
@@ -19,7 +19,7 @@ Set-PnPBrowserIdleSignOut [-Enabled] <Boolean> [[-WarnAfter] <TimeSpan>] [[-Sign
 ```
 
 ## DESCRIPTION
-Use this cmdlet to set the current configuration values for Idle session sign-out, the time at which users are warned and subsequently signed out of Microsoft 365 after a period of browser inactivity in SharePoint and OneDrive
+Use this cmdlet to set the current configuration values for Idle session sign-out, the time at which users are warned and subsequently signed out of Microsoft 365 after a period of browser inactivity in SharePoint and OneDrive.
 
 ## EXAMPLES
 
@@ -39,11 +39,12 @@ This example enables the browser idle sign-out policy, sets a warning at 45 minu
 
 ### -Enabled
 
-Enables the browser idle sign-out policy
+Enables the browser idle sign-out policy.
 
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
+
 Required: True
 Position: Named
 Default value: None
@@ -70,6 +71,7 @@ where:
 ```yaml
 Type: TimeSpan
 Parameter Sets: (All)
+
 Required: True
 Position: Named
 Default value: None
@@ -96,6 +98,7 @@ where:
 ```yaml
 Type: TimeSpan
 Parameter Sets: (All)
+
 Required: True
 Position: Named
 Default value: None

--- a/src/Commands/Admin/SetBrowserIdleSignOut.cs
+++ b/src/Commands/Admin/SetBrowserIdleSignOut.cs
@@ -5,24 +5,31 @@ using System;
 
 namespace PnP.PowerShell.Commands.Admin
 {
-    [Cmdlet(VerbsCommon.Set, "PnPBrowserIdleSignout")]
+    [Cmdlet(VerbsCommon.Set, "PnPBrowserIdleSignout", DefaultParameterSetName = DisableBrowserIdleSignout)]
     public class SetBrowserIdleSignout : PnPAdminCmdlet
     {
-        [Parameter(Mandatory = true)]
+        private const string DisableBrowserIdleSignout = "DisableBrowserIdleSignout";
+        private const string EnableBrowserIdleSignout = "EnableBrowserIdleSignout";
+
+        [Parameter(Mandatory = true, ParameterSetName = DisableBrowserIdleSignout)]
+        [Parameter(Mandatory = true, ParameterSetName = EnableBrowserIdleSignout)]
         public bool Enabled;
 
-        [Parameter(Mandatory = false)]
+        [Parameter(Mandatory = true, ParameterSetName = EnableBrowserIdleSignout)]
         public TimeSpan WarnAfter;
 
-        [Parameter(Mandatory = false)]
+        [Parameter(Mandatory = true, ParameterSetName = EnableBrowserIdleSignout)]
         public TimeSpan SignoutAfter;
 
         protected override void ExecuteCmdlet()
         {
+            if(Enabled && (!ParameterSpecified(nameof(WarnAfter)) || !ParameterSpecified(nameof(SignoutAfter))))
+            {
+                throw new PSArgumentException($"{nameof(WarnAfter)} and {nameof(SignoutAfter)} must be specified when enabling the browser idle signout");
+            }
+
             var result = this.Tenant.SetIdleSessionSignOutForUnmanagedDevices(Enabled,WarnAfter,SignoutAfter);
             ClientContext.ExecuteQueryRetry();
         }
     }
-
-
 }


### PR DESCRIPTION

## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample
- [x] Formatting

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
In the source -WarnAfter and -SignoutAfter parameters are non-Mandatory. I'm guessing it's because for 
```powershell
 Set-PnPBrowserIdleSignout -Enabled $false
```
they are not needed and there is only one parameter set.

In the Documentation they are Required. I left them as such because 
```powershell
Set-PnPBrowserIdleSignout -Enabled $true -SignoutAfter 0.11:00:00
```
doesn't work without the other parameter and vice-versa.


Feel free to amend with a commit if you feel it should be otherwise.