### PR TITLE
Added OneDriveRequestFilesLinkEnabled option to Set-PnPTenant and RequestFilesLinkEnabled to Set-PnPSite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added ability to create shared Teams channels using `Add-PnPTeamsChannel -ChannelType Shared` [#2308](https://github.com/pnp/powershell/pull/2308)
 - Added support for `IsLoopEnabled` properties in `Get-PnPTenant` and `Set-PnPTenant` cmdlets to to enable/disable loop components in the tenant. [#2307](https://github.com/pnp/powershell/pull/2307)
 - Added support for `SubscribeMembersToCalendarEventsDisabled` resource behavior option in `New-PnPMicrosoft365Group` and `New-PnPTeamsTeam` cmdlet. [#2349](https://github.com/pnp/powershell/pull/2349)
+- Added `-OneDriveRequestFilesLinkEnabled` option to `Set-PnPTenant` to allow configuring the request files anonymously feature
 
 ### Changed
 - Changed to no longer require `https://` to be prefixed when using `Connect-PnPOnline -Url tenant.sharepoint.com` [#2139](https://github.com/pnp/powershell/pull/2139)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added ability to create shared Teams channels using `Add-PnPTeamsChannel -ChannelType Shared` [#2308](https://github.com/pnp/powershell/pull/2308)
 - Added support for `IsLoopEnabled` properties in `Get-PnPTenant` and `Set-PnPTenant` cmdlets to to enable/disable loop components in the tenant. [#2307](https://github.com/pnp/powershell/pull/2307)
 - Added support for `SubscribeMembersToCalendarEventsDisabled` resource behavior option in `New-PnPMicrosoft365Group` and `New-PnPTeamsTeam` cmdlet. [#2349](https://github.com/pnp/powershell/pull/2349)
-- Added `-OneDriveRequestFilesLinkEnabled` option to `Set-PnPTenant` to allow configuring the request files anonymously feature [#2360](https://github.com/pnp/powershell/pull/2360)
+- Added `-OneDriveRequestFilesLinkEnabled` option to `Set-PnPTenant` to allow configuring the request files anonymously feature on the tenant level [#2360](https://github.com/pnp/powershell/pull/2360)
+- Added `-RequestFilesLinkEnabled` option to `Set-PnPSite` to allow configuring the request files anonymously feature on a per site collection level [#2360](https://github.com/pnp/powershell/pull/2360)
 
 ### Changed
 - Changed to no longer require `https://` to be prefixed when using `Connect-PnPOnline -Url tenant.sharepoint.com` [#2139](https://github.com/pnp/powershell/pull/2139)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added ability to create shared Teams channels using `Add-PnPTeamsChannel -ChannelType Shared` [#2308](https://github.com/pnp/powershell/pull/2308)
 - Added support for `IsLoopEnabled` properties in `Get-PnPTenant` and `Set-PnPTenant` cmdlets to to enable/disable loop components in the tenant. [#2307](https://github.com/pnp/powershell/pull/2307)
 - Added support for `SubscribeMembersToCalendarEventsDisabled` resource behavior option in `New-PnPMicrosoft365Group` and `New-PnPTeamsTeam` cmdlet. [#2349](https://github.com/pnp/powershell/pull/2349)
-- Added `-OneDriveRequestFilesLinkEnabled` option to `Set-PnPTenant` to allow configuring the request files anonymously feature
+- Added `-OneDriveRequestFilesLinkEnabled` option to `Set-PnPTenant` to allow configuring the request files anonymously feature [#2360](https://github.com/pnp/powershell/pull/2360)
 
 ### Changed
 - Changed to no longer require `https://` to be prefixed when using `Connect-PnPOnline -Url tenant.sharepoint.com` [#2139](https://github.com/pnp/powershell/pull/2139)

--- a/documentation/Set-PnPSite.md
+++ b/documentation/Set-PnPSite.md
@@ -460,8 +460,6 @@ Accept wildcard characters: False
 Allows configuring whether users will be able to create anonymous requests for people to upload files regardless of the Share with anyone link configuration setting for this particular site collection.
 
 ```yaml
-
-```yaml
 Type: Boolean
 Parameter Sets: (All)
 

--- a/documentation/Set-PnPSite.md
+++ b/documentation/Set-PnPSite.md
@@ -24,7 +24,7 @@ Set-PnPSite [-Identity <String>] [-Classification <String>] [-DisableFlows] [-Lo
  [-DisableCompanyWideSharingLinks <CompanyWideSharingLinksPolicy>] [-DisableSharingForNonOwners]
  [-LocaleId <UInt32>] [-RestrictedToGeo <RestrictedToRegion>] [-SocialBarOnSitePagesDisabled]
  [-AnonymousLinkExpirationInDays <Int32>] [-OverrideTenantAnonymousLinkExpirationPolicy]
- [-MediaTranscription <MediaTranscriptionPolicyType>] [-SensitivityLabel <Guid>]
+ [-MediaTranscription <MediaTranscriptionPolicyType>] [-SensitivityLabel <Guid>] [-RequestFilesLinkEnabled <Boolean>]
  [-Connection <PnPConnection>] [<CommonParameters>]
 ```
 
@@ -448,6 +448,22 @@ When the feature is enabled, videos can have transcripts generated on demand or 
 Type: MediaTranscriptionPolicyType
 Parameter Sets: Set Properties
 Accepted values: Enabled, Disabled
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RequestFilesLinkEnabled
+Allows configuring whether users will be able to create anonymous requests for people to upload files regardless of the Share with anyone link configuration setting for this particular site collection.
+
+```yaml
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
 
 Required: False
 Position: Named

--- a/documentation/Set-PnPTenant.md
+++ b/documentation/Set-PnPTenant.md
@@ -1410,8 +1410,6 @@ Accept wildcard characters: False
 Allows configuring whether users will be able to create anonymous requests for people to upload files regardless of the Share with anyone link configuration setting.
 
 ```yaml
-
-```yaml
 Type: Boolean
 Parameter Sets: (All)
 

--- a/documentation/Set-PnPTenant.md
+++ b/documentation/Set-PnPTenant.md
@@ -51,7 +51,7 @@ Set-PnPTenant [-SpecialCharactersStateInFileFolderNames <SpecialCharactersState>
  [-EnableAutoNewsDigest <Boolean>] [-CommentsOnListItemsDisabled <Boolean>] [-CommentsOnFilesDisabled <Boolean>]
  [-DisableBackToClassic <Boolean>] [-InformationBarriersSuspension <Boolean>] 
  [-AllowFilesWithKeepLabelToBeDeletedODB <Boolean>] [-AllowFilesWithKeepLabelToBeDeletedSPO <Boolean>]
- [-ExternalUserExpirationRequired <Boolean>] [-ExternalUserExpireInDays <Boolean>]
+ [-ExternalUserExpirationRequired <Boolean>] [-ExternalUserExpireInDays <Boolean>] [-OneDriveRequestFilesLinkEnabled <Boolean>]
  [-Force] [-Connection <PnPConnection>] [<CommonParameters>]
 ```
 
@@ -1394,6 +1394,22 @@ Accept wildcard characters: False
 
 ### -IsLoopEnabled
 Allows configuring whether loop components are enabled or disabled in the tenant. If set to `$true`, loop components will be allowed to be created in the tenant. If set to `$false`, it will be disabled in the tenant.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OneDriveRequestFilesLinkEnabled
+Allows configuring whether users will be able to create anonymous requests for people to upload files regardless of the Share with anyone link configuration setting.
+
+```yaml
 
 ```yaml
 Type: Boolean

--- a/src/Commands/Admin/SetTenant.cs
+++ b/src/Commands/Admin/SetTenant.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Online.SharePoint.TenantAdministration;
 using Microsoft.SharePoint.Client;
-
 using PnP.PowerShell.Commands.Base;
 using System.Management.Automation;
 using System;
@@ -259,6 +258,9 @@ namespace PnP.PowerShell.Commands.Admin
 
         [Parameter(Mandatory = false)]
         public bool? IsLoopEnabled;
+
+        [Parameter(Mandatory = false)]
+        public bool? OneDriveRequestFilesLinkEnabled;        
 
         public SwitchParameter Force;
 
@@ -943,7 +945,13 @@ namespace PnP.PowerShell.Commands.Admin
             {
                 Tenant.IsLoopEnabled = IsLoopEnabled.Value;
                 modified = true;
-            }            
+            }
+
+            if (OneDriveRequestFilesLinkEnabled.HasValue)
+            {
+                Tenant.OneDriveRequestFilesLinkEnabled = OneDriveRequestFilesLinkEnabled.Value;
+                modified = true;
+            }
 
             if (modified)
             {

--- a/src/Commands/Site/SetSite.cs
+++ b/src/Commands/Site/SetSite.cs
@@ -100,7 +100,7 @@ namespace PnP.PowerShell.Commands.Site
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
         public Guid? SensitivityLabel;
 
-        [Parameter(Mandatory = false)]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
         public bool? RequestFilesLinkEnabled;           
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_LOCKSTATE)]

--- a/src/Commands/Site/SetSite.cs
+++ b/src/Commands/Site/SetSite.cs
@@ -100,6 +100,9 @@ namespace PnP.PowerShell.Commands.Site
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
         public Guid? SensitivityLabel;
 
+        [Parameter(Mandatory = false)]
+        public bool? RequestFilesLinkEnabled;           
+
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_LOCKSTATE)]
         public SwitchParameter Wait;
 
@@ -306,7 +309,12 @@ namespace PnP.PowerShell.Commands.Site
                     siteProperties.MediaTranscription = MediaTranscription.Value;
                     executeQueryRequired = true;
                 }
-
+                
+                if (RequestFilesLinkEnabled.HasValue)
+                {
+                    siteProperties.RequestFilesLinkEnabled = RequestFilesLinkEnabled.Value;
+                    executeQueryRequired = true;
+                }                
                 if (executeQueryRequired)
                 {
                     siteProperties.Update();


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
Announced through MC428259 / RM98097

## What is in this Pull Request ? ##
- Added `-OneDriveRequestFilesLinkEnabled` option to `Set-PnPTenant` to allow configuring the request files anonymously feature on the tenant level
- Added `-RequestFilesLinkEnabled` option to `Set-PnPSite` to allow configuring the request files anonymously feature on a per site collection level