### PR TITLE
Fixes issue with filenames in template output of New-PnPSitetemplateFromFolder. Closes #2944

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `New-PnPSite` cmdlet to work with non-commercial cloud environments.
 - Fixed `Set-PnPSearchSettings` cmdlet not working with vanity domain tenants [#2884](https://github.com/pnp/powershell/pull/2884)
 - Fixed `Add-PnPFieldFromXml` cmdlet. It will now return the correct typed field if the added field was of type `Taxonomy`. [#2926](https://github.com/pnp/powershell/pull/2926)
+- Fixed `New-PnPSitetemplateFromFolder` removing the first character of filenames [#2944](https://github.com/pnp/powershell/pull/2944)
 
 ### Contributors
 - [enthusol]

--- a/src/Commands/Provisioning/Site/NewSiteTemplateFromFolder.cs
+++ b/src/Commands/Provisioning/Site/NewSiteTemplateFromFolder.cs
@@ -229,7 +229,7 @@ namespace PnP.PowerShell.Commands.Provisioning
             var fileInfo = dirInfo.GetFiles(Match);
             foreach (var file in fileInfo.Where(f => (f.Attributes & FileAttributes.Hidden) == 0))
             {
-                var unrootedPath = file.FullName.Substring(Folder.Length + 1);
+                var unrootedPath = file.FullName.Substring(Folder.Length);
                 var targetFolder = Path.Combine(TargetFolder, unrootedPath.LastIndexOf("\\") > -1 ? unrootedPath.Substring(0, unrootedPath.LastIndexOf("\\")) : "");
                 targetFolder = targetFolder.Replace('\\', '/');
                 var modelFile = new PnP.Framework.Provisioning.Model.File()


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #2944

## What is in this Pull Request ? ##
Fixes issue with filenames in template output of New-PnPSitetemplateFromFolder. 