### PR TITLE
feat: new props in commands json

### DIFF
--- a/build/Build-Nightly.ps1
+++ b/build/Build-Nightly.ps1
@@ -195,6 +195,9 @@ if ($runPublish -eq $true) {
 		exit 1
 	}
 
+	# Generate predictor commands
+	./build/Generate-PredictorCommands.ps1 -Version $version
+
 	Write-Host "Generating Documentation" -ForegroundColor Yellow
 	Set-PSRepository PSGallery -InstallationPolicy Trusted
 	Install-Module PlatyPS -ErrorAction Stop
@@ -208,7 +211,4 @@ if ($runPublish -eq $true) {
 
 	# Write version back to version
 	Set-Content ./version.txt -Value $version -Force -NoNewline
-
-	# Generate predictor commands
-	./build/Generate-PredictorCommands.ps1 -Version $version
 }

--- a/build/Generate-PredictorCommands.ps1
+++ b/build/Generate-PredictorCommands.ps1
@@ -13,11 +13,14 @@ try {
     # get all files in the srcfiles folder
     $files = Get-ChildItem -Path ".\documentation" -Filter "*.md" -Recurse;
 
+    # set id to 1
+    $id = 1;
+
     # loop through each file
     $files | ForEach-Object {
         
         # get file name without extension
-        $baseName = $_.BaseName.ToLower();
+        $baseName = $_.BaseName;
 
         # get the file data
         $fileData = Get-Content $_.FullName -Raw;
@@ -28,7 +31,10 @@ try {
             $pattern = "(?s)(?<=### EXAMPLE .*``````)(.*?)(?=``````)";
         }
 
-        $result = [regex]::Matches($fileData, $pattern);
+        # ignore case for regex
+        $options = [Text.RegularExpressions.RegexOptions]'IgnoreCase, CultureInvariant'
+
+        $result = [regex]::Matches($fileData, $pattern, $options);
 
         $i = 1;
         foreach ($item in $result) {
@@ -40,12 +46,15 @@ try {
 
 
             # if the item value begins with the name of the file then add it to the json
-            if ($value.ToLower() -match "^$($baseName).*") {
+            if ($value.ToLower() -match "^$($baseName.ToLower()).*") {
                 $json += @{
+                    "CommandName" = $baseName
                     "Command" = $value
                     "Rank" = $i
+                    "Id" = $id
                 }
                 $i++;
+                $id++;
             }
         }
 


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## What is in this Pull Request ? ##
- Added 2 new props for the predictor JSON file - `CommandName` and `Id`.
- In the Build-nightly.ps1 file, moved the generate-commands line above publish module. 