### PR TITLE
Deprecates BlockEdit and BlockDeletion parameters of Set-PnPLabel. Closes #2932

### DIFF
--- a/documentation/Set-PnPLabel.md
+++ b/documentation/Set-PnPLabel.md
@@ -38,17 +38,10 @@ Set-PnPLabel -List "Demo List" -Label "Project Documentation" -SyncToItems $true
 
 This sets an O365 label on the specified list or library and sets the label to all the items in the list and library as well.
 
-### EXAMPLE 3
-```powershell
-Set-PnPLabel -List "Demo List" -Label "Project Documentation" -BlockDelete $true -BlockEdit $true
-```
-
-This sets an O365 label on the specified list or library. Next, it also blocks the ability to either edit or delete the item. 
-
 ## PARAMETERS
 
 ### -BlockDeletion
-Block deletion of items in the library
+Block deletion of items in the library. This parameter has been deprecated because overriding Purview retention label settings has been deprecated in SharePoint Online. This parameter will be removed in the next major release.
 
 ```yaml
 Type: Boolean
@@ -62,7 +55,7 @@ Accept wildcard characters: False
 ```
 
 ### -BlockEdit
-Block editing of items in the library
+Block editing of items in the library. This parameter has been deprecated because overriding Purview retention label settings has been deprecated in SharePoint Online. This parameter will be removed in the next major release.
 
 ```yaml
 Type: Boolean

--- a/src/Commands/InformationManagement/SetLabel.cs
+++ b/src/Commands/InformationManagement/SetLabel.cs
@@ -2,6 +2,7 @@
 using Microsoft.SharePoint.Client;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 using System.Linq;
+using System;
 
 namespace PnP.PowerShell.Commands.InformationManagement
 {
@@ -17,9 +18,11 @@ namespace PnP.PowerShell.Commands.InformationManagement
         [Parameter(Mandatory = false)]
         public bool SyncToItems;
 
+        [Obsolete("Overriding Purview retention label settings has been deprecated in SharePoint Online. This parameter will be removed in the next major release.")]
         [Parameter(Mandatory = false)]
         public bool BlockDeletion;
 
+        [Obsolete("Overriding Purview retention label settings has been deprecated in SharePoint Online. This parameter will be removed in the next major release.")]
         [Parameter(Mandatory = false)]
         public bool BlockEdit;
 
@@ -30,9 +33,10 @@ namespace PnP.PowerShell.Commands.InformationManagement
 
             if (list != null)
             {
-                if (availableTags.FirstOrDefault(tag => tag.TagName.ToString() == Label) != null)
+                var availableTag = availableTags.FirstOrDefault(tag => tag.TagName.ToString() == Label);
+                if (availableTag != null)
                 {
-                    list.SetComplianceTag(Label, BlockDeletion, BlockEdit, SyncToItems);
+                    list.SetComplianceTag(Label, availableTag.BlockDelete, availableTag.BlockEdit, SyncToItems);
                 }
                 else
                 {


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample
- [x] Enhancement

## Related Issues? ##
Closes #2932

## What is in this Pull Request ? ##
Deprecates `BlockEdit` and `BlockDeletion` parameters of `Set-PnPLabel`. The code has been updated to not use the deprecated parameters, but use the found retention label settings when calling the `ComplianceTag` method, even though that is not really necessary because using the properties have been cut off by Microsoft. 

