### PR TITLE
Support DisplayNamesOfFileViewers and DisplayNamesOfFileViewersInSpo

### DIFF
--- a/src/Commands/Admin/SetTenant.cs
+++ b/src/Commands/Admin/SetTenant.cs
@@ -251,6 +251,12 @@ namespace PnP.PowerShell.Commands.Admin
         [Parameter(Mandatory = false)]
         public int? ExternalUserExpireInDays;
 
+        [Parameter(Mandatory = false)]
+        public bool? DisplayNamesOfFileViewers;
+
+        [Parameter(Mandatory = false)]
+        public bool? DisplayNamesOfFileViewersInSpo;
+
         public SwitchParameter Force;
 
         protected override void ExecuteCmdlet()
@@ -915,6 +921,18 @@ namespace PnP.PowerShell.Commands.Admin
             if (ExternalUserExpireInDays.HasValue)
             {
                 Tenant.ExternalUserExpireInDays = ExternalUserExpireInDays.Value;
+                modified = true;
+            }
+
+            if(DisplayNamesOfFileViewers.HasValue)
+            {
+                Tenant.DisplayNamesOfFileViewers = DisplayNamesOfFileViewers.Value;
+                modified = true;
+            }
+
+            if (DisplayNamesOfFileViewersInSpo.HasValue)
+            {
+                Tenant.DisplayNamesOfFileViewersInSpo = DisplayNamesOfFileViewersInSpo.Value;
                 modified = true;
             }
 

--- a/src/Commands/Model/SPOTenant.cs
+++ b/src/Commands/Model/SPOTenant.cs
@@ -40,6 +40,8 @@ namespace PnP.PowerShell.Commands.Model
             this.viewInFileExplorerEnabled = tenant.ViewInFileExplorerEnabled;
             this.externalUserExpirationRequired = tenant.ExternalUserExpirationRequired;
             this.externalUserExpireInDays = tenant.ExternalUserExpireInDays;
+            this.displayNamesOfFileViewers = tenant.DisplayNamesOfFileViewers;
+            this.displayNamesOfFileViewersInSpo = tenant.DisplayNamesOfFileViewersInSpo;
 
             try
             {
@@ -551,6 +553,10 @@ namespace PnP.PowerShell.Commands.Model
         public bool ExternalUserExpirationRequired => externalUserExpirationRequired;
 
         public int ExternalUserExpireInDays => externalUserExpireInDays;
+        
+        public bool DisplayNamesOfFileViewers => displayNamesOfFileViewers;
+        
+        public bool DisplayNamesOfFileViewersInSpo => displayNamesOfFileViewersInSpo;
 
         public Guid[] DisabledModernListTemplateIds => disabledModernListTemplateIds;
 
@@ -709,6 +715,10 @@ namespace PnP.PowerShell.Commands.Model
         private bool externalUserExpirationRequired;
 
         private int externalUserExpireInDays;
+
+        private bool displayNamesOfFileViewers;
+
+        private bool displayNamesOfFileViewersInSpo;
 
     }
 }


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## What is in this Pull Request ? ##
Add support for tenant object properties to show/hide viewers in property pane for a file (currently only works in ODB).