### PR TITLE
Fix NullDereferenceException in Add-PnPTeamsTab

### DIFF
--- a/src/Commands/Teams/AddTeamsTab.cs
+++ b/src/Commands/Teams/AddTeamsTab.cs
@@ -80,6 +80,7 @@ namespace PnP.PowerShell.Commands.Graph
                             case TeamTabType.PowerPoint:
                             case TeamTabType.PDF:
                                 {
+                                    EnsureDynamicParameters(officeFileParameters);
                                     entityId = officeFileParameters.EntityId;
                                     contentUrl = officeFileParameters.ContentUrl;
                                     break;
@@ -87,11 +88,13 @@ namespace PnP.PowerShell.Commands.Graph
                             case TeamTabType.DocumentLibrary:
                             case TeamTabType.WebSite:
                                 {
+                                    EnsureDynamicParameters(documentLibraryParameters);
                                     contentUrl = documentLibraryParameters.ContentUrl;
                                     break;
                                 }
                             case TeamTabType.Custom:
                                 {
+                                    EnsureDynamicParameters(customParameters);
                                     entityId = customParameters.EntityId;
                                     contentUrl = customParameters.ContentUrl;
                                     removeUrl = customParameters.RemoveUrl;
@@ -124,6 +127,14 @@ namespace PnP.PowerShell.Commands.Graph
                 throw new PSArgumentException("Group not found");
             }
 
+        }
+
+        private void EnsureDynamicParameters(object dynamicParameters)
+        {
+            if (dynamicParameters == null)
+            {
+                throw new PSArgumentException($"Please specify the parameter -{nameof(Type)} when invoking this cmdlet", nameof(Type));
+            }
         }
 
         public class OfficeFileParameters


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
No linked issues

## What is in this Pull Request ? ##
Similar to https://github.com/pnp/powershell/pull/2156 and https://github.com/pnp/powershell/pull/2338 ,  this PR fixes NullDereferenceExceptions thrown when calling Add-PnPTeamsTab without specifying -Type parameter but later selecting a Type that requires dynamic parameters.

The affected -Type options are:
- Word
- Excel
- PowerPoint
- PDF
- Custom

## Tests
Old behavior:
![image](https://user-images.githubusercontent.com/1153754/193409383-7334a7c6-1681-42cb-916e-fdb17e5248cb.png)

New behavior:
![image](https://user-images.githubusercontent.com/1153754/193409392-76b7559e-6f20-4fd6-ada2-dfa69bd4edf2.png)
