### PR TITLE
Fix NullDereferenceException in New-PnPSite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Contributors
 
+- Giacomo Pozzoni [jackpoz]
 - James May [fowl2]
 - Jimmy Hang [JimmyHang]
 - Marcus Blennegård [mblennegard]

--- a/src/Commands/Admin/NewSite.cs
+++ b/src/Commands/Admin/NewSite.cs
@@ -62,6 +62,7 @@ namespace PnP.PowerShell.Commands
         {
             if (Type == SiteType.CommunicationSite)
             {
+                EnsureDynamicParameters(_communicationSiteParameters);
                 if (!ParameterSpecified("Lcid"))
                 {
                     ClientContext.Web.EnsureProperty(w => w.Language);
@@ -109,6 +110,7 @@ namespace PnP.PowerShell.Commands
             }
             else if (Type == SiteType.TeamSite)
             {
+                EnsureDynamicParameters(_teamSiteParameters);
                 if (!ParameterSpecified("Lcid"))
                 {
                     ClientContext.Web.EnsureProperty(w => w.Language);
@@ -158,6 +160,7 @@ namespace PnP.PowerShell.Commands
             }
             else
             {
+                EnsureDynamicParameters(_teamSiteWithoutMicrosoft365GroupParameters);
                 if (!ParameterSpecified("Lcid"))
                 {
                     ClientContext.Web.EnsureProperty(w => w.Language);
@@ -196,6 +199,12 @@ namespace PnP.PowerShell.Commands
                     WriteObject(returnedContext.Url);
                 }
             }
+        }
+
+        private void EnsureDynamicParameters(object dynamicParameters)
+        {
+            if (dynamicParameters == null)
+                throw new ArgumentException($"Please specify the parameter -{nameof(Type)} when invoking the command");
         }
 
         public class CommunicationSiteParameters

--- a/src/Commands/Admin/NewSite.cs
+++ b/src/Commands/Admin/NewSite.cs
@@ -1,12 +1,9 @@
-﻿using System.Management.Automation;
-using Microsoft.SharePoint.Client;
-
-using PnP.PowerShell.Commands.Base.PipeBinds;
-using PnP.PowerShell.Commands.Enums;
-using System;
-using PnP.PowerShell.Commands.Base;
-using PnP.PowerShell.Commands.Attributes;
+﻿using System;
 using System.Linq;
+using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using PnP.PowerShell.Commands.Enums;
+using PnP.PowerShell.Commands.Attributes;
 
 namespace PnP.PowerShell.Commands
 {
@@ -40,20 +37,16 @@ namespace PnP.PowerShell.Commands
             switch (Type)
             {
                 case SiteType.CommunicationSite:
-                    {
-                        _communicationSiteParameters = new CommunicationSiteParameters();
-                        return _communicationSiteParameters;
-                    }
+                    _communicationSiteParameters = new CommunicationSiteParameters();
+                    return _communicationSiteParameters;
+
                 case SiteType.TeamSite:
-                    {
-                        _teamSiteParameters = new TeamSiteParameters();
-                        return _teamSiteParameters;
-                    }
+                    _teamSiteParameters = new TeamSiteParameters();
+                    return _teamSiteParameters;
+
                 case SiteType.TeamSiteWithoutMicrosoft365Group:
-                    {
-                        _teamSiteWithoutMicrosoft365GroupParameters = new TeamSiteWithoutMicrosoft365Group();
-                        return _teamSiteWithoutMicrosoft365GroupParameters;
-                    }
+                    _teamSiteWithoutMicrosoft365GroupParameters = new TeamSiteWithoutMicrosoft365Group();
+                    return _teamSiteWithoutMicrosoft365GroupParameters;
             }
             return null;
         }
@@ -204,7 +197,9 @@ namespace PnP.PowerShell.Commands
         private void EnsureDynamicParameters(object dynamicParameters)
         {
             if (dynamicParameters == null)
-                throw new ArgumentException($"Please specify the parameter -{nameof(Type)} when invoking the command");
+            {
+                throw new PSArgumentException($"Please specify the parameter -{nameof(Type)} when invoking this cmdlet", nameof(Type));
+            }
         }
 
         public class CommunicationSiteParameters


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
No linked issues

## What is in this Pull Request ? ##
New-PnPSite uses dynamic parameters, meaning the full set of parameters is determined on the value of -Type . -Type parameter is mandatory, so one would expect it has always a valid value. As explained at https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.idynamicparameters.getdynamicparameters , this is not the case:
>Therefore, parameters which allow input from the pipeline may not be set at the time this method is called, even if the parameters are mandatory.

This means that when invoking `New-PnPSite` with no parameters, the custom dynamic parameters handler will be called before -Type is filled in by the user, causing unexpected behavior in the cmdlet handler:
![image](https://user-images.githubusercontent.com/1153754/179254990-abd7f297-210f-4871-8ee0-5777adfda612.png)

This PR adds some validation to ensure the dynamic parameters handler was successful and an error message that attempts to explain how to call the cmdlet in a working way, with a clearer error message than a null exception:
![image](https://user-images.githubusercontent.com/1153754/179255400-e58db968-70cd-4b45-a5b2-8a53d39c7495.png)

I opted for a validator inside the cmdlet handler as that felt like the cleanest solution, supporting scenarios where the parameter itself is not mandatory. If this PR is approved, I will apply the same to other affected cmdlets:
- Add-PnPTeamsTab
- Set-PnPPage when HeaderType is Custom
- Add-PnPField when Type is Choice
![image](https://user-images.githubusercontent.com/1153754/179255772-22960a66-c2bf-4c39-8982-9d11171fa934.png)

All in all I learnt dynamic parameters don't work as one would expect and one should try to avoid them 😄 