### PR TITLE
Corrected titles and online versions

### DIFF
--- a/documentation/Add-PnPPlannerBucket.md
+++ b/documentation/Add-PnPPlannerBucket.md
@@ -4,7 +4,7 @@ schema: 2.0.0
 applicable: SharePoint Online
 online version: https://pnp.github.io/powershell/cmdlets/Add-PnPPlannerBucket.html
 external help file: PnP.PowerShell.dll-Help.xml
-title: add-pnpplannerbucket
+title: Add-PnPPlannerBucket
 ---
   
 # Add-PnPPlannerBucket

--- a/documentation/Add-PnPPlannerTask.md
+++ b/documentation/Add-PnPPlannerTask.md
@@ -4,7 +4,7 @@ schema: 2.0.0
 applicable: SharePoint Online
 online version: https://pnp.github.io/powershell/cmdlets/Add-PnPPlannerTask.html
 external help file: PnP.PowerShell.dll-Help.xml
-title: add-pnpplannertask
+title: Add-PnPPlannerTask
 ---
   
 # Add-PnPPlannerTask

--- a/documentation/Add-PnPSiteDesignFromWeb.md
+++ b/documentation/Add-PnPSiteDesignFromWeb.md
@@ -2,7 +2,7 @@
 Module Name: PnP.PowerShell
 schema: 2.0.0
 applicable: SharePoint Online
-online version: https://pnp.github.io/powershell/cmdlets/Add-PnPSiteDesignFromWebFromWeb.html
+online version: https://pnp.github.io/powershell/cmdlets/Add-PnPSiteDesignFromWeb.html
 external help file: PnP.PowerShell.dll-Help.xml
 title: Add-PnPSiteDesignFromWeb
 ---

--- a/documentation/Convert-PnPSiteTemplateToMarkdown.md
+++ b/documentation/Convert-PnPSiteTemplateToMarkdown.md
@@ -4,7 +4,7 @@ schema: 2.0.0
 applicable: SharePoint Online
 online version: https://pnp.github.io/powershell/cmdlets/Convert-PnPSiteTemplateToMarkdown.html
 external help file: PnP.PowerShell.dll-Help.xml
-title: convert-pnpsitetemplatetomarkdown
+title: Convert-PnPSiteTemplateToMarkdown
 ---
   
 # Convert-PnPSiteTemplateToMarkdown

--- a/documentation/Get-PnPAzureADAppSitePermission.md
+++ b/documentation/Get-PnPAzureADAppSitePermission.md
@@ -49,7 +49,7 @@ Returns the apps that have permissions for the currently connected to site. Note
 
 ### EXAMPLE 2
 ```powershell
-Get-PnPAzureADAppSitePermissions -Site https://contoso.sharepoint.com/sites/projects
+Get-PnPAzureADAppSitePermission -Site https://contoso.sharepoint.com/sites/projects
 ```
 
 Returns the apps that have permissions for the site specified. Note that you required to have the SharePoint Administrator role in your tenant to be able to use this command.

--- a/documentation/Get-PnPBrowserIdleSignout.md
+++ b/documentation/Get-PnPBrowserIdleSignout.md
@@ -25,9 +25,9 @@ Use this cmdlet to retrieve the current configuration values for Idle session si
 
 ### EXAMPLE 1
 ```powershell
-Get-PnPBrowserIdleSignOut
+Get-PnPBrowserIdleSignout
 ```
-This example retrieves the current configuration values for Idle session sign-out
+This example retrieves the current configuration values for Idle session sign-out.
 
 ## RELATED LINKS
 

--- a/documentation/Get-PnPCompatibleHubContentTypes.md
+++ b/documentation/Get-PnPCompatibleHubContentTypes.md
@@ -2,7 +2,7 @@
 Module Name: PnP.PowerShell
 schema: 2.0.0
 applicable: SharePoint Online
-online version: https://pnp.github.io/powershell/cmdlets/Add-PnPContentTypesFromContentTypeHub.html
+online version: https://pnp.github.io/powershell/cmdlets/Get-PnPCompatibleHubContentTypes.html
 external help file: PnP.PowerShell.dll-Help.xml
 title: Get-PnPCompatibleHubContentTypes
 ---

