### PR TITLE
Add PreviousNode parameter to Add-PnPNavigationNode

### DIFF
--- a/documentation/Add-PnPNavigationNode.md
+++ b/documentation/Add-PnPNavigationNode.md
@@ -14,8 +14,16 @@ Adds an item to a navigation element
 
 ## SYNTAX
 
+### Default
+
 ```powershell
-Add-PnPNavigationNode -Location <NavigationType> -Title <String> [-Url <String>] [-Parent <Int32>] [-First] [-External] [-AudienceIds <Guid[]>] [-Connection <PnPConnection>]
+Add-PnPNavigationNode -Location <NavigationType> -Title <String> [-Url <String>] [-Parent <NavigationNodePipeBind>] [-First] [-External] [-AudienceIds <Guid[]>] [-Connection <PnPConnection>]
+```
+
+### Provide PreviousNode
+
+```powershell
+Add-PnPNavigationNode -Location <NavigationType> -Title <String> -PreviousNode <NavigationNodePipeBind> [-Url <String>] [-Parent <NavigationNodePipeBind>] [-External] [-AudienceIds <Guid[]>] [-Connection <PnPConnection>]
 ```
 
 ## DESCRIPTION
@@ -65,6 +73,12 @@ Add-PnPNavigationNode -Title "Label" -Location "TopNavigationBar" -Url "http://l
 
 Adds a navigation node to the top navigation bar. The navigation node will be created as a label.
 
+### EXAMPLE 7
+```powershell
+Add-PnPNavigationNode -Title "Wiki" -Location "QuickLaunch" -Url "wiki/" -PreviousNode 2012
+```
+Adds a navigation node to the quicklaunch. The navigation node will have the title "Wiki" and will link to the Wiki library on the selected Web after the node with the ID 2012.
+
 ## PARAMETERS
 
 ### -Connection
@@ -100,7 +114,7 @@ Add the new menu item to beginning of the collection
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: (All)
+Parameter Sets: Default
 
 Required: False
 Position: Named
@@ -125,13 +139,27 @@ Accept wildcard characters: False
 ```
 
 ### -Parent
-The key of the parent. Leave empty to add to the top level
+The parent navigation node. Leave empty to add to the top level
 
 ```yaml
-Type: Int32
+Type: NavigationNodePipeBind
 Parameter Sets: (All)
 
 Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PreviousNode
