### PR TITLE
Fixes `Remove-PnPFile` cmdlet parameter set error

### DIFF
--- a/src/Commands/Files/RemoveFile.cs
+++ b/src/Commands/Files/RemoveFile.cs
@@ -28,7 +28,7 @@ namespace PnP.PowerShell.Commands.Files
 
         protected override void ExecuteCmdlet()
         {
-            if (!string.IsNullOrEmpty(SiteRelativeUrl))
+            if (ParameterSpecified(SiteRelativeUrl))
             {
                 var webUrl = CurrentWeb.EnsureProperty(w => w.ServerRelativeUrl);
                 ServerRelativeUrl = UrlUtility.Combine(webUrl, SiteRelativeUrl);

--- a/src/Commands/Files/RemoveFile.cs
+++ b/src/Commands/Files/RemoveFile.cs
@@ -1,8 +1,8 @@
-﻿using System.Management.Automation;
-using Microsoft.SharePoint.Client;
-using Resources = PnP.PowerShell.Commands.Properties.Resources;
+﻿using Microsoft.SharePoint.Client;
 using PnP.Framework.Utilities;
 using PnP.PowerShell.Commands.Model.SharePoint;
+using System.Management.Automation;
+using Resources = PnP.PowerShell.Commands.Properties.Resources;
 
 namespace PnP.PowerShell.Commands.Files
 {
@@ -11,21 +11,16 @@ namespace PnP.PowerShell.Commands.Files
     {
         private const string ParameterSet_SERVER_Delete = "Delete by Server Relative";
         private const string ParameterSet_SITE_Delete = "Delete by Site Relative";
-        private const string ParameterSet_SERVER_Recycle = "Recycle by Server Relative";
-        private const string ParameterSet_SITE_Recycle = "Recycle by Site Relative";
 
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = ParameterSet_SERVER_Delete)]
-        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = ParameterSet_SERVER_Recycle)]
         [ValidateNotNullOrEmpty]
         public string ServerRelativeUrl = string.Empty;
 
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = ParameterSet_SITE_Delete)]
-        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = ParameterSet_SITE_Recycle)]
         [ValidateNotNullOrEmpty]
         public string SiteRelativeUrl = string.Empty;
 
-        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_SERVER_Recycle)]
-        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_SITE_Recycle)]
+        [Parameter(Mandatory = false)]
         public SwitchParameter Recycle;
 
         [Parameter(Mandatory = false)]
@@ -33,7 +28,7 @@ namespace PnP.PowerShell.Commands.Files
 
         protected override void ExecuteCmdlet()
         {
-            if (!string.IsNullOrEmpty(ServerRelativeUrl))
+            if (!string.IsNullOrEmpty(SiteRelativeUrl))
             {
                 var webUrl = CurrentWeb.EnsureProperty(w => w.ServerRelativeUrl);
                 ServerRelativeUrl = UrlUtility.Combine(webUrl, SiteRelativeUrl);

--- a/src/Commands/Files/RemoveFile.cs
+++ b/src/Commands/Files/RemoveFile.cs
@@ -28,7 +28,7 @@ namespace PnP.PowerShell.Commands.Files
 
         protected override void ExecuteCmdlet()
         {
-            if (ParameterSpecified(SiteRelativeUrl))
+            if (ParameterSpecified(nameof(SiteRelativeUrl)))
             {
                 var webUrl = CurrentWeb.EnsureProperty(w => w.ServerRelativeUrl);
                 ServerRelativeUrl = UrlUtility.Combine(webUrl, SiteRelativeUrl);

--- a/src/Commands/Model/SharePoint/RecycleResult.cs
+++ b/src/Commands/Model/SharePoint/RecycleResult.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace PnP.PowerShell.Commands.Model.SharePoint
 {


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #2099

## What is in this Pull Request ? ##
* Removed some redundant parameter sets that caused the cmdlet to error.
* Fixed the `SiteRelativeUrl` condition check.