### PR TITLE
Fix #3220 - issue with Includes usage in Get-PnPField cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed issue with `Get-PnPTenantSyncClientRestriction` cmdlet not populating the necessary properties. [#3099](https://github.com/pnp/powershell/pull/3099)
 - Fixed `Add/Set/Get-PnPPage` cmdlets when using multilingual translation parameters which caused some exceptions. [#3120](https://github.com/pnp/powershell/pull/3120)
 - Fixed `New-PnPSite` cmdlet now supports creating Team site in non-commercial cloud environments. [#885](https://github.com/pnp/pnpframework/pull/885)
+- Fixed issue where `Get-PnPField` cmdlet was throwing error in case `-Includes` parameter was used.
 
 ### Changed
 

--- a/src/Commands/Fields/GetField.cs
+++ b/src/Commands/Fields/GetField.cs
@@ -53,6 +53,8 @@ namespace PnP.PowerShell.Commands.Fields
                     ClientContext.Load(field, RetrievalExpressions);
                     ClientContext.ExecuteQueryRetry();
 
+                    field.EnsureProperty(f => f.FieldTypeKind);
+
                     switch (field.FieldTypeKind)
                     {
                         case FieldType.DateTime:
@@ -212,6 +214,8 @@ namespace PnP.PowerShell.Commands.Fields
                     ClientContext.Load(field, RetrievalExpressions);
                     ClientContext.ExecuteQueryRetry();
 
+                    field.EnsureProperty(f => f.FieldTypeKind);
+
                     switch (field.FieldTypeKind)
                     {
                         case FieldType.DateTime:
@@ -292,8 +296,6 @@ namespace PnP.PowerShell.Commands.Fields
                     }
                 }
             }
-
         }
     }
-
 }


### PR DESCRIPTION
<!-- The PnP PowerShell team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #3220

## What is in this Pull Request ? ##
Fix property not initialized error when Includes was used in Get-PnPField cmdlet

## Summary 
<!-- cspell:disable-next-line -->
copilot:summary

## Details 
<!-- cspell:disable-next-line -->
copilot:walkthrough