### PR TITLE
Fix #2785 : issue with RowLimit not being respected when specified from CAML query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed issue with `Invoke-PnPSPRestMethod` throwing error when the response string is empty. [#2784](https://github.com/pnp/powershell/pull/2784)
 - Fixed issue with `Invoke-PnPSPRestMethod` and `Invoke-PnPGraphMethod` throwing error when passing complex JSON object as payload.
 - Fixed issue with `Add-PnPListItem` and `Set-PnPListItem` not correctly setting the Purview `Unlocked by default`. [#2800](https://github.com/pnp/powershell/pull/2800)
+- Fixed issue with `Get-PnPListItem` cmdlet not respecting `RowLimit` in the CAML query.
 
 ### Contributors
 

--- a/src/Commands/Lists/GetListItem.cs
+++ b/src/Commands/Lists/GetListItem.cs
@@ -170,7 +170,10 @@ namespace PnP.PowerShell.Commands.Lists
                         ScriptBlock.Invoke(listItems);
                     }
 
-                    query.ListItemCollectionPosition = listItems.ListItemCollectionPosition;
+                    if (HasPageSize())
+                    {
+                        query.ListItemCollectionPosition = listItems.ListItemCollectionPosition;
+                    }
                 } while (query.ListItemCollectionPosition != null);
             }
         }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #2785 

## What is in this Pull Request ? ##
Fix issue with RowLimit not being respected when specified in CAML query.