### PR TITLE
Fixed `Set-PnPTermGroup` cmdlet group not found error

### DIFF
--- a/src/Commands/Taxonomy/SetTermGroup.cs
+++ b/src/Commands/Taxonomy/SetTermGroup.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Linq.Expressions;
-using System.Management.Automation;
-using System.Security.Cryptography;
-using Microsoft.SharePoint.Client;
+﻿using Microsoft.SharePoint.Client;
 using Microsoft.SharePoint.Client.Taxonomy;
-
 using PnP.PowerShell.Commands.Base.PipeBinds;
+using System;
+using System.Management.Automation;
 
 namespace PnP.PowerShell.Commands.Taxonomy
 {
@@ -41,12 +38,19 @@ namespace PnP.PowerShell.Commands.Taxonomy
             if (termStore != null)
             {
                 var group = Identity.GetGroup(termStore);
-                ClientContext.Load(group);
-                ClientContext.ExecuteQueryRetry();
-
-                if (group.ServerObjectIsNull.Value != false)
+                try
                 {
-                    bool updateRequired = false;
+                    ClientContext.Load(group);
+                    ClientContext.ExecuteQueryRetry();
+                }
+                catch (Exception)
+                {
+                    throw new PSArgumentException("Group not found");
+                }
+
+                try
+                {
+                    var updateRequired = false;
                     if (ParameterSpecified(nameof(Name)))
                     {
                         group.Name = Name;
@@ -64,9 +68,9 @@ namespace PnP.PowerShell.Commands.Taxonomy
                     }
                     WriteObject(group);
                 }
-                else
+                catch (Exception e)
                 {
-                    throw new PSArgumentException("Group not found");
+                    throw new PSArgumentException(e.Message);
                 }
             }
         }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #2231

## What is in this Pull Request ? ##
Fixed issue which throws a `Group not found` error.
Issue occurred because the line underneath was always `false` even when the group exists.

https://github.com/pnp/powershell/blob/d3bae07d6aeb289546e6b23be072f1e6a584d774/src/Commands/Taxonomy/SetTermGroup.cs#L47