### PR TITLE
Fix #2133 - issue with Import-PnPTaxonomy not working in PS 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Add-PnPField` cmdlet , it was throwing null reference error when `-Type` was not specified and after the prompt you entered the correct type. [#2338](https://github.com/pnp/powershell/pull/2338)
 - Fixed regression issue with `New-Microsoft365Group` cmdlet. [#2349](https://github.com/pnp/powershell/pull/2349)
 - Fixed issue with `Add-PnPTaxonomyField`, it was throwing error when using `-TaxonomyItemId` parameter. [#2351](https://github.com/pnp/powershell/pull/2351)
+- Fixed `Import-PnPTermGroupFromXml` issue where a valid template was not working.
 
 ### Contributors
 

--- a/src/Commands/Taxonomy/ImportTermGroupFromXml.cs
+++ b/src/Commands/Taxonomy/ImportTermGroupFromXml.cs
@@ -22,11 +22,7 @@ namespace PnP.PowerShell.Commands.Taxonomy
         protected override void ExecuteCmdlet()
         {
             var template = new ProvisioningTemplate();
-            //template.Security = null;
-            //template.Features = null;
-            //template.CustomActions = null;
-            //template.ComposedLook = null;
-
+            
             template.Id = "TAXONOMYPROVISIONING";
 
             var outputStream = XMLPnPSchemaFormatter.LatestFormatter.ToFormattedTemplate(template);
@@ -36,6 +32,17 @@ namespace PnP.PowerShell.Commands.Taxonomy
             var fullXml = reader.ReadToEnd();
 
             var document = XDocument.Parse(fullXml);
+
+#if !NETFRAMEWORK
+
+            XElement preferencesElement = document.Root.Descendants(document.Root.GetNamespaceOfPrefix("pnp") + "Preferences").FirstOrDefault();
+            if (preferencesElement != null && preferencesElement.PreviousNode != null)
+            {
+                preferencesElement.PreviousNode.AddBeforeSelf(preferencesElement);
+                preferencesElement.Remove();
+            }
+
+#endif
 
             XElement termGroupsElement;
             if (ParameterSpecified(nameof(Xml)))


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #2133 

## What is in this Pull Request ? ##
For some weird reason, the template was not working in PS 7 but worked fine in PS5.
Fixed it.