### PR TITLE
#2530 - added ApplicationId as alias for ClientId in cmdlets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `-IsVivaConnectionsDefaultStartForCompanyPortalSiteEnabled` parameter to `Get-PnPHomeSite` which returns information on whether Viva Connections landing experience is set to the SharePoint home site. [#2779](https://github.com/pnp/powershell/pull/2779)
 - Added `-VivaConnectionsDefaultStart` parameter to `Set-PnPHomeSite` which sets the home site to the provided site collection url and keeps the Viva Connections landing experience to the SharePoint home site. [#2779](https://github.com/pnp/powershell/pull/2779)
 - Added `-LargeList` parameter to `Remove-PnPList` cmdlet which improves the list recycling experience for Lists containing huge number of items. [#2778](https://github.com/pnp/powershell/pull/2778)
+- Added `-ApplicationId` as alias for `-ClientId` in `Connect-PnPOnline` and `Request-PnPAccessToken` cmdlets.
 
 ### Changed
 

--- a/documentation/Connect-PnPOnline.md
+++ b/documentation/Connect-PnPOnline.md
@@ -307,7 +307,7 @@ The Client ID of the Azure AD Application
 ```yaml
 Type: String
 Parameter Sets: Credentials, PnP Management Shell / DeviceLogin, Interactive
-Aliases:
+Aliases: ApplicationId
 
 Required: False
 Position: Named

--- a/documentation/Request-PnPAccessToken.md
+++ b/documentation/Request-PnPAccessToken.md
@@ -59,6 +59,7 @@ The Azure Application Client Id to use to retrieve the token. Defaults to the Pn
 ```yaml
 Type: String
 Parameter Sets: (All)
+Aliases: ApplicationId
 
 Required: False
 Position: Named

--- a/src/Commands/Base/ConnectOnline.cs
+++ b/src/Commands/Base/ConnectOnline.cs
@@ -129,6 +129,7 @@ namespace PnP.PowerShell.Commands.Base
         [Parameter(Mandatory = true, ParameterSetName = ParameterSet_ACSAPPONLY)]
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_INTERACTIVE)]
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_DEVICELOGIN)]
+        [Alias("ApplicationId")]
         public string ClientId;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_CREDENTIALS)]

--- a/src/Commands/Base/RequestAccessToken.cs
+++ b/src/Commands/Base/RequestAccessToken.cs
@@ -12,6 +12,7 @@ namespace PnP.PowerShell.Commands.Base
     public class RequestAccessToken : PnPConnectedCmdlet
     {
         [Parameter(Mandatory = false)]
+        [Alias("ApplicationId")]
         public string ClientId = PnPConnection.PnPManagementShellClientId; // defaults to PnPManagementShell
 
         [Parameter(Mandatory = false)]


### PR DESCRIPTION

## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #2530 

## What is in this Pull Request ? ##
Added `-ApplicationId` as alias for `Connect-PnPOnline` and `Request-PnPAccessToken` cmdlets