### PR TITLE
Added `-ShowInFiltersPane` to `Set-PnPField`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `Remove-PnPAzureADServicePrincipalAppRole` which allows for app roles to be removed from a service principal/application registration in Azure Active Directory [#2551](https://github.com/pnp/powershell/pull/2551)
 - Added latest added SharePoint Online Site Templates to `Set-PnPBuiltInSiteTemplateSettings` allowing them to be hidden or shown [#2586](https://github.com/pnp/powershell/pull/2586)
 - Added support for `.NET 6.0` since `.NET Core 3.1` support is getting deprecated. We have **removed** support for .NET Core 3.1, so users will have to update from `PowerShell 7.0.x` to `PowerShell 7.2.x or later`  [#2292](https://github.com/pnp/powershell/pull/2292)
-- Added `-ShowInFiltersPane` to `Set-PnPField` which allows fields to be shown or hidden in the filters pane
+- Added `-ShowInFiltersPane` to `Set-PnPField` which allows fields to be shown or hidden in the filters pane [#2623](https://github.com/pnp/powershell/pull/2632)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `Remove-PnPAzureADServicePrincipalAppRole` which allows for app roles to be removed from a service principal/application registration in Azure Active Directory [#2551](https://github.com/pnp/powershell/pull/2551)
 - Added latest added SharePoint Online Site Templates to `Set-PnPBuiltInSiteTemplateSettings` allowing them to be hidden or shown [#2586](https://github.com/pnp/powershell/pull/2586)
 - Added support for `.NET 6.0` since `.NET Core 3.1` support is getting deprecated. We have **removed** support for .NET Core 3.1, so users will have to update from `PowerShell 7.0.x` to `PowerShell 7.2.x or later`  [#2292](https://github.com/pnp/powershell/pull/2292)
+- Added `-ShowInFiltersPane` to `Set-PnPField` which allows fields to be shown or hidden in the filters pane
 
 ### Changed
 

--- a/documentation/Set-PnPField.md
+++ b/documentation/Set-PnPField.md
@@ -10,18 +10,17 @@ online version: https://pnp.github.io/powershell/cmdlets/Set-PnPField.html
 # Set-PnPField
 
 ## SYNOPSIS
-Changes one or more properties of a field in a specific list or for the whole web
+Changes one or more properties of a field in a specific list or for the whole site
 
 ## SYNTAX
 
 ```powershell
-Set-PnPField [-List <ListPipeBind>] [-Identity] <FieldPipeBind> -Values <Hashtable> [-UpdateExistingLists]
- [-Connection <PnPConnection>] [<CommonParameters>]
+Set-PnPField [-List <ListPipeBind>] [-Identity <FieldPipeBind>] [-Values <Hashtable>] [-ShowInFiltersPane <ShowInFiltersPaneStatus>] [-UpdateExistingLists] [-Connection <PnPConnection>]
 ```
 
 ## DESCRIPTION
 
-Allows to modify a field in a specific list or for site.
+Allows to modify a field in a specific list or for the whole site.
 
 ## EXAMPLES
 
@@ -111,16 +110,28 @@ Hashtable of properties to update on the field. Use the syntax @{property1="valu
 Type: Hashtable
 Parameter Sets: (All)
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ShowInFiltersPane
+Allows configuring a field to either always be shown (Pinned), never be shown (Removed) or have SharePoint define if it should be shown (Auto = default).
 
+```yaml
+Type: Commands.Enums.ShowInFiltersPaneStatus
+Parameter Sets: (All)
+Accepted values: Auto, Removed, Pinned
+
+Required: False
+Position: Named
+Default value: Auto
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ## RELATED LINKS
 
 [Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)
-

--- a/src/Commands/Enums/ShowInFiltersPaneStatus.cs
+++ b/src/Commands/Enums/ShowInFiltersPaneStatus.cs
@@ -1,0 +1,24 @@
+namespace PnP.PowerShell.Commands.Enums
+{
+    /// <summary>
+    /// Defines the options for showing fields in the Filter Pane
+    /// </summary>
+    /// <remarks>See https://learn.microsoft.com/en-us/previous-versions/office/sharepoint-server/mt844959(v=office.15) for more information</remarks>
+    public enum ShowInFiltersPaneStatus
+    {
+        /// <summary>
+        /// Have SharePoint define if the field should be shown in the filter pane
+        /// </summary>
+        Auto,
+
+        /// <summary>
+        /// Always show the field in the filter pane
+        /// </summary>
+        Pinned,
+
+        /// <summary>
+        /// Never show the field in the filter pane
+        /// </summary>
+        Removed
+    }
+}

--- a/src/Commands/Fields/SetField.cs
+++ b/src/Commands/Fields/SetField.cs
@@ -17,11 +17,14 @@ namespace PnP.PowerShell.Commands.Fields
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
         public FieldPipeBind Identity = new FieldPipeBind();
 
-        [Parameter(Mandatory = true)]
+        [Parameter(Mandatory = false)]
         public Hashtable Values;
 
         [Parameter(Mandatory = false)]
         public SwitchParameter UpdateExistingLists;
+
+        [Parameter(Mandatory = false)]
+        public ShowInFiltersPaneStatus? ShowInFiltersPane;
 
         protected override void ExecuteCmdlet()
         {
@@ -29,6 +32,7 @@ namespace PnP.PowerShell.Commands.Fields
             Field field = null;
             if (List != null)
             {
+                WriteVerbose("Retrieving provided list");
                 var list = List.GetList(CurrentWeb);
 
                 if (list == null)
@@ -38,10 +42,12 @@ namespace PnP.PowerShell.Commands.Fields
 
                 if (Identity.Id != Guid.Empty)
                 {
+                    WriteVerbose($"Retrieving field by its ID {Identity.Id} from the list");
                     field = list.Fields.GetById(Identity.Id);
                 }
                 else if (!string.IsNullOrEmpty(Identity.Name))
                 {
+                    WriteVerbose($"Retrieving field by its name {Identity.Name} from the list");
                     field = list.Fields.GetByInternalNameOrTitle(Identity.Name);
                 }
                 if (field == null)
@@ -53,14 +59,17 @@ namespace PnP.PowerShell.Commands.Fields
             {
                 if (Identity.Id != Guid.Empty)
                 {
+                    WriteVerbose($"Retrieving field by its ID {Identity.Id} from the web");
                     field = ClientContext.Web.Fields.GetById(Identity.Id);
                 }
                 else if (!string.IsNullOrEmpty(Identity.Name))
                 {
+                    WriteVerbose($"Retrieving field by its name {Identity.Name} from the web");
                     field = ClientContext.Web.Fields.GetByInternalNameOrTitle(Identity.Name);
                 }
                 else if (Identity.Field != null)
                 {
+                    WriteVerbose($"Using passed in field");
                     field = Identity.Field;
                 }
 
@@ -70,7 +79,7 @@ namespace PnP.PowerShell.Commands.Fields
                 }
             }
 
-            if (Values.ContainsKey(allowDeletionPropertyKey))
+            if (Values != null && Values.Count > 0 && Values.ContainsKey(allowDeletionPropertyKey))
             {
                 ClientContext.Load(field, f => f.SchemaXmlWithResourceTokens);
             }
@@ -78,44 +87,57 @@ namespace PnP.PowerShell.Commands.Fields
             {
                 ClientContext.Load(field);
             }
-            ClientContext.ExecuteQueryRetry();
-
-            // Get a reference to the type-specific object to allow setting type-specific properties, i.e. LookupList and LookupField for Microsoft.SharePoint.Client.FieldLookup
-            var typeSpecificField = field.TypedObject;
-
-            foreach (string key in Values.Keys)
+            if(ShowInFiltersPane.HasValue)
             {
-                var value = Values[key];
-
-                var property = typeSpecificField.GetType().GetProperty(key);
-
-                bool isAllowDeletionProperty = string.Equals(key, allowDeletionPropertyKey, StringComparison.Ordinal);
-
-                if (property == null && !isAllowDeletionProperty)
-                {
-                    WriteWarning($"No property '{key}' found on this field. Value will be ignored.");
-                }
-                else
-                {
-                    try
-                    {
-                        if (isAllowDeletionProperty)
-                        {
-                            field.SetAllowDeletion(value as bool?);
-                        }
-                        else
-                        {
-                            property.SetValue(typeSpecificField, value);
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        WriteWarning($"Setting property '{key}' to '{value}' failed with exception '{e.Message}'. Value will be ignored.");
-                    }
-                }
+                WriteVerbose($"Updating field to show in filters pane setting {ShowInFiltersPane.Value}");
+                field.ShowInFiltersPane = ShowInFiltersPane.Value;
+                field.Update();
             }
-            field.UpdateAndPushChanges(UpdateExistingLists);
             ClientContext.ExecuteQueryRetry();
+
+            if (Values != null  && Values.Count > 0)
+            {
+                WriteVerbose($"Updating {Values.Count} field value{(Values.Count != 1 ? "s" : "")}");
+
+                // Get a reference to the type-specific object to allow setting type-specific properties, i.e. LookupList and LookupField for Microsoft.SharePoint.Client.FieldLookup
+                var typeSpecificField = field.TypedObject;
+
+                foreach (string key in Values.Keys)
+                {
+                    var value = Values[key];
+
+                    WriteVerbose($"Updating field {key} to {value}");
+
+                    var property = typeSpecificField.GetType().GetProperty(key);
+
+                    bool isAllowDeletionProperty = string.Equals(key, allowDeletionPropertyKey, StringComparison.Ordinal);
+
+                    if (property == null && !isAllowDeletionProperty)
+                    {
+                        WriteWarning($"No property '{key}' found on this field. Value will be ignored.");
+                    }
+                    else
+                    {
+                        try
+                        {
+                            if (isAllowDeletionProperty)
+                            {
+                                field.SetAllowDeletion(value as bool?);
+                            }
+                            else
+                            {
+                                property.SetValue(typeSpecificField, value);
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            WriteWarning($"Setting property '{key}' to '{value}' failed with exception '{e.Message}'. Value will be ignored.");
+                        }
+                    }
+                }
+                field.UpdateAndPushChanges(UpdateExistingLists);
+                ClientContext.ExecuteQueryRetry();
+            }
         }
     }
 }


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
Requested through #2620 

## What is in this Pull Request ? ##
Added `-ShowInFiltersPane` to `Set-PnPField` which allows defining for every field if it should be shown in the filters panel of SharePoint Online on a list or library