### PR TITLE
GetSiteSearchQueryResults: fix 'Value cannot be null' exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fixed issue where passing in `-Connection` to `Disconnect-PnPOnline` would throw an exception [#2093](https://github.com/pnp/powershell/pull/2093)
+- Fixed `Get-PnPSiteSearchQueryResults` throwing `Value cannot be null` exception [#2138](https://github.com/pnp/powershell/pull/2138)
 
 ### Contributors
 
+- James May [fowl2]
 - Marcus Blennegård [mblennegard]
 - Arleta Wanat [PowerShellScripts]
 - Koen Zomers [koenzomers]

--- a/src/Commands/Search/GetSiteSearchQueryResults.cs
+++ b/src/Commands/Search/GetSiteSearchQueryResults.cs
@@ -1,5 +1,4 @@
 ﻿using System.Management.Automation;
-
 using System.Collections.Generic;
 
 namespace PnP.PowerShell.Commands.Search
@@ -22,18 +21,18 @@ namespace PnP.PowerShell.Commands.Search
 
         protected override void ExecuteCmdlet()
         {
-            var queryCmdLet = new SubmitSearchQuery();
-
-            queryCmdLet.Connection = Connection;
-            
-            queryCmdLet.StartRow = StartRow;
-            queryCmdLet.MaxResults = MaxResults;
-            queryCmdLet.All = All;
+            var queryCmdLet = new SubmitSearchQuery
+            {
+                Connection = Connection,
+                StartRow = StartRow,
+                MaxResults = MaxResults,
+                All = All
+            };
             
             var query = "contentclass:STS_Site";
             if (!string.IsNullOrEmpty(Query))
             {
-                query = query + " AND " + Query;
+                query = $"{query} AND {Query}";
             }
             queryCmdLet.Query = query;
 

--- a/src/Commands/Search/GetSiteSearchQueryResults.cs
+++ b/src/Commands/Search/GetSiteSearchQueryResults.cs
@@ -23,6 +23,8 @@ namespace PnP.PowerShell.Commands.Search
         protected override void ExecuteCmdlet()
         {
             var queryCmdLet = new SubmitSearchQuery();
+
+            queryCmdLet.Connection = Connection;
             
             queryCmdLet.StartRow = StartRow;
             queryCmdLet.MaxResults = MaxResults;

--- a/src/Commands/Search/SubmitSearchQuery.cs
+++ b/src/Commands/Search/SubmitSearchQuery.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Management.Automation;
 using Microsoft.SharePoint.Client;
 using Microsoft.SharePoint.Client.Search.Query;
-
 using System.Collections.Generic;
 using System.Linq;
 
@@ -304,4 +303,3 @@ namespace PnP.PowerShell.Commands.Search
         }
     }
 }
-


### PR DESCRIPTION
## Type ##
- [X] Bug Fix

## Related Issues? ##
Fixes #2130

### Repro

1. Connect to a site using `Connect-PnPOnline`
2. Run `Get-PnPSiteSearchQueryResults`

This exception occurs:

```
Message          : Value cannot be null.
                   Parameter name: context
Stacktrace       :    at Microsoft.SharePoint.Client.ObjectPath..ctor(ClientRuntimeContext context, ObjectPath 
                   parent, Boolean addToContext)
                      at Microsoft.SharePoint.Client.ObjectPathConstructor..ctor(ClientRuntimeContext context, 
                   String typeId, Object[] parameters)
                      at Microsoft.SharePoint.Client.Search.Query.KeywordQuery..ctor(ClientRuntimeContext 
                   context)
                      at PnP.PowerShell.Commands.Search.SubmitSearchQuery.CreateKeywordQuery(String 
                   clientFunction)
                      at PnP.PowerShell.Commands.Search.SubmitSearchQuery.Run()
                      at PnP.PowerShell.Commands.Search.GetSiteSearchQueryResults.ExecuteCmdlet()
                      at PnP.PowerShell.Commands.PnPSharePointCmdlet.ProcessRecord()

```

I'm honestly not sure how this cmdlet ever worked without passing the connection. I've had a quick look through the commit history and see nothing obvious.

## What is in this Pull Request ? ##
Pass the connection from the parent cmdlet to the child cmdlet, so that it can access the ClientContext.
