### PR TITLE
Fixes `Get-PnPAccessToken` on different sites

### DIFF
--- a/src/Commands/Base/GetAccessToken.cs
+++ b/src/Commands/Base/GetAccessToken.cs
@@ -1,6 +1,7 @@
-﻿using System.Management.Automation;
-using PnP.PowerShell.Commands.Attributes;
+﻿using PnP.PowerShell.Commands.Attributes;
 using PnP.PowerShell.Commands.Enums;
+using System;
+using System.Management.Automation;
 
 namespace PnP.PowerShell.Commands.Base
 {
@@ -43,7 +44,13 @@ namespace PnP.PowerShell.Commands.Base
                         accessTokenValue = AccessToken;
                         break;
                     case ResourceTypeName.SharePoint:
-                        accessTokenValue = TokenHandler.GetAccessToken(null, Connection?.Context?.Url?.TrimEnd('/') + "/.default", Connection);
+                        var currentUrl = Connection?.Context?.Url?.TrimEnd('/');
+                        if (string.IsNullOrEmpty(currentUrl))
+                        {
+                            throw new PSArgumentException("No connection found, please login first.");
+                        }
+                        var rootUrl = new Uri(currentUrl).GetLeftPart(UriPartial.Authority);
+                        accessTokenValue = TokenHandler.GetAccessToken(null, rootUrl + "/.default", Connection);
                         break;
                     case ResourceTypeName.ARM:
                         accessTokenValue = TokenHandler.GetAccessToken(null, "https://management.azure.com/.default", Connection);


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] Enhancement
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #2269, partially fixes #Y, mentioned in #Z, etc.

## What is in this Pull Request ? ##
Extracts the root URL of the current context. This URL is used as resource to fetch an access token. This way you are able to get an access token on all SharePoint sites. Now you must connect to the root site or you'll receive an error.