### PR TITLE
Updates `Get-PnPAvailableSensitivityLabel` to use new endpoint

### DIFF
--- a/src/Commands/Purview/GetAvailableSensitivityLabel.cs
+++ b/src/Commands/Purview/GetAvailableSensitivityLabel.cs
@@ -1,5 +1,4 @@
-﻿using PnP.PowerShell.Commands.Attributes;
-using PnP.PowerShell.Commands.Base;
+﻿using PnP.PowerShell.Commands.Base;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 using PnP.PowerShell.Commands.Utilities.REST;
 using System;
@@ -26,24 +25,24 @@ namespace PnP.PowerShell.Commands.Purview
             {
                 var user = User.GetUser(AccessToken);
 
-                if(user == null)
+                if (user == null)
                 {
                     WriteWarning("Provided user not found");
                     return;
                 }
 
-                url = $"/beta/users/{user.UserPrincipalName}/informationProtection/policy/labels";
+                url = $"/beta/users/{user.UserPrincipalName}/security/informationProtection/sensitivityLabels";
             }
             else
             {
-                if(Connection.ConnectionMethod == Model.ConnectionMethod.AzureADAppOnly)
+                if (Connection.ConnectionMethod == Model.ConnectionMethod.AzureADAppOnly)
                 {
-                    url = "/beta/informationProtection/policy/labels";
+                    url = "/beta/security/informationProtection/sensitivityLabels";
                 }
                 else
                 {
-                    url = "/beta/me/informationProtection/policy/labels";
-                }                
+                    url = "/beta/me/security/informationProtection/sensitivityLabels";
+                }
             }
 
             if (ParameterSpecified(nameof(Identity)))


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample
- [x] Enhancement

## Related Issues? ##
Mentioned in #2233

## What is in this Pull Request ? ##
The current endpoint to list sensitivity labels is marked deprecated (they will break next year). Replaced the old endpoints with the new ones.
Source: https://docs.microsoft.com/en-us/graph/api/informationprotectionpolicy-list-labels?view=graph-rest-beta&tabs=http

## Comments
In order for this endpoint to work, delegated Graph permissions of type `InformationProtectionPolicy.Read` are needed. These permissions should be added to the PnP app registration.