### PR TITLE
Fix setting multi taxonomy field value when input is PSObject[]

### DIFF
--- a/src/Commands/Utilities/ListItemHelper.cs
+++ b/src/Commands/Utilities/ListItemHelper.cs
@@ -114,10 +114,10 @@ namespace PnP.PowerShell.Commands.Utilities
                                     {
                                         TaxonomyItem taxonomyItem;
                                         Guid termGuid;
-                                        if (!Guid.TryParse(arrayItem as string, out termGuid))
+                                        if (!Guid.TryParse(arrayItem?.ToString(), out termGuid))
                                         {
                                             // Assume it's a TermPath
-                                            taxonomyItem = clonedContext.Site.GetTaxonomyItemByPath(arrayItem as string);
+                                            taxonomyItem = clonedContext.Site.GetTaxonomyItemByPath(arrayItem?.ToString());
                                         }
                                         else
                                         {


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
None

## What is in this Pull Request ? ##
Fix setting multi taxonomy field value when input is PSObject[] .

Using the script below, an error is generated when copying TaxonomyFieldTypeMulti field values from a list item to another, storing them in a temporary array:
```powershell
# Copy multi taxonomy field values from list item ID 1 to list item ID 2
$list = get-pnplist "List with taxonomy"
$item = get-pnplistitem $list -Id 1

# Add each term to a temporary array
$values = @()
$item.FieldValues.Multi.TermGuid | %{$values += $_}

# Update list item 2
Set-PnPListItem -Identity 2 -Values @{Multi = $values} -List $list
$values
$values.GetType().FullName
$values[0].GetType().FullName
```
![image](https://user-images.githubusercontent.com/1153754/205499450-e3ab4d28-1ceb-42d8-ba57-c706d3376891.png)

This is caused by the C# code expecting the input to be of type String but PowerShell wraps it around a PSObject when using Foreach-Object at `$item.FieldValues.Multi.TermGuid | %{$values += $_}`
![image](https://user-images.githubusercontent.com/1153754/205499593-63bd1a8f-d4e7-4c2b-8b04-7508b6670f34.png)

Instead of doing a cast, this PR changes the code to just do a ToString().
See below the same code, this time not throwing any exception:
![image](https://user-images.githubusercontent.com/1153754/205499602-40b76f84-6a95-490b-aa5a-81ac168be9dd.png)

![image](https://user-images.githubusercontent.com/1153754/205499607-e5c3a62d-bdfa-4cde-9f33-1b9ccb21b5c3.png)

