### PR TITLE
Adding full html link and img for batching image in docs - 2nd attempt!

### DIFF
--- a/documentation/Add-PnPListItem.md
+++ b/documentation/Add-PnPListItem.md
@@ -13,7 +13,9 @@ title: Add-PnPListItem
 
 Adds an item to the list and sets the creation time to the current date and time. The author is set to the current authenticated user executing the cmdlet. In order to set the author to a different user, please refer to Set-PnPListItem.
 
-<a href="https://pnp.github.io/powershell/articles/batching.html" rel="Supports Batching">![Supports Batching](https://raw.githubusercontent.com/pnp/powershell/gh-pages/images/batching/Batching.png)</a>
+<a href="https://pnp.github.io/powershell/articles/batching.html">
+<img src="https://raw.githubusercontent.com/pnp/powershell/gh-pages/images/batching/Batching.png" alt="Supports Batching">
+</a>
 
 ## SYNTAX
 


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
First attempt in #2245

## What is in this Pull Request ? ##
Appears I need to use full html using both **a** AND **img** tags (DocFX did not translate the markdown image tag - so the "Supports Batching" image appears does not appear in web page with my last attempt) to ensure on Add-PnPListItem the image appears on both the markdown and the web page.

New attempt below - **Fingers crossed this works - would appreciate a quick merge 😁**
```
<a href="https://pnp.github.io/powershell/articles/batching.html">
<img src="https://raw.githubusercontent.com/pnp/powershell/gh-pages/images/batching/Batching.png" alt="Supports Batching">
</a>
```