--- a/documentation/Get-PnPPlannerBucket.md
+++ b/documentation/Get-PnPPlannerBucket.md
@@ -1,6 +1,6 @@
 ---
 Module Name: PnP.PowerShell
-title: get-pnpplannerbucket
+title: Get-PnPPlannerBucket
 schema: 2.0.0
 applicable: SharePoint Online
 external help file: PnP.PowerShell.dll-Help.xml

--- a/documentation/Get-PnPPlannerPlan.md
+++ b/documentation/Get-PnPPlannerPlan.md
@@ -1,6 +1,6 @@
 ---
 Module Name: PnP.PowerShell
-title: get-pnpplannerplan
+title: Get-PnPPlannerPlan
 schema: 2.0.0
 applicable: SharePoint Online
 external help file: PnP.PowerShell.dll-Help.xml

--- a/documentation/Get-PnPPlannerTask.md
+++ b/documentation/Get-PnPPlannerTask.md
@@ -1,6 +1,6 @@
 ---
 Module Name: PnP.PowerShell
-title: get-pnpplannertask
+title: Get-PnPPlannerTask
 schema: 2.0.0
 applicable: SharePoint Online
 external help file: PnP.PowerShell.dll-Help.xml

--- a/documentation/Get-PnPSiteCollectionAppCatalog.md
+++ b/documentation/Get-PnPSiteCollectionAppCatalog.md
@@ -35,7 +35,7 @@ Get-PnPSiteCollectionAppCatalog -CurrentSite
 ```
 Will return the site collection app catalog for the currently connected to site, if it has one. Otherwise it will yield no result.
 
-### EXAMPLE 2
+### EXAMPLE 3
 ```powershell
 Get-PnPSiteCollectionAppCatalog -ExcludeDeletedSites
 ```

--- a/documentation/Get-PnPSiteScriptFromWeb.md
+++ b/documentation/Get-PnPSiteScriptFromWeb.md
@@ -65,14 +65,14 @@ Get-PnPSiteScriptFromWeb -Url "https://contoso.sharepoint.com/sites/teamsite" -I
 
 Returns the generated Site Script JSON containing all supported components from the site at the provided Url including the lists "Shared Documents" and "MyList"
 
-### EXAMPLE 5
+### EXAMPLE 4
 ```powershell
 Get-PnPSiteScriptFromWeb -Url "https://contoso.sharepoint.com/sites/teamsite" -IncludeBranding -IncludeLinksToExportedItems
 ```
 
 Returns the generated Site Script JSON containing the branding and navigation links from the site at the provided Url
 
-### EXAMPLE 6
+### EXAMPLE 5
 ```powershell
 Get-PnPSiteScriptFromWeb -IncludeAllLists
 ```

--- a/documentation/Get-PnPSyntexModel.md
+++ b/documentation/Get-PnPSyntexModel.md
@@ -4,7 +4,7 @@ title: Get-PnPSyntexModel
 schema: 2.0.0
 applicable: SharePoint Online
 external help file: PnP.PowerShell.dll-Help.xml
-online version: https://pnp.github.io/powershell/cmdlets/Get-PnPPage.html
+online version: https://pnp.github.io/powershell/cmdlets/Get-PnPSyntexModel.html
 ---
  
 # Get-PnPSyntexModel

--- a/documentation/Get-PnPSyntexModelPublication.md
+++ b/documentation/Get-PnPSyntexModelPublication.md
@@ -4,7 +4,7 @@ title: Get-PnPSyntexModelPublication
 schema: 2.0.0
 applicable: SharePoint Online
 external help file: PnP.PowerShell.dll-Help.xml
-online version: https://pnp.github.io/powershell/cmdlets/Get-PnPPage.html
+online version: https://pnp.github.io/powershell/cmdlets/Get-PnPSyntexModelPublication.html
 ---
  
 # Get-PnPSyntexModelPublication


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample
- [x] Documentation

## Related Issues? ##
n/a

## What is in this Pull Request ? ##
Consolidated titles with commands and online versions.



Some titles in

Module Name: PnP.PowerShell
**title:** Get-PnPSyntexModelPublication
schema: 2.0.0
applicable: SharePoint Online
external help file: PnP.PowerShell.dll-Help.xml
online version: https://pnp.github.io/powershell/cmdlets/Get-PnPSyntexModelPublication.html

are missing. Should they be added or is the property no longer used? 