### PR TITLE
Feature: Use v1 Graph endpoint to list teams tag

### DIFF
--- a/src/Commands/Utilities/TeamsUtility.cs
+++ b/src/Commands/Utilities/TeamsUtility.cs
@@ -938,13 +938,13 @@ namespace PnP.PowerShell.Commands.Utilities
 
         public static async Task<IEnumerable<TeamTag>> GetTagsAsync(string accessToken, PnPConnection connection, string groupId)
         {
-            var collection = await GraphHelper.GetResultCollectionAsync<TeamTag>(connection, $"beta/teams/{groupId}/tags", accessToken);
+            var collection = await GraphHelper.GetResultCollectionAsync<TeamTag>(connection, $"v1.0/teams/{groupId}/tags", accessToken);
             return collection;
         }
 
         public static async Task<TeamTag> GetTagsWithIdAsync(string accessToken, PnPConnection connection, string groupId, string tagId)
         {
-            var tagInformation = await GraphHelper.GetAsync<TeamTag>(connection, $"beta/teams/{groupId}/tags/{tagId}", accessToken);
+            var tagInformation = await GraphHelper.GetAsync<TeamTag>(connection, $"v1.0/teams/{groupId}/tags/{tagId}", accessToken);
             return tagInformation;
         }
 


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
NA

## What is in this Pull Request ? ##
Use the v1 Graph endpoint to list teams tag instead of beta endpoint since it went GA during Ignite