### PR TITLE
Change Set-PnPWebhookSubscription to use the same defualt expiration date as Add-PnPWebhookSubsription

### DIFF
--- a/src/Commands/Webhooks/SetWebhookSubscription.cs
+++ b/src/Commands/Webhooks/SetWebhookSubscription.cs
@@ -11,9 +11,9 @@ namespace PnP.PowerShell.Commands.Webhooks
     [OutputType(typeof(WebhookSubscription))]
     public class SetWebhookSubscription : PnPWebCmdlet
     {
-        public const int DefaultValidityInMonths = 6;
+        public const int DefaultValidityInDays = 180; // Note: the max is 180 days not 6 months - https://learn.microsoft.com/sharepoint/dev/apis/webhooks/overview-sharepoint-webhooks
         public const int ValidityDeltaInDays = -72; // Note: Some expiration dates too close to the limit are rejected
-        
+
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
         public WebhookSubscriptionPipeBind Subscription;
 
@@ -24,7 +24,7 @@ namespace PnP.PowerShell.Commands.Webhooks
         public string NotificationUrl;
 
         [Parameter(Mandatory = false)]
-        public DateTime ExpirationDate = DateTime.Today.ToUniversalTime().AddMonths(DefaultValidityInMonths).AddHours(ValidityDeltaInDays);
+        public DateTime ExpirationDate = DateTime.Today.ToUniversalTime().AddDays(DefaultValidityInDays).AddHours(ValidityDeltaInDays);
 
         protected override void ExecuteCmdlet()
         {


### PR DESCRIPTION
…kSubscription

<!-- The PnP PowerShell team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##

## What is in this Pull Request ? ##
Update to Set-PnPWebhookSubscription to use the same default expiration data as Add-PnPWebhookSubscription.
This resolves a potential issue where 6 months - 72 hours > 180 days which would return an error from the API. (see: https://learn.microsoft.com/en-us/sharepoint/dev/apis/webhooks/overview-sharepoint-webhooks#expiration)

## Summary 
<!-- cspell:disable-next-line -->
copilot:summary

## Details 
<!-- cspell:disable-next-line -->
copilot:walkthrough