### PR TITLE
Super basic simple fix: now accepts -RowLimit parameter

### DIFF
--- a/src/Commands/Properties/Resources.Designer.cs
+++ b/src/Commands/Properties/Resources.Designer.cs
@@ -725,6 +725,15 @@ namespace PnP.PowerShell.Commands.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Restore {0} items from recycle bin to their original locations?.
+        /// </summary>
+        internal static string Restore0RecycleBinItems {
+            get {
+                return ResourceManager.GetString("Restore0RecycleBinItems", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Restore the file &apos;{0}&apos; from the recycle bin to its original location?.
         /// </summary>
         internal static string RestoreRecycleBinItem {

--- a/src/Commands/Properties/Resources.resx
+++ b/src/Commands/Properties/Resources.resx
@@ -155,7 +155,7 @@
   </data>
   <data name="NoSharePointConnectionInProvidedConnection" xml:space="preserve">
     <value>The provided connection through -Connection holds no SharePoint context. Please use one of the Connect-PnPOnline commands which uses the -Url argument to connect.</value>
-  </data>  
+  </data>
   <data name="NoConnectionToDisconnect" xml:space="preserve">
     <value>No connection to disconnect</value>
   </data>
@@ -362,5 +362,8 @@
   </data>
   <data name="RemoveListDesign" xml:space="preserve">
     <value>Remove list design?</value>
+  </data>
+  <data name="Restore0RecycleBinItems" xml:space="preserve">
+    <value>Restore {0} items from recycle bin to their original locations?</value>
   </data>
 </root>

--- a/src/Commands/RecycleBin/RestoreRecycleBinItem.cs
+++ b/src/Commands/RecycleBin/RestoreRecycleBinItem.cs
@@ -11,7 +11,7 @@ namespace PnP.PowerShell.Commands.RecycleBin
     [OutputType(typeof(void))]
     public class RestoreRecycleBinItem : PnPSharePointCmdlet
     {
-        [Parameter(Mandatory = true, ValueFromPipeline = true)]
+        [Parameter(Mandatory = false, ValueFromPipeline = true)]
         public RecycleBinItemPipeBind Identity;
 
         [Parameter(Mandatory = false)]
@@ -37,7 +37,7 @@ namespace PnP.PowerShell.Commands.RecycleBin
             {
                 if (ParameterSpecified(nameof(RowLimit)))
                 {
-                    if (Force || ShouldContinue(Resources.RestoreRecycleBinItems, Resources.Confirm))
+                    if (Force || ShouldContinue(string.Format(Resources.Restore0RecycleBinItems, RowLimit), Resources.Confirm))
                     {
                         RecycleBinItemCollection items = ClientContext.Site.GetRecycleBinItems(null, RowLimit, false, RecycleBinOrderBy.DeletedDate, RecycleBinItemState.None);
                         ClientContext.Load(items);


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Partial fix to #2485.

## What is in this Pull Request ? ##
The commandlet now accepts RowLimit parameter (earlier it was always ignored due to how Identity was managed, and the commandlet could effectively be used to only restore 1 item at a time). This implementation blindly accepts the -RowLimit (without validating whether the number makes sense).

A proper fix should also implement paging or at least verify that restoring with high RowLimits works (which I can also test myself later on if need be).

Also adds a nicer message for confirming restoring X number of items.