### PR TITLE
Fix missing dash in syntax block for Get-PnPHomeSite

### DIFF
--- a/documentation/Get-PnPHomeSite.md
+++ b/documentation/Get-PnPHomeSite.md
@@ -20,7 +20,7 @@ Returns the home site url for your tenant
 ## SYNTAX
 
 ```powershell
-Get-PnPHomeSite [IsVivaConnectionsDefaultStartForCompanyPortalSiteEnabled <SwitchParameter>] [-Connection <PnPConnection>] [<CommonParameters>]
+Get-PnPHomeSite [-IsVivaConnectionsDefaultStartForCompanyPortalSiteEnabled <SwitchParameter>] [-Connection <PnPConnection>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION


### PR DESCRIPTION
Added missing dash to the `-isViva....` switch parameter in the syntax block

Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
None that I'm aware

## What is in this Pull Request ? ##
just fixed a missing dash in the help markdown


