### PR TITLE
Trimming starting slash in `Set-PnPHomePage`

### DIFF
--- a/documentation/Set-PnPHomePage.md
+++ b/documentation/Set-PnPHomePage.md
@@ -15,8 +15,7 @@ Sets the home page of the current web.
 ## SYNTAX
 
 ```powershell
-Set-PnPHomePage [-RootFolderRelativeUrl] <String> [-Connection <PnPConnection>]
- 
+Set-PnPHomePage [-RootFolderRelativeUrl] <String> [-Connection <PnPConnection>] [-Verbose] 
 ```
 
 ## DESCRIPTION
@@ -56,7 +55,7 @@ Accept wildcard characters: False
 ```
 
 ### -RootFolderRelativeUrl
-The root folder relative url of the homepage, e.g. 'sitepages/home.aspx'
+The root folder relative url of the homepage, e.g. 'sitepages/home.aspx'. Notice that the url is relative to the root folder of the web.
 
 ```yaml
 Type: String
@@ -70,9 +69,20 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
+### -Verbose
+When provided, additional debug statements will be shown while executing the cmdlet.
 
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ## RELATED LINKS
 
 [Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)
-

--- a/src/Commands/Branding/SetHomepage.cs
+++ b/src/Commands/Branding/SetHomepage.cs
@@ -1,7 +1,6 @@
 ﻿using System.Management.Automation;
 using Microsoft.SharePoint.Client;
 
-
 namespace PnP.PowerShell.Commands.Branding
 {
     [Cmdlet(VerbsCommon.Set, "PnPHomePage")]
@@ -12,8 +11,14 @@ namespace PnP.PowerShell.Commands.Branding
 
         protected override void ExecuteCmdlet()
         {
+            if(RootFolderRelativeUrl.StartsWith("/"))
+            {
+                WriteVerbose($"Removing leading / from {nameof(RootFolderRelativeUrl)}");
+                RootFolderRelativeUrl = RootFolderRelativeUrl.TrimStart('/');
+            }
+
+            WriteVerbose($"Setting homepage to {RootFolderRelativeUrl}");
             CurrentWeb.SetHomePage(RootFolderRelativeUrl);
         }
     }
-
 }


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample
- [X] Optimization

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Removing slash at the beginning if present to avoid commonly made mistake. Added some verbose logging as well while at it.