### PR TITLE
Fix for batch image in Add-PnPListItem in Markdown page and web page

### DIFF
--- a/documentation/Add-PnPListItem.md
+++ b/documentation/Add-PnPListItem.md
@@ -13,7 +13,7 @@ title: Add-PnPListItem
 
 Adds an item to the list and sets the creation time to the current date and time. The author is set to the current authenticated user executing the cmdlet. In order to set the author to a different user, please refer to Set-PnPListItem.
 
-[![Supports Batching](https://github.com/pnp/powershell/blob/gh-pages/images/batching/Batching.png)](../articles/batching.html)
+<a href="https://pnp.github.io/powershell/articles/batching.html" rel="Supports Batching">![Supports Batching](https://raw.githubusercontent.com/pnp/powershell/gh-pages/images/batching/Batching.png)</a>
 
 ## SYNTAX
 

--- a/documentation/Remove-PnPListItem.md
+++ b/documentation/Remove-PnPListItem.md
@@ -13,7 +13,7 @@ online version: https://pnp.github.io/powershell/cmdlets/Remove-PnPListItem.html
 
 Deletes an item from a list
 
-[![Supports Batching](https://github.com/pnp/powershell/blob/gh-pages/images/batching/Batching.png)](../articles/batching.html)
+<a href="https://github.com/pnp/powershell/blob/gh-pages/articles/batching.html" rel="Supports Batching">![Supports Batching](https://raw.githubusercontent.com/pnp/powershell/gh-pages/images/batching/Batching.png)</a>
 
 ## SYNTAX
 


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Mention in #2164 

## What is in this Pull Request ? ##
Added HTML hyperlink and image pointing to full paths i.e. 

```
<a href="https://pnp.github.io/powershell/articles/batching.html" rel="Supports Batching">![Supports Batching](https://raw.githubusercontent.com/pnp/powershell/gh-pages/images/batching/Batching.png)</a>
```

Seems Docfx is converting the image paths and making them either work in the web page or the markdown file but not both - hopefully the option above will show the batching image correctly in

[https://github.com/pnp/powershell/blob/dev/documentation/Add-PnPListItem.md](https://github.com/pnp/powershell/blob/dev/documentation/Add-PnPListItem.md)
and
[https://pnp.github.io/powershell/cmdlets/Add-PnPListItem.html](https://pnp.github.io/powershell/cmdlets/Add-PnPListItem.html)

Fingers crossed this approach works and can be rolled out to:

* [`Set-PnPListItem`](/powershell/cmdlets/Set-PnPListItem.html)
* [`Remove-PnPListItem`](/powershell/cmdlets/Remove-PnPListItem.html)
* [`Publish-PnPSyntexModel`](/powershell/cmdlets/Publish-PnPSyntexModel.html)
* [`Unpublish-PnPSyntexModel`](/powershell/cmdlets/Unpublish-PnPSyntexModel.html)
* [`Request-PnPSyntexClassifyAndExtract`](/powershell/cmdlets/Request-PnPSyntexClassifyAndExtract.html)