### PR TITLE
Refactor Remove-PnPListItemVersion to use PnP Core SDK

### DIFF
--- a/src/Commands/Lists/RemoveListItemVersion.cs
+++ b/src/Commands/Lists/RemoveListItemVersion.cs
@@ -1,8 +1,8 @@
 ﻿using System.Linq;
 using System.Management.Automation;
-using Microsoft.SharePoint.Client;
+using PnP.Core.Model.SharePoint;
+using PnP.Core.QueryModel;
 using PnP.PowerShell.Commands.Base.PipeBinds;
-using PnP.PowerShell.Commands.Extensions;
 using Resources = PnP.PowerShell.Commands.Properties.Resources;
 
 namespace PnP.PowerShell.Commands.Lists
@@ -12,16 +12,19 @@ namespace PnP.PowerShell.Commands.Lists
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
         public ListPipeBind List;
+
         [Parameter(Mandatory = true, ValueFromPipeline = true)]
         public ListItemPipeBind Identity;
+        
         [Parameter(Mandatory = true, ValueFromPipeline = true)]
         public ListItemVersionPipeBind Version;
+        
         [Parameter(Mandatory = false)]
         public SwitchParameter Force;
 
         protected override void ExecuteCmdlet()
         {
-            var list = List.GetList(CurrentWeb);
+            var list = List.GetList(PnPContext);
 
             if (list is null)
             {
@@ -29,22 +32,24 @@ namespace PnP.PowerShell.Commands.Lists
             }
 
             var item = Identity.GetListItem(list);
-        
+
             if (item is null)
             {
                 throw new PSArgumentException($"Cannot find the list item provided through -{nameof(Identity)}", nameof(Identity));
             }
 
-            item.LoadProperties(i => i.Versions);
+            item.EnsureProperties(i => i.All, i => i.Versions);
 
-            ListItemVersion version = null;
+            var itemVersionCollection = item.Versions.AsRequested();
+
+            IListItemVersion version = null;
             if (!string.IsNullOrEmpty(Version.VersionLabel))
             {
-                version = item.Versions.FirstOrDefault(v => v.VersionLabel == Version.VersionLabel);
+                version = itemVersionCollection.FirstOrDefault(v => v.VersionLabel == Version.VersionLabel);
             }
             else if (Version.Id != -1)
             {
-                version = item.Versions.FirstOrDefault(v => v.VersionId == Version.Id);
+                version = itemVersionCollection.FirstOrDefault(v => v.Id == Version.Id);
             }
 
             if (version is null)
@@ -52,13 +57,12 @@ namespace PnP.PowerShell.Commands.Lists
                 throw new PSArgumentException($"Cannot find the list item version provided through -{nameof(Version)}", nameof(Version));
             }
 
-            if(Force || ShouldContinue(string.Format(Resources.Delete0, version.VersionLabel), Resources.Confirm))
+            if (Force || ShouldContinue(string.Format(Resources.Delete0, version.VersionLabel), Resources.Confirm))
             {
                 WriteVerbose($"Trying to remove version {Version.VersionLabel}");
-                
-                version.DeleteObject();
-                ClientContext.ExecuteQueryRetry();
-                
+
+                version.Delete();
+
                 WriteVerbose($"Removed version {Version.VersionLabel} of list item {item.Id} in list {list.Title}");
             }
         }


### PR DESCRIPTION
<!-- The PnP PowerShell team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

## Type ##
- [x] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
NA

## What is in this Pull Request ? ##
Refactor Remove-PnPListItem to use PnP Core SDK

## Summary 
<!-- cspell:disable-next-line -->
copilot:summary

## Details 
<!-- cspell:disable-next-line -->
copilot:walkthrough