### PR TITLE
Currently 2.1.1 is a PnP.PowerShell stable version we can use within Azure. Runbooks 7.2

### DIFF
--- a/pages/articles/azureautomationrunbook.md
+++ b/pages/articles/azureautomationrunbook.md
@@ -43,7 +43,8 @@ To add PnP PowerShell to the Azure Automation Account, follow these steps:
 #### Specific stable version
 
    > [!Important]
-   > There's currently no stable PnP PowerShell version that works with Azure Automation 7.2 Runbooks. Use the [latest nightly build](#latest-prerelease-version) instead.
+   > Currently stable PnP PowerShell version that works with Azure Automation 7.2 Runbooks is **2.1.1**. 
+   > If you would like to use a [latest nightly build] (#latest-prerelease-version) instead, use the below instructions
 
    Select **Browse from gallery**, Runtime version **7.2 (preview)** and click on the **Click here to browse from gallery** link
 


### PR DESCRIPTION
Changed the sentence "
[!Important]There's currently no stable PnP PowerShell version that works with Azure Automation 7.2 Runbooks. Use the latest nightly build instead." to 
"
[!Important] Currently stable PnP PowerShell version that works with Azure Automation 7.2 Runbooks is 2.1.1. If you would like to use a [latest nightly build] (#latest-prerelease-version) instead, follow the below instructions "

<!-- The PnP PowerShell team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #X, partially fixes #Y, mentioned in #Z, etc.

## What is in this Pull Request ? ##
Please describe the changes in the PR. 

### Guidance ###
* You can delete this section when you are submitting the pull request.* 
* *Please update this PR information accordingly. We use this as part of our release notes in monthly communications.*
* **Please target your PR to Dev branch. If you do not target the Dev branch we will not accept this PR.**


## Summary 
<!-- cspell:disable-next-line -->
copilot:summary

## Details 
<!-- cspell:disable-next-line -->
copilot:walkthrough