+Specifies the navigation node after which the new navigation node will appear in the navigation node collection.
+
+```yaml
+Type: NavigationNodePipeBind
+Parameter Sets: Add node after another node
+
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/src/Commands/Base/PipeBinds/NavigationNodePipeBind.cs
+++ b/src/Commands/Base/PipeBinds/NavigationNodePipeBind.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.SharePoint.Client;
+using PnP.PowerShell.Commands.Branding;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,6 +11,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
     public class NavigationNodePipeBind
     {
         private int _id;
+        private NavigationNode _node;
 
         public NavigationNodePipeBind(int id)
         {
@@ -18,9 +20,26 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
 
         public NavigationNodePipeBind(NavigationNode node)
         {
-            _id = node.Id;
+            _node = node;
         }
 
-        public int Id => _id;
+        internal NavigationNode GetNavigationNode(Web web)
+        {
+            NavigationNode node = null;
+            if (_node != null)
+            {
+                node = _node;
+            } else {
+                node = web.Navigation.GetNodeById(_id);
+            }
+
+            if (node != null)
+            {
+                web.Context.Load(node);
+                web.Context.ExecuteQueryRetry();
+            }
+
+            return node;
+        }
     }
 }

--- a/src/Commands/Navigation/AddNavigationNode.cs
+++ b/src/Commands/Navigation/AddNavigationNode.cs
@@ -3,33 +3,54 @@ using System.Collections.Generic;
 using System.Management.Automation;
 using Microsoft.SharePoint.Client;
 using PnP.Framework.Enums;
+using PnP.PowerShell.Commands.Base.PipeBinds;
 
 namespace PnP.PowerShell.Commands.Branding
 {
+
     [Cmdlet(VerbsCommon.Add, "PnPNavigationNode")]
     [OutputType(typeof(NavigationNode))]
     public class AddNavigationNode : PnPWebCmdlet
     {
+        private const string ParameterSet_Default = "Default";
+        private const string ParameterSet_PreviousNode = "Add node after another node";
+
+        [Parameter(ParameterSetName = ParameterSet_Default)]
+        [Parameter(ParameterSetName = ParameterSet_PreviousNode)]
         [Parameter(Mandatory = true)]
         public NavigationType Location;
 
+        [Parameter(ParameterSetName = ParameterSet_Default)]
+        [Parameter(ParameterSetName = ParameterSet_PreviousNode)]
         [Parameter(Mandatory = true)]
         public string Title;
 
+        [Parameter(ParameterSetName = ParameterSet_Default)]
+        [Parameter(ParameterSetName = ParameterSet_PreviousNode)]
         [Parameter(Mandatory = false)]
         public string Url;
 
+        [Parameter(ParameterSetName = ParameterSet_Default)]
+        [Parameter(ParameterSetName = ParameterSet_PreviousNode)]
         [Parameter(Mandatory = false)]
-        public int? Parent;
+        public NavigationNodePipeBind Parent;
 
+        [Parameter(ParameterSetName = ParameterSet_Default)]
         [Parameter(Mandatory = false)]
         public SwitchParameter First;
 
+        [Parameter(ParameterSetName = ParameterSet_Default)]
+        [Parameter(ParameterSetName = ParameterSet_PreviousNode)]
         [Parameter(Mandatory = false)]
         public SwitchParameter External;
 
+        [Parameter(ParameterSetName = ParameterSet_Default)]
+        [Parameter(ParameterSetName = ParameterSet_PreviousNode)]
         [Parameter(Mandatory = false)]
         public List<Guid> AudienceIds;
+
+        [Parameter(Mandatory = true, ParameterSetName = ParameterSet_PreviousNode)]
+        public NavigationNodePipeBind PreviousNode;
 
         protected override void ExecuteCmdlet()
         {
@@ -39,72 +60,70 @@ namespace PnP.PowerShell.Commands.Branding
                 ClientContext.ExecuteQueryRetry();
                 Url = CurrentWeb.Url;
             }
-            if (Parent.HasValue)
+
+            var navigationNodeCreationInformation = new NavigationNodeCreationInformation {
+                Title = Title,
+                Url = Url,
+                IsExternal = External.IsPresent,
+            };
+
+            if (ParameterSpecified(nameof(PreviousNode)))
             {
-                var parentNode = CurrentWeb.Navigation.GetNodeById(Parent.Value);
-                ClientContext.Load(parentNode);
-                ClientContext.ExecuteQueryRetry();
-                var addedNode = parentNode.Children.Add(new NavigationNodeCreationInformation()
+                navigationNodeCreationInformation.PreviousNode = PreviousNode.GetNavigationNode(CurrentWeb);
+            } else
+            {
+                navigationNodeCreationInformation.AsLastNode = !First.IsPresent;
+            }
+
+            NavigationNodeCollection nodeCollection = null;
+            if (ParameterSpecified(nameof(Parent)))
+            {
+                var parentNode = Parent.GetNavigationNode(CurrentWeb);
+                nodeCollection = parentNode.Children;
+                CurrentWeb.Context.Load(nodeCollection);
+                CurrentWeb.Context.ExecuteQueryRetry();
+            } 
+            else if (Location == NavigationType.SearchNav)
+            {
+                nodeCollection = CurrentWeb.LoadSearchNavigation();
+            }
+            else if (Location == NavigationType.Footer)
+            {
+                nodeCollection = CurrentWeb.LoadFooterNavigation();
+            }
+            else
+            {
+                nodeCollection = Location == NavigationType.QuickLaunch ? CurrentWeb.Navigation.QuickLaunch : CurrentWeb.Navigation.TopNavigationBar;
+                ClientContext.Load(nodeCollection);
+            }
+
+            if (nodeCollection != null)
+            {
+                var addedNode = nodeCollection.Add(navigationNodeCreationInformation);
+
+                if (ParameterSpecified(nameof(AudienceIds)))
                 {
-                    Title = Title,
-                    Url = Url,
-                    IsExternal = External.IsPresent,
-                    AsLastNode = !First.IsPresent
-                });
+                    addedNode.AudienceIds = AudienceIds;
+                    addedNode.Update();
+                }
+
                 ClientContext.Load(addedNode);
                 ClientContext.ExecuteQueryRetry();
+
+                if (Location == NavigationType.QuickLaunch)
+                {
+                    // Retrieve the menu definition and save it back again. This step is needed to enforce some properties of the menu to be shown, such as the audience targeting.
+                    CurrentWeb.EnsureProperties(w => w.Url);
+                    var menuState = Utilities.REST.RestHelper.GetAsync(Connection.HttpClient, $"{CurrentWeb.Url}/_api/navigation/MenuState", ClientContext, "application/json;odata=nometadata").GetAwaiter().GetResult();
+                    Utilities.REST.RestHelper.PostAsync(Connection.HttpClient, $"{CurrentWeb.Url}/_api/navigation/SaveMenuState", ClientContext, @"{ ""menuState"": " + menuState + "}", "application/json", "application/json;odata=nometadata").GetAwaiter().GetResult();
+                }
+
                 WriteObject(addedNode);
             }
             else
             {
-                NavigationNodeCollection nodeCollection = null;
-                if (Location == NavigationType.SearchNav)
-                {
-                    nodeCollection = CurrentWeb.LoadSearchNavigation();
-                }
-                else if (Location == NavigationType.Footer)
-                {
-                    nodeCollection = CurrentWeb.LoadFooterNavigation();
-                }
-                else
-                {
-                    nodeCollection = Location == NavigationType.QuickLaunch ? CurrentWeb.Navigation.QuickLaunch : CurrentWeb.Navigation.TopNavigationBar;
-                    ClientContext.Load(nodeCollection);
-                }
-                if (nodeCollection != null)
-                {
-                    var addedNode = nodeCollection.Add(new NavigationNodeCreationInformation
-                    {
-                        Title = Title,
-                        Url = Url,
-                        IsExternal = External.IsPresent,
-                        AsLastNode = !First.IsPresent
-                    });
-
-                    if (ParameterSpecified(nameof(AudienceIds)))
-                    {
-                        addedNode.AudienceIds = AudienceIds;
-                        addedNode.Update();
-                    }
-
-                    ClientContext.Load(addedNode);
-                    ClientContext.ExecuteQueryRetry();
-
-                    if (Location == NavigationType.QuickLaunch)
-                    {
-                        // Retrieve the menu definition and save it back again. This step is needed to enforce some properties of the menu to be shown, such as the audience targeting.
-                        CurrentWeb.EnsureProperties(w => w.Url);
-                        var menuState = Utilities.REST.RestHelper.GetAsync(Connection.HttpClient, $"{CurrentWeb.Url}/_api/navigation/MenuState", ClientContext, "application/json;odata=nometadata").GetAwaiter().GetResult();
-                        Utilities.REST.RestHelper.PostAsync(Connection.HttpClient, $"{CurrentWeb.Url}/_api/navigation/SaveMenuState", ClientContext, @"{ ""menuState"": " + menuState + "}", "application/json", "application/json;odata=nometadata").GetAwaiter().GetResult();
-                    }
-
-                    WriteObject(addedNode);
-                }
-                else
-                {
-                    throw new Exception("Navigation Node Collection is null");
-                }
-            }
+                throw new Exception("Navigation Node Collection is null");
+            }            
         }
     }
 }

--- a/src/Commands/Navigation/RemoveNavigationNode.cs
+++ b/src/Commands/Navigation/RemoveNavigationNode.cs
@@ -54,7 +54,7 @@ namespace PnP.PowerShell.Commands.Branding
                 {
                     if (ParameterSetName == ParameterSet_BYID)
                     {
-                        var node = CurrentWeb.Navigation.GetNodeById(Identity.Id);
+                        var node = Identity.GetNavigationNode(CurrentWeb);
                         node.DeleteObject();
                         ClientContext.ExecuteQueryRetry();
                     }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [x] New Feature
- [ ] Sample

## What is in this Pull Request ? ##
Added parameter `PreviousNode` to specify the navigation node after which the new navigation node will appear in the navigation node collection, which allows to add it to the correct position in the navigation instead of adding and then reordering afterwards.

Changed the type of the `Parent` parameter to NavigationPipeBind to allow a object of type NavigationNode as input in addition to just the ID.

Fixed the issue that target audiences weren't set when creating a node as a child of a parent node.