### PR TITLE
Fix NullDereferenceException in Add-PnPField

### DIFF
--- a/src/Commands/Fields/AddField.cs
+++ b/src/Commands/Fields/AddField.cs
@@ -122,6 +122,7 @@ namespace PnP.PowerShell.Commands.Fields
                     }
                     if (Type == FieldType.Choice || Type == FieldType.MultiChoice)
                     {
+                        EnsureDynamicParameters(choiceFieldParameters);
                         f = list.CreateField<FieldChoice>(fieldCI);
                         ((FieldChoice)f).Choices = choiceFieldParameters.Choices;
                         f.Update();
@@ -129,6 +130,8 @@ namespace PnP.PowerShell.Commands.Fields
                     }
                     else if (Type == FieldType.Calculated)
                     {
+                        EnsureDynamicParameters(calculatedFieldParameters);
+
                         // Either set the ResultType as input parameter or set it to the default Text
                         if (!string.IsNullOrEmpty(calculatedFieldParameters.ResultType))
                         {
@@ -231,6 +234,7 @@ namespace PnP.PowerShell.Commands.Fields
 
                 if (Type == FieldType.Choice || Type == FieldType.MultiChoice)
                 {
+                    EnsureDynamicParameters(choiceFieldParameters);
                     f = CurrentWeb.CreateField<FieldChoice>(fieldCI);
                     ((FieldChoice)f).Choices = choiceFieldParameters.Choices;
                     f.Update();
@@ -238,6 +242,7 @@ namespace PnP.PowerShell.Commands.Fields
                 }
                 else if (Type == FieldType.Calculated)
                 {
+                    EnsureDynamicParameters(calculatedFieldParameters);
                     f = CurrentWeb.CreateField<FieldCalculated>(fieldCI);
                     ((FieldCalculated)f).Formula = calculatedFieldParameters.Formula;
                     f.Update();
@@ -335,6 +340,14 @@ namespace PnP.PowerShell.Commands.Fields
                             break;
                         }
                 }
+            }
+        }
+
+        private void EnsureDynamicParameters(object dynamicParameters)
+        {
+            if (dynamicParameters == null)
+            {
+                throw new PSArgumentException($"Please specify the parameter -{nameof(Type)} when invoking this cmdlet", nameof(Type));
             }
         }
 


### PR DESCRIPTION
Fix NullDereferenceException in Add-PnPField when not including -Type parameter and specifying Choice, MultiChoice or Calculated as Type later on

Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
No linked issues

## What is in this Pull Request ? ##
Similar to https://github.com/pnp/powershell/pull/2156 and New-PnPSite, this PR fixes NullDereferenceExceptions thrown when calling `Add-PnPField` without specifying -Type parameter but later selecting a Type that requires dynamic parameters.

The affected -Type options are:
- Choice
- MultiChoice
- Calculated

## Tests

Old behavior:
![image](https://user-images.githubusercontent.com/1153754/189532425-cd5a9f01-7544-426d-99d7-3400054eeeef.png)

New behavior: 
![image](https://user-images.githubusercontent.com/1153754/189532489-38071f89-c389-47e6-9797-7d39c7d1a582.png)

Test passing -Type:
![image](https://user-images.githubusercontent.com/1153754/189532503-4232b0ed-edf5-4667-b980-8dce851f4187.png)

Test without passing -Type but specifying Text:
![image](https://user-images.githubusercontent.com/1153754/189532636-18b287c7-1513-4465-8726-d45398f08273.png)
