### PR TITLE
Adds `-DraftVersionVisibility` option to `Set-PnPList` cmdlet

### DIFF
--- a/documentation/Set-PnPList.md
+++ b/documentation/Set-PnPList.md
@@ -227,6 +227,20 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -DraftItemSecurity
+Specify which users should be able to view drafts in this list.
+
+```yaml
+Type: DraftVisibilityType
+Parameter Sets: (All)
+Accepted values: Approver, Author, Reader
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -EnableVersioning
 Enable or disable versioning. Set to $true to enable, $false to disable.
 

--- a/documentation/Set-PnPList.md
+++ b/documentation/Set-PnPList.md
@@ -227,7 +227,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -DraftItemSecurity
+### -DraftVersionVisibility
 Specify which users should be able to view drafts in this list.
 
 ```yaml

--- a/src/Commands/Lists/SetList.cs
+++ b/src/Commands/Lists/SetList.cs
@@ -64,7 +64,7 @@ namespace PnP.PowerShell.Commands.Lists
         public bool EnableModeration;
 
         [Parameter(Mandatory = false)]
-        public DraftVisibilityType DraftItemSecurity;
+        public DraftVisibilityType DraftVersionVisibility;
 
         [Parameter(Mandatory = false)]
         public ListReadSecurity ReadSecurity;
@@ -141,9 +141,9 @@ namespace PnP.PowerShell.Commands.Lists
                     updateRequired = true;
                 }
 
-                if (ParameterSpecified(nameof(DraftItemSecurity)))
+                if (ParameterSpecified(nameof(DraftVersionVisibility)))
                 {
-                    list.DraftVersionVisibility = DraftItemSecurity;
+                    list.DraftVersionVisibility = DraftVersionVisibility;
                     updateRequired = true;
                 }
 

--- a/src/Commands/Lists/SetList.cs
+++ b/src/Commands/Lists/SetList.cs
@@ -1,8 +1,7 @@
-﻿using System.Management.Automation;
-using Microsoft.SharePoint.Client;
-
+﻿using Microsoft.SharePoint.Client;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 using PnP.PowerShell.Commands.Enums;
+using System.Management.Automation;
 
 namespace PnP.PowerShell.Commands.Lists
 {
@@ -14,20 +13,16 @@ namespace PnP.PowerShell.Commands.Lists
         public ListPipeBind Identity;
 
         [Parameter(Mandatory = false)]
-        public bool
-            EnableContentTypes;
+        public bool EnableContentTypes;
 
         [Parameter(Mandatory = false)]
-        public
-            SwitchParameter BreakRoleInheritance;
+        public SwitchParameter BreakRoleInheritance;
 
         [Parameter(Mandatory = false)]
-        public
-            SwitchParameter ResetRoleInheritance;
+        public SwitchParameter ResetRoleInheritance;
 
         [Parameter(Mandatory = false)]
-        public
-            SwitchParameter CopyRoleAssignments;
+        public SwitchParameter CopyRoleAssignments;
 
         [Parameter(Mandatory = false)]
         public SwitchParameter ClearSubscopes;
@@ -69,6 +64,9 @@ namespace PnP.PowerShell.Commands.Lists
         public bool EnableModeration;
 
         [Parameter(Mandatory = false)]
+        public DraftVisibilityType DraftItemSecurity;
+
+        [Parameter(Mandatory = false)]
         public ListReadSecurity ReadSecurity;
 
         [Parameter(Mandatory = false)]
@@ -93,9 +91,7 @@ namespace PnP.PowerShell.Commands.Lists
 
                 var enableVersioning = list.EnableVersioning;
                 var enableMinorVersions = list.EnableMinorVersions;
-                var hidden = list.Hidden;
                 var enableAttachments = list.EnableAttachments;
-                var disableGridEditing = list.DisableGridEditing;
                 var updateRequired = false;
                 if (BreakRoleInheritance)
                 {
@@ -103,7 +99,7 @@ namespace PnP.PowerShell.Commands.Lists
                     updateRequired = true;
                 }
 
-                if ((list.HasUniqueRoleAssignments) && (ResetRoleInheritance))
+                if (list.HasUniqueRoleAssignments && ResetRoleInheritance)
                 {
                     list.ResetRoleInheritance();
                     updateRequired = true;
@@ -142,6 +138,12 @@ namespace PnP.PowerShell.Commands.Lists
                 if (ParameterSpecified(nameof(EnableModeration)) && list.EnableModeration != EnableModeration)
                 {
                     list.EnableModeration = EnableModeration;
+                    updateRequired = true;
+                }
+
+                if (ParameterSpecified(nameof(DraftItemSecurity)))
+                {
+                    list.DraftVersionVisibility = DraftItemSecurity;
                     updateRequired = true;
                 }
 


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #2282

## What is in this Pull Request ? ##
New option to set the draft item security in a list. Content approval should be enabled on the list in order to see this value changing in the UI.
Possible values: `Reader`, `Author`, `Approver`

Example:
```powershell
Set-PnPList -Identity "Testlist" -DraftVersionVisibility Approver
```