### PR TITLE
Added `-OutStream` to `Invoke-PnPGraphMethod`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Added `-OutFile` to `Invoke-PnPGraphMethod` which allows for the response to be written to a file [#2971](https://github.com/pnp/powershell/pull/2971)
+- Added `-OutStream` to `Invoke-PnPGraphMethod` which allows for the response to be written to a memory stream
 
 ### Contributors
 

--- a/documentation/Invoke-PnPGraphMethod.md
+++ b/documentation/Invoke-PnPGraphMethod.md
@@ -41,6 +41,19 @@ Invoke-PnPGraphMethod -Url <String>
                       [-Verbose]
 ```
 
+### Out to stream
+```powershell
+Invoke-PnPGraphMethod -Url <String>
+                      [-AdditionalHeaders <System.Collections.Generic.IDictionary`2[System.String,System.String]>]
+                      [[-Method] <HttpRequestMethod>] 
+                      [-Content <Object>] 
+                      [-ContentType <String>] 
+                      [-ConsistencyLevelEventual] 
+                      [-Connection <PnPConnection>]
+                      [-OutStream]
+                      [-Verbose]
+```
+
 ## DESCRIPTION
 Invokes a REST request towards the Microsoft Graph API. It will take care of potential throttling retries that are needed to retrieve the data.
 
@@ -88,6 +101,13 @@ Invoke-PnPGraphMethod "https://graph.microsoft.com/v1.0/users/user@contoso.com/p
 ```
 
 Downloads the user profile photo of the specified user to the specified file.
+
+### Example 7
+```powershell
+Invoke-PnPGraphMethod "https://graph.microsoft.com/v1.0/users/user@contoso.com/photo/`$value" -OutStream | Add-PnPFile -FileName user.jpg -Folder "Shared Documents"
+```
+
+Takes the user profile photo of the specified user and uploads it to the specified library in SharePoint Online.
 
 ## PARAMETERS
 
@@ -205,6 +225,21 @@ The full path including filename to write the output to, i.e. c:\temp\myfile.txt
 ```yaml
 Type: String
 Parameter Sets: Out to file
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutStream
+Indicates that the result of the request should be returned as a memory stream.
+
+```yaml
+Type: String
+Parameter Sets: Out to stream
 Aliases:
 
 Required: True

--- a/src/Commands/Files/AddFile.cs
+++ b/src/Commands/Files/AddFile.cs
@@ -32,7 +32,7 @@ namespace PnP.PowerShell.Commands.Files
         [ValidateNotNullOrEmpty]
         public string NewFileName = string.Empty;
 
-        [Parameter(Mandatory = true, ParameterSetName = ParameterSet_ASSTREAM)]
+        [Parameter(Mandatory = true, ParameterSetName = ParameterSet_ASSTREAM, ValueFromPipeline = true, Position = 0)]
         [ValidateNotNullOrEmpty]
         public Stream Stream;
 


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Added `-OutStream` to `Invoke-PnPGraphMethod` which allows for the response to be written to a memory stream which would allow for things such as this:

```PowerShell
Invoke-PnPGraphMethod "https://graph.microsoft.com/v1.0/users/user@contoso.com/photo/`$value" -OutStream | Add-PnPFile -FileName user.jpg -Folder "Shared Documents"
```` 