### PR TITLE
Feature: added parameters to prevent recording downloads in Tenant cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `EnableAzureADB2BIntegration` to be returned by `Get-PnPTenant` [#3022](https://github.com/pnp/powershell/pull/3022)
 - Added `-SkipUrlValidation` to `Get-PnPSiteCollectionAppCatalog` which allows for skipping the URL validation when retrieving the site collection app catalog making it faster but potentially returning URLs that have been renamed [#2305](https://github.com/pnp/powershell/pull/3025)
 - Added `Get-PnPLargeListOperationStatus` cmdlet to retrieve the status of a large list operation. [#3033](https://github.com/pnp/powershell/pull/3033)
+- Added `-BlockDownloadFileTypePolicy`, `-BlockDownloadFileTypeIds` and `-ExcludedBlockDownloadGroupIds` parameters to `Set-PnPTenant` cmdlet.
 
 ### Fixed
 

--- a/documentation/Set-PnPTenant.md
+++ b/documentation/Set-PnPTenant.md
@@ -119,6 +119,9 @@ Set-PnPTenant [-SpecialCharactersStateInFileFolderNames <SpecialCharactersState>
  [-IBImplicitGroupBased <Boolean>]
  [-ShowOpenInDesktopOptionForSyncedFiles <Boolean>]
  [-ShowPeoplePickerGroupSuggestionsForIB <Boolean>]
+ [-BlockDownloadFileTypePolicy <Boolean>]
+ [-BlockDownloadFileTypeIds <SPBlockDownloadFileTypeId[]>]
+ [-ExcludedBlockDownloadGroupIds <GUID[]>]
  [-Force] [-Connection <PnPConnection>]
 ```
 
@@ -1989,6 +1992,59 @@ For more information on this feature, please take a look [here](https://learn.mi
 
 ```yaml
 Type: Boolean
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BlockDownloadFileTypePolicy
+
+You can block the download of Teams meeting recording files from SharePoint or OneDrive. This allows users to remain productive while addressing the risk of accidental data loss. Users have browser-only access to play the meeting recordings with no ability to download or sync files or access them through apps.
+
+This policy applies to new meeting recordings across the entire organization. You can exempt people who are members of specified security groups from the policy. This allows you to specify governance or compliance specialists who should have download access to meeting recordings.
+
+After the policy is turned on, any new Teams meeting recording files created by the Teams service and saved in SharePoint and OneDrive are blocked from download.
+
+Because this policy affects meeting recordings stored in OneDrive and SharePoint, you must be a SharePoint administrator to configure it.
+
+Note that this policy doesn't apply to manually uploaded meeting recording files. For more details, see [Block the download of Teams meeting recording files from SharePoint or OneDrive.](https://learn.microsoft.com/en-us/microsoftteams/block-download-meeting-recording)
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BlockDownloadFileTypeIds
+
+The File Type IDs which need to specified to prevent download.
+
+```yaml
+Type: SPBlockDownloadFileTypeId[]
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExcludedBlockDownloadGroupIds
+
+This parameter exempts users in the specified security groups from this policy so that they can download meeting recording files.
+
+```yaml
+Type: GUID[]
 Parameter Sets: (All)
 
 Required: False

--- a/src/Commands/Admin/SetTenant.cs
+++ b/src/Commands/Admin/SetTenant.cs
@@ -6,6 +6,8 @@ using System;
 using Microsoft.Online.SharePoint.TenantManagement;
 using System.Collections.Generic;
 using Microsoft.SharePoint.Client.Sharing;
+using Microsoft.SharePoint.Client.Administration;
+using System.Linq;
 
 namespace PnP.PowerShell.Commands.Admin
 {
@@ -348,6 +350,17 @@ namespace PnP.PowerShell.Commands.Admin
 
         [Parameter(Mandatory = false)]
         public int? OneDriveRequestFilesLinkExpirationInDays { get; set; }
+
+        [Parameter(Mandatory = false)]
+        public bool? BlockDownloadFileTypePolicy { get; set; }
+
+        [Parameter(Mandatory = false)]
+        [ValidateNotNull]
+        public SPBlockDownloadFileTypeId[] BlockDownloadFileTypeIds { get; set; }
+
+        [Parameter(Mandatory = false)]
+        [ValidateNotNull]
+        public Guid[] ExcludedBlockDownloadGroupIds { get; set; }
 
         [Parameter(Mandatory = false)]
         public SwitchParameter Force;
@@ -1058,7 +1071,7 @@ namespace PnP.PowerShell.Commands.Admin
             {
                 Tenant.EnableRestrictedAccessControl = EnableRestrictedAccessControl.Value;
                 modified = true;
-            }            
+            }
 
             if (SyncAadB2BManagementPolicy.HasValue)
             {
@@ -1206,6 +1219,50 @@ namespace PnP.PowerShell.Commands.Admin
             if (ShowPeoplePickerGroupSuggestionsForIB.HasValue)
             {
                 Tenant.ShowPeoplePickerGroupSuggestionsForIB = ShowPeoplePickerGroupSuggestionsForIB.Value;
+                modified = true;
+            }
+
+            if (BlockDownloadFileTypePolicy.HasValue)
+            {
+                if (!BlockDownloadFileTypePolicy.Value)
+                {
+                    Tenant.SetBlockDownloadFileTypePolicyData(BlockDownloadFileTypePolicy.Value, new SPBlockDownloadFileTypeId[0], new Guid[0]);
+                    modified = true;
+                }
+                else
+                {
+                    if (BlockDownloadFileTypeIds == null || BlockDownloadFileTypeIds.Length == 0)
+                    {
+                        throw new InvalidOperationException("Please specify the File Type Ids that you want to block for download.");
+                    }
+                    if (BlockDownloadFileTypeIds.Contains(SPBlockDownloadFileTypeId.TeamsMeetingRecording))
+                    {
+                        WriteWarning("Please note that this policy only prevents download of Teams Meeting Recording files saved in SharePoint Online by the Teams service. Only new meeting recordings saved after this policy is set will be impacted.");
+                    }
+                    BlockDownloadFileTypeIds = BlockDownloadFileTypeIds.Distinct().ToArray();
+                    if (ExcludedBlockDownloadGroupIds != null && ExcludedBlockDownloadGroupIds.Length != 0)
+                    {
+                        if (ExcludedBlockDownloadGroupIds.Length > 10)
+                        {
+                            throw new InvalidOperationException("You can only specify 10 IDs in the Block Download File Type Policy Invalid Exclusion List");
+                        }
+                        Tenant.SetBlockDownloadFileTypePolicyData(BlockDownloadFileTypePolicy.Value, BlockDownloadFileTypeIds, ExcludedBlockDownloadGroupIds);
+                    }
+                    else
+                    {
+                        Tenant.SetBlockDownloadFileTypePolicyData(BlockDownloadFileTypePolicy.Value, BlockDownloadFileTypeIds, new Guid[0]);
+                    }
+                    modified = true;
+                }
+
+            }
+            else if (ExcludedBlockDownloadGroupIds != null)
+            {
+                if (ExcludedBlockDownloadGroupIds.Length > 10)
+                {
+                    throw new InvalidOperationException("You can only specify 10 IDs in the Block Download File Type Policy Invalid Exclusion List");
+                }
+                Tenant.SetBlockDownloadFileTypePolicyExclusionList(ExcludedBlockDownloadGroupIds);
                 modified = true;
             }
 


### PR DESCRIPTION

<!-- The PnP PowerShell team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
NA

## What is in this Pull Request ? ##
Added additional params to `Set-PnPTenant` cmdlet to apply block download policy for teams recordings

## Summary 
<!-- cspell:disable-next-line -->
copilot:summary

## Details 
<!-- cspell:disable-next-line -->
copilot:walkthrough