### PR TITLE
Add check if group is M365 group to the Get-PnPMicrosoft365Group command

### DIFF
--- a/src/Commands/Utilities/Microsoft365GroupsUtility.cs
+++ b/src/Commands/Utilities/Microsoft365GroupsUtility.cs
@@ -53,6 +53,12 @@ namespace PnP.PowerShell.Commands.Utilities
         internal static async Task<Microsoft365Group> GetGroupAsync(PnPConnection connection, Guid groupId, string accessToken, bool includeSiteUrl, bool includeOwners)
         {
             var group = await GraphHelper.GetAsync<Microsoft365Group>(connection, $"v1.0/groups/{groupId}", accessToken);
+
+            if (!group.GroupTypes.Contains("Unified"))
+            {
+                throw new Exception($"Group with ID '{groupId}' is not a Microsoft365 group. Please use Get-PnPAzureADGroup instead.");
+            }
+
             if (includeSiteUrl)
             {
                 bool wait = true;

--- a/src/Commands/Utilities/Microsoft365GroupsUtility.cs
+++ b/src/Commands/Utilities/Microsoft365GroupsUtility.cs
@@ -7,7 +7,6 @@ using PnP.PowerShell.Commands.Utilities.REST;
 using System.Text.Json;
 using PnP.PowerShell.Commands.Model;
 using PnP.PowerShell.Commands.Base;
-using System.Management.Automation;
 
 namespace PnP.PowerShell.Commands.Utilities
 {
@@ -110,7 +109,7 @@ namespace PnP.PowerShell.Commands.Utilities
             {
                 return await GetGroupFilteredAsync($"(id eq '{groupId}' or displayName eq '{groupId}' or mailNickName eq '{groupId}')", connection, accessToken, includeSiteUrl, includeOwners);
             } 
-            catch (Exception e)
+            catch (Exception)
             {
                 throw new Exception($"No Microsoft 365 group found with id, display name or mail nickname '{groupId}'");
             }                      
@@ -123,7 +122,7 @@ namespace PnP.PowerShell.Commands.Utilities
             {
                 return await GetGroupFilteredAsync($"(displayName eq '{displayName}' or mailNickName eq '{displayName}')", connection, accessToken, includeSiteUrl, includeOwners);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 throw new Exception($"No Microsoft 365 group found with id, display name or mail nickname '{displayName}'");
             }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## What is in this Pull Request ? ##

Added check if the group is a Microsoft 365 group when getting a group by ID with the Get-PnPMicrosoft365Group command.
This is to align the return of the command with `Get-PnPMicrosoft365Group | Where-Object {$_.Id -eq '{guid}'`

~~When a group with the specified ID exists that is not a Microsoft 365 group, then an error will be thrown including a hint to use the `Get-PnPAzureADGroup` command.~~

**Update 24.08.2022:**

Hint regarding usage of `Get-PnPAzureADGroup` command dropped due to different implementation.

Added fixes for the following bugs:

- Get-PnPMicrosoft365Group returns a group if the mailNickname of the group matches the provided Identity even if the group is not a Microsoft 365 group
- Get-PnPMicrosoft365Group doesn't return a group if the format of the provided identity matches the GUID format but is meant to be the display name or mail nickname