### PR TITLE
Update Remove-PnPTermGroup.md

### DIFF
--- a/documentation/Remove-PnPTermGroup.md
+++ b/documentation/Remove-PnPTermGroup.md
@@ -11,17 +11,17 @@ online version: https://pnp.github.io/powershell/cmdlets/Remove-PnPTermGroup.htm
 # Remove-PnPTermGroup
 
 ## SYNOPSIS
-Removes a taxonomy term group and all its containing termsets
+Removes a taxonomy term group and all its term sets.
 
 ## SYNTAX
 
 ```
 Remove-PnPTermGroup -Identity <TaxonomyTermGroupPipeBind> [-TermStore <TaxonomyTermStorePipeBind>] [-Force]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-WhatIf] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet removes a term group and all the containing termsets.
+This cmdlet removes a term group and all the contained term sets.
 
 ## EXAMPLES
 
@@ -30,39 +30,25 @@ This cmdlet removes a term group and all the containing termsets.
 Remove-PnPTermGroup -Identity 3d9e60e8-d89c-4cd4-af61-a010cf93b380
 ```
 
-Removes the specified termgroup.
+Removes the specified term group.
 
 ### Example 2
 ```powershell
 Remove-PnPTermGroup -Identity "Corporate"
 ```
+Removes the specified term group.
 
 ### Example 3
 ```powershell
 Remove-PnPTermGroup -Identity "HR" -Force
 ```
 
-Removes the specified termgroup without prompting for confirmation.
+Removes the specified term group without prompting for confirmation.
 
 ## PARAMETERS
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Identity
-The name of GUID of the group to remove.
+The name or GUID of the group to remove.
 
 ```yaml
 Type: TaxonomyTermGroupPipeBind
@@ -92,6 +78,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
+Specifying the Force parameter will skip the confirmation question.
 
 ```yaml
 Type: SwitchParameter

--- a/documentation/Remove-PnPTermGroup.md
+++ b/documentation/Remove-PnPTermGroup.md
@@ -17,7 +17,6 @@ Removes a taxonomy term group and all its term sets.
 
 ```
 Remove-PnPTermGroup -Identity <TaxonomyTermGroupPipeBind> [-TermStore <TaxonomyTermStorePipeBind>] [-Force]
- [-WhatIf] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -91,21 +90,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: wi
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
 
 ## RELATED LINKS
 


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample
- [x] Parameter descriptions
- [x] Removed Confirm parameter
- [x] Removed WhatIf parameter

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
* Parameter descriptions
* 'term group' instead of 'termgroup' as per https://docs.microsoft.com/en-us/sharepoint/set-up-new-group-for-term-sets 
* Removed -Confirm, because it doesn't look like it's implemented. The cmdlet asks for confirmation anyway, unless you use -Force.
* Removed -WhatIf in the second commit (missed at first). Doesn't look like it's implemented and doesn't do what it's supposed to.