### PR TITLE
Implements advanced queries to Get-PnPTeamsTeam

### DIFF
--- a/documentation/Get-PnPTeamsTeam.md
+++ b/documentation/Get-PnPTeamsTeam.md
@@ -25,7 +25,7 @@ Get-PnPTeamsTeam [-Identity <TeamsTeamPipeBind>] [-Filter <String>]  [<CommonPar
 
 ## DESCRIPTION
 
-Allows to retrieve list of Microsoft Teams teams. By using `Identity` it is possible to retrieve a specific team, and by using `Filter` you can supply simple filter queries.
+Allows to retrieve list of Microsoft Teams teams. By using `Identity` it is possible to retrieve a specific team, and by using `Filter` you can supply any filter queries supported by the Graph API.
 
 ## EXAMPLES
 
@@ -56,6 +56,13 @@ Get-PnPTeamsTeam -Filter "startswith(mailNickName, 'contoso')"
 ```
 
 Retrieves all Microsoft Teams instances with MailNickName starting with "contoso". 
+
+### EXAMPLE 5
+```powershell
+Get-PnPTeamsTeam -Filter "startswith(description, 'contoso')"
+```
+
+Retrieves all Microsoft Teams instances with Description starting with "contoso". This example demonstrates using Advanced Query capabilities (see: https://learn.microsoft.com/en-us/graph/aad-advanced-queries?tabs=http#group-properties).
 
 ## PARAMETERS
 


### PR DESCRIPTION
Improves Get-PnPTeamsTeam's -Filter parameter.

## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
Continues work on #2467, improves the implementation of #1301.

## What is in this Pull Request ? ##
Implements Advanced Query capabilities for Get-PnPTeamsTeam by passing on the required parameter and header, makes it possible to use more complex Filter queries.

Updates documentation with a sample.