### PR TITLE
Add support for large list recycle for Remove-PnPList 

### DIFF
--- a/documentation/Remove-PnPList.md
+++ b/documentation/Remove-PnPList.md
@@ -15,7 +15,7 @@ Deletes a list.
 ## SYNTAX
 
 ```powershell
-Remove-PnPList [-Identity] <ListPipeBind> [-Recycle] [-Force] [-Connection <PnPConnection>]
+Remove-PnPList [-Identity] <ListPipeBind> [-Recycle] [-LargeList] [-Force] [-Connection <PnPConnection>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,14 @@ Remove-PnPList -Identity Announcements -Recycle
 ```
 
 Removes the list named 'Announcements' and moves it to the Recycle Bin.
+
+### EXAMPLE 4
+```powershell
+Remove-PnPList -Identity Announcements -Recycle -LargeList
+```
+
+Removes the large list named 'Announcements' and moves it to the Recycle Bin.
+
 
 ## PARAMETERS
 
@@ -91,6 +99,20 @@ Accept wildcard characters: False
 
 ### -Recycle
 When provided, the list will be moved to recycle bin. If omitted, the list will directly be deleted.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LargeList
+When provided, the large list will be moved to recycle bin through a timer job. It must be paired with the Recycle Parameter.
 
 ```yaml
 Type: SwitchParameter

--- a/src/Commands/Lists/RemoveList.cs
+++ b/src/Commands/Lists/RemoveList.cs
@@ -24,6 +24,9 @@ namespace PnP.PowerShell.Commands.Lists
 
         [Parameter(Mandatory = false)]
         public SwitchParameter Force;
+
+        [Parameter(Mandatory = false)]
+        public SwitchParameter LargeList;
         protected override void ExecuteCmdlet()
         {
             var list = Identity.GetList(CurrentWeb);
@@ -33,9 +36,18 @@ namespace PnP.PowerShell.Commands.Lists
                 {
                     if (Recycle)
                     {
-                        var recycleResult = list.Recycle();
-                        ClientContext.ExecuteQueryRetry();
-                        WriteObject(new RecycleResult { RecycleBinItemId = recycleResult.Value });
+                        if (LargeList)
+                        {
+                            var operationId = list.StartRecycle();
+                            ClientContext.ExecuteQueryRetry();
+                            WriteObject($"Large List Operation Job {operationId.Value} initiated. It may take a while for this job to complete.");
+                        }
+                        else
+                        { 
+                            var recycleResult = list.Recycle();
+                            ClientContext.ExecuteQueryRetry();
+                            WriteObject(new RecycleResult { RecycleBinItemId = recycleResult.Value });
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## What is in this Pull Request ? ##
Add the the LargeList parameter to Remove-PnPList to support large list recycle. list.StartRecycle() will call the job-largeFolder-delete timerjob and recycle the large list. 
We intend to add another cmdlet to check status of the timer job in the future update. 
