### PR TITLE
Fix build warning from duplicate PackageReference for 'NewtonSoft.Json' 

### DIFF
--- a/src/Commands/PnP.PowerShell.csproj
+++ b/src/Commands/PnP.PowerShell.csproj
@@ -130,7 +130,6 @@
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
 		<PackageReference Include="System.Management.Automation" Version="7.0.3" />
-		<PackageReference Include="NewtonSoft.Json" Version="12.0.3" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net462'">


### PR DESCRIPTION
(The version stays the same.)