### PR TITLE
Added AllowDeletion parameter to Set-PnPList cmdlet

### DIFF
--- a/documentation/Set-PnPList.md
+++ b/documentation/Set-PnPList.md
@@ -17,7 +17,7 @@ Updates list settings
 ```powershell
 Set-PnPList -Identity <ListPipeBind> [-EnableContentTypes <Boolean>] [-BreakRoleInheritance]
  [-ResetRoleInheritance] [-CopyRoleAssignments] [-ClearSubScopes] [-Title <String>] [-Description <String>]
- [-Hidden <Boolean>] [-ForceCheckout <Boolean>] [-ListExperience <ListExperience>]
+ [-Hidden <Boolean>] [-AllowDeletion <Boolean>] [-ForceCheckout <Boolean>] [-ListExperience <ListExperience>]
  [-EnableAttachments <Boolean>] [-EnableFolderCreation <Boolean>] [-EnableVersioning <Boolean>]
  [-EnableMinorVersions <Boolean>] [-MajorVersions <UInt32>] [-MinorVersions <UInt32>]
  [-EnableModeration <Boolean>] [-DraftVersionVisibility <DraftVisibilityType>] [-ReadSecurity <ListReadSecurity>] [-WriteSecurity <ListWriteSecurity>]
@@ -322,6 +322,20 @@ Accept wildcard characters: False
 
 ### -Hidden
 Hide the list from the SharePoint UI. Set to $true to hide, $false to show.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AllowDeletion
+Allow or prevent deletion of the list from the SharePoint UI. Set to $true to allow, $false to prevent.
 
 ```yaml
 Type: Boolean

--- a/src/Commands/Lists/SetList.cs
+++ b/src/Commands/Lists/SetList.cs
@@ -39,6 +39,9 @@ namespace PnP.PowerShell.Commands.Lists
         public bool Hidden;
 
         [Parameter(Mandatory = false)]
+        public bool AllowDeletion;
+
+        [Parameter(Mandatory = false)]
         public bool ForceCheckout;
 
         [Parameter(Mandatory = false)]
@@ -122,7 +125,7 @@ namespace PnP.PowerShell.Commands.Lists
                 list = newIdentity.GetList(CurrentWeb);
             }
 
-            list.EnsureProperties(l => l.EnableAttachments, l => l.EnableVersioning, l => l.EnableMinorVersions, l => l.Hidden, l => l.EnableModeration, l => l.BaseType, l => l.HasUniqueRoleAssignments, l => l.ContentTypesEnabled, l => l.ExemptFromBlockDownloadOfNonViewableFiles, l => l.DisableGridEditing, l => l.DisableCommenting);
+            list.EnsureProperties(l => l.EnableAttachments, l => l.EnableVersioning, l => l.EnableMinorVersions, l => l.Hidden, l => l.AllowDeletion, l => l.EnableModeration, l => l.BaseType, l => l.HasUniqueRoleAssignments, l => l.ContentTypesEnabled, l => l.ExemptFromBlockDownloadOfNonViewableFiles, l => l.DisableGridEditing, l => l.DisableCommenting);
 
             var enableVersioning = list.EnableVersioning;
             var enableMinorVersions = list.EnableMinorVersions;
@@ -149,6 +152,12 @@ namespace PnP.PowerShell.Commands.Lists
             if (ParameterSpecified(nameof(Hidden)) && Hidden != list.Hidden)
             {
                 list.Hidden = Hidden;
+                updateRequired = true;
+            }
+
+            if (ParameterSpecified(nameof(AllowDeletion)) && AllowDeletion != list.AllowDeletion)
+            {
+                list.AllowDeletion = AllowDeletion;
                 updateRequired = true;
             }
 


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Closes #3138 

## What is in this Pull Request? ##
Added `-AllowDeletion` parameter to Set-PnPList cmdlet which allows or prevent deletion of the list from the SharePoint UI.
