### PR TITLE
Added DisableCommenting parameter to Set-PnPList cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `CalendarMemberReadOnly` and `ConnectorsDisabled` as `-ResourceBehaviorOptions` to `New-PnPMicrosoft365Group` [#2929](https://github.com/pnp/powershell/pull/2929)
 - Added `-Identity` option to `Get-PnPPowerPlatformEnvironment` which allows retrieval of one specific environment by its displayname or id. [#2794](https://github.com/pnp/powershell/pull/2794)
 - Added `Get-PnPPowerApp` which allows PowerApps to be retrieved [#2794](https://github.com/pnp/powershell/pull/2794)
+- Added `-DisableCommenting` to `Set-PnPList` which allows enabling or disabling commenting on a list. [#2939](https://github.com/pnp/powershell/pull/2939)
 
 ### Changed
 
@@ -107,7 +108,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Add-PnPFieldFromXml` cmdlet. It will now return the correct typed field if the added field was of type `Taxonomy`. [#2926](https://github.com/pnp/powershell/pull/2926)
 
 ### Contributors
-
+- Ganesh Sanap [ganesh-sanap]
 - Chris R. [ChrisRo89]
 - Aimery Thomas [a1mery]
 - Ganesh Sanap [ganesh-sanap]

--- a/documentation/Set-PnPList.md
+++ b/documentation/Set-PnPList.md
@@ -21,7 +21,7 @@ Set-PnPList -Identity <ListPipeBind> [-EnableContentTypes <Boolean>] [-BreakRole
  [-EnableAttachments <Boolean>] [-EnableFolderCreation <Boolean>] [-EnableVersioning <Boolean>]
  [-EnableMinorVersions <Boolean>] [-MajorVersions <UInt32>] [-MinorVersions <UInt32>]
  [-EnableModeration <Boolean>] [-DraftVersionVisibility <DraftVisibilityType>] [-ReadSecurity <ListReadSecurity>] [-WriteSecurity <ListWriteSecurity>]
- [-NoCrawl] [-ExemptFromBlockDownloadOfNonViewableFiles <Boolean>] [-DisableGridEditing <Boolean>] [-DefaultSensitivityLabelForLibrary <SensitivityLabelPipeBind>]
+ [-NoCrawl] [-ExemptFromBlockDownloadOfNonViewableFiles <Boolean>] [-DisableGridEditing <Boolean>] [-DisableCommenting <Boolean>] [-DefaultSensitivityLabelForLibrary <SensitivityLabelPipeBind>]
  [-Path <String>] [-OpenDocumentsMode <DocumentLibraryOpenDocumentsInMode>] [-Connection <PnPConnection>]
 ```
 
@@ -456,6 +456,20 @@ Accept wildcard characters: False
 
 ### -DisableGridEditing
 Enable or disable whether edit grid editing is enabled for the list. Set to $true to disable, $false to enable.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisableCommenting
+Enable or disable whether commenting is enabled for the list. Set to $true to disable, $false to enable.
 
 ```yaml
 Type: Boolean

--- a/src/Commands/Lists/SetList.cs
+++ b/src/Commands/Lists/SetList.cs
@@ -82,6 +82,9 @@ namespace PnP.PowerShell.Commands.Lists
 
         [Parameter(Mandatory = false)]
         public bool DisableGridEditing;
+        
+        [Parameter(Mandatory = false)]
+        public bool DisableCommenting;
 
         [Parameter(Mandatory = false)]
         public string Path;
@@ -113,7 +116,7 @@ namespace PnP.PowerShell.Commands.Lists
                 list = newIdentity.GetList(CurrentWeb);
             }
 
-            list.EnsureProperties(l => l.EnableAttachments, l => l.EnableVersioning, l => l.EnableMinorVersions, l => l.Hidden, l => l.EnableModeration, l => l.BaseType, l => l.HasUniqueRoleAssignments, l => l.ContentTypesEnabled, l => l.ExemptFromBlockDownloadOfNonViewableFiles, l => l.DisableGridEditing);
+            list.EnsureProperties(l => l.EnableAttachments, l => l.EnableVersioning, l => l.EnableMinorVersions, l => l.Hidden, l => l.EnableModeration, l => l.BaseType, l => l.HasUniqueRoleAssignments, l => l.ContentTypesEnabled, l => l.ExemptFromBlockDownloadOfNonViewableFiles, l => l.DisableGridEditing, l => l.DisableCommenting);
 
             var enableVersioning = list.EnableVersioning;
             var enableMinorVersions = list.EnableMinorVersions;
@@ -233,6 +236,12 @@ namespace PnP.PowerShell.Commands.Lists
                 updateRequired = true;
             }
 
+            if (ParameterSpecified(nameof(DisableCommenting)))
+            {
+                list.DisableCommenting = DisableCommenting;
+                updateRequired = true;
+            }
+ 
             if (updateRequired)
             {
                 list.Update();


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Related to #2913 

## What is in this Pull Request ? ##
Added `-DisableCommenting` parameter to Set-PnPList cmdlet which allows enabling/disabling comments on individual SharePoint lists.

