### PR TITLE
Feature: made planner content URL mandatory for pnpteams tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `-UserAssignedManagedIdentityAzureResourceId` and `-UserAssignedManagedIdentityClientId` as alternatives to `-UserAssignedManagedIdentityObjectId` for `Connect-PnPOnline -ManagedIdentity` to provide an user managed identity to authenticate with. [#2813](https://github.com/pnp/powershell/pull/2813)
 - Added clearer error message when connecting using an expired client secret and trying to execute a command.[#2828](https://github.com/pnp/powershell/pull/2828)
 - Added `Undo-PnPFileCheckedOut` which allows a checked out file to discard its changes and revert to the last checked in version. [#2837](https://github.com/pnp/powershell/pull/2837)
+- Added support for specifying the `-ContentUrl` configuration in `Add-PnPTeamsTab` cmdlet when trying to add a Planner as a tab in Teams channel.
 
 ### Changed
 

--- a/MIGRATE-1.0-to-2.0.md
+++ b/MIGRATE-1.0-to-2.0.md
@@ -81,6 +81,8 @@ Using PnP PowerShell in Azure functions ? You might be required to change the Pn
 
 ## Changes to output type
 
+- When using `Add-PnPTeamsTab` cmdlet, if you specify the `-Type SharePointPageAndList`, then `-WebSiteUrl` is mandatory.
+- When using `Add-PnPTeamsTab` cmdlet, if you specify the `-Type Planner`, then `-ContentUrl` is mandatory.
 - The output type of `Get-PnPAzureADGroupOwner` has changed to `PnP.PowerShell.Commands.Model.Microsoft365User`
 - The output type of `Get-PnPAzureADGroupMember` has changed to `PnP.PowerShell.Commands.Model.Microsoft365User`
 - The output type of `Get-PnPAzureADGroup` has changed to `PnP.PowerShell.Commands.Model.Graph.Group`

--- a/src/Commands/Teams/AddTeamsTab.cs
+++ b/src/Commands/Teams/AddTeamsTab.cs
@@ -30,6 +30,7 @@ namespace PnP.PowerShell.Commands.Graph
         private DocumentLibraryParameters documentLibraryParameters;
         private SharePointPageAndListParameters sharePointPageAndListParameters;
         private CustomParameters customParameters;
+
         public object GetDynamicParameters()
         {
             switch (Type)
@@ -43,6 +44,7 @@ namespace PnP.PowerShell.Commands.Graph
                         return officeFileParameters;
                     }
                 case TeamTabType.DocumentLibrary:
+                case TeamTabType.Planner:
                 case TeamTabType.WebSite:
                     {
                         documentLibraryParameters = new DocumentLibraryParameters();
@@ -50,7 +52,7 @@ namespace PnP.PowerShell.Commands.Graph
                     }
                 case TeamTabType.SharePointPageAndList:
                     {
-                        sharePointPageAndListParameters= new SharePointPageAndListParameters();
+                        sharePointPageAndListParameters = new SharePointPageAndListParameters();
                         return sharePointPageAndListParameters;
                     }
                 case TeamTabType.Custom:
@@ -90,6 +92,7 @@ namespace PnP.PowerShell.Commands.Graph
                                     break;
                                 }
                             case TeamTabType.DocumentLibrary:
+                            case TeamTabType.Planner:
                             case TeamTabType.WebSite:
                                 {
                                     EnsureDynamicParameters(documentLibraryParameters);

--- a/src/Commands/Utilities/TeamsUtility.cs
+++ b/src/Commands/Utilities/TeamsUtility.cs
@@ -908,6 +908,8 @@ namespace PnP.PowerShell.Commands.Utilities
                 case TeamTabType.Planner:
                     {
                         tab.TeamsAppId = "com.microsoft.teamspace.tab.planner";
+                        tab.Configuration = new TeamTabConfiguration();                        
+                        tab.Configuration.ContentUrl = contentUrl;
                         break;
                     }
                 case TeamTabType.MicrosoftStream:


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #2844

## What is in this Pull Request ? ##
Made `-ContentUrl` mandatory for planner teams tab configuration