### PR TITLE
Adding `Undo-PnpFlecheckedOut` cmdlet which allows for a file receive an undo checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `-Connection` option to `Connect-PnPOnline` which allows of reusing an authenticated connection to connect to a different site [#2821](https://github.com/pnp/powershell/pull/2821)
 - Added `-UserAssignedManagedIdentityAzureResourceId` and `-UserAssignedManagedIdentityClientId` as alternatives to `-UserAssignedManagedIdentityObjectId` for `Connect-PnPOnline -ManagedIdentity` to provide an user managed identity to authenticate with. [#2813](https://github.com/pnp/powershell/pull/2813)
 - Added clearer error message when connecting using an expired client secret and trying to execute a command.[#2828](https://github.com/pnp/powershell/pull/2828)
+- Added `Undo-PnPFileCheckedOut` which allows a checked out file to discard its changes and revert to the last checked in version. [#2837](https://github.com/pnp/powershell/pull/2837)
 
 ### Changed
 
@@ -85,6 +86,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Contributors
 
+- Arnaud Rompen [rompenar]
 - [reusto]
 - Ronald Mavarez [ronaldmavarez]
 - [lilealdai]

--- a/documentation/Undo-PnPFileCheckedOut.md
+++ b/documentation/Undo-PnPFileCheckedOut.md
@@ -1,0 +1,65 @@
+---
+Module Name: PnP.PowerShell
+title: Undo-PnPFileCheckedOut
+schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/Undo-PnPFileCheckedOut.html
+---
+ 
+# Undo-PnPFileCheckedOut
+
+## SYNOPSIS
+Discards changes to a file.
+
+## SYNTAX
+
+```powershell
+Undo-PnPFileCheckedOut [-Url] <String> [-Connection <PnPConnection>]
+```
+
+## DESCRIPTION
+This cmdlet discards changes to a single file.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Undo-PnPFileCheckedOut -Url "/sites/PnP/Shared Documents/Contract.docx"
+```
+
+Discards changes in the file "Contract.docx" in the "Documents" library
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Url
+The server relative url of the file to discard changes.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/src/Commands/Files/SetFileCheckedIn.cs
+++ b/src/Commands/Files/SetFileCheckedIn.cs
@@ -21,6 +21,9 @@ namespace PnP.PowerShell.Commands.Files
 
         protected override void ExecuteCmdlet()
         {
+            // Remove URL decoding from the Url as that will not work. We will encode the + character specifically, because if that is part of the filename, it needs to stay and not be decoded.
+            Url = Utilities.UrlUtilities.UrlDecode(Url.Replace("+", "%2B"));
+            
             CurrentWeb.CheckInFile(Url, CheckinType, Comment);
             if (Approve)
                 CurrentWeb.ApproveFile(Url, Comment);

--- a/src/Commands/Files/SetFileCheckedOut.cs
+++ b/src/Commands/Files/SetFileCheckedOut.cs
@@ -12,6 +12,9 @@ namespace PnP.PowerShell.Commands.Files
 
         protected override void ExecuteCmdlet()
         {
+            // Remove URL decoding from the Url as that will not work. We will encode the + character specifically, because if that is part of the filename, it needs to stay and not be decoded.
+            Url = Utilities.UrlUtilities.UrlDecode(Url.Replace("+", "%2B"));
+
             CurrentWeb.CheckOutFile(Url);
         }
     }

--- a/src/Commands/Files/UndoFileCheckedOut.cs
+++ b/src/Commands/Files/UndoFileCheckedOut.cs
@@ -1,0 +1,21 @@
+﻿using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+
+
+namespace PnP.PowerShell.Commands.Files
+{
+    [Cmdlet(VerbsCommon.Undo, "PnPFileCheckedOut")]
+    public class UndoFileCheckedOut : PnPWebCmdlet
+    {
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+        public string Url = string.Empty;
+
+        protected override void ExecuteCmdlet()
+        {
+            // Remove URL decoding from the Url as that will not work. We will encode the + character specifically, because if that is part of the filename, it needs to stay and not be decoded.
+            Url = Utilities.UrlUtilities.UrlDecode(Url.Replace("+", "%2B"));
+
+            CurrentWeb.UndoCheckOutFileAsync(Url);
+        }
+    }
+}


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
None

## What is in this Pull Request ? ##
Append Undo-PnPFileCheckedOut cmdlet with documentation.

Add url deconding on SetFileCheckedIn and SetFileCheckedOut to be able to use "/sites/pnp/Shared Documents" and "/sites/pnp/Shared%20Documents" server relative url

This pull request is linked to [Append UndoCheckOutFile extension #842](https://github.com/pnp/pnpframework/pull/842)