### PR TITLE
Fix: taxonomy return type in Add-PnPFieldFromXML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Register-PnPAzureADApp` cmdlet to not change or generate certificate if `-CertificatePath` parameter is already specified. [#2878](https://github.com/pnp/powershell/pull/2878)
 - Fixed `New-PnPSite` cmdlet to work with non-commercial cloud environments.
 - Fixed `Set-PnPSearchSettings` cmdlet not working with vanity domain tenants [#2884](https://github.com/pnp/powershell/pull/2884)
-- Fixed `Add-PnPFieldFromXml` cmdlet. It will now return the correct typed field if the added field was of type `Taxonomy`.
+- Fixed `Add-PnPFieldFromXml` cmdlet. It will now return the correct typed field if the added field was of type `Taxonomy`. [#2926](https://github.com/pnp/powershell/pull/2926)
 
 ### Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Register-PnPAzureADApp` cmdlet to not change or generate certificate if `-CertificatePath` parameter is already specified. [#2878](https://github.com/pnp/powershell/pull/2878)
 - Fixed `New-PnPSite` cmdlet to work with non-commercial cloud environments.
 - Fixed `Set-PnPSearchSettings` cmdlet not working with vanity domain tenants [#2884](https://github.com/pnp/powershell/pull/2884)
+- Fixed `Add-PnPFieldFromXml` cmdlet. It will now return the correct typed field if the added field was of type `Taxonomy`.
 
 ### Contributors
 

--- a/src/Commands/Fields/AddFieldFromXml.cs
+++ b/src/Commands/Fields/AddFieldFromXml.cs
@@ -1,6 +1,6 @@
 ﻿using System.Management.Automation;
 using Microsoft.SharePoint.Client;
-
+using Microsoft.SharePoint.Client.Taxonomy;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 
 namespace PnP.PowerShell.Commands.Fields
@@ -22,7 +22,6 @@ namespace PnP.PowerShell.Commands.Fields
             if (List != null)
             {
                 List list = List.GetList(CurrentWeb);
-
                 f = list.CreateField(FieldXml);
             }
             else
@@ -31,6 +30,7 @@ namespace PnP.PowerShell.Commands.Fields
             }
             ClientContext.Load(f);
             ClientContext.ExecuteQueryRetry();
+
             switch (f.FieldTypeKind)
             {
                 case FieldType.DateTime:
@@ -93,6 +93,15 @@ namespace PnP.PowerShell.Commands.Fields
                     {
                         WriteObject(ClientContext.CastTo<FieldNumber>(f));
                         break;
+                    }
+                case FieldType.Invalid:
+                    {
+                        if (f.TypeAsString.StartsWith("TaxonomyFieldType"))
+                        {
+                            WriteObject(ClientContext.CastTo<TaxonomyField>(f));
+                            break;
+                        }
+                        goto default;
                     }
                 default:
                     {


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
NA

## What is in this Pull Request ? ##
Fix return type in case Taxonomy field is added via the PnPFieldFromXML cmdlet