### PR TITLE
Feature: add ListsShowHeaderAndNavigation  property to PnPTenantSite and PnPSite cmdlets

### DIFF
--- a/documentation/Set-PnPSite.md
+++ b/documentation/Set-PnPSite.md
@@ -46,6 +46,7 @@ Set-PnPSite [-Identity <String>]
  [-ScriptSafeDomainName <string>]
  [-BlockDownloadPolicy <Boolean>] [-ExcludeBlockDownloadPolicySiteOwners <Boolean>]
  [-ExcludedBlockDownloadGroupIds <Guid[]>]
+ [-ListsShowHeaderAndNavigation <Boolean>]
  [-Connection <PnPConnection>]
 ```
 
@@ -575,6 +576,20 @@ Exempts users from the mentioned groups from this policy and they can fully down
 
 ```yaml
 Type: GUID[]
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ListsShowHeaderAndNavigation
+Set a property on a site collection to make all lists always load with the site elements intact.
+
+```yaml
+Type: Boolean
 Parameter Sets: Set Properties
 
 Required: False

--- a/documentation/Set-PnPTenantSite.md
+++ b/documentation/Set-PnPTenantSite.md
@@ -36,6 +36,7 @@ Set-PnPTenantSite [-Identity] <String> [-Title <String>] [-LocaleId <UInt32>] [-
  [-MediaTranscription <MediaTranscriptionPolicyType>] 
  [-BlockDownloadPolicy <Boolean>] [-ExcludeBlockDownloadPolicySiteOwners <Boolean>]
  [-ExcludedBlockDownloadGroupIds <Guid[]>]
+ [-ListsShowHeaderAndNavigation <Boolean>]
  [-Wait] 
  [-Connection <PnPConnection>] 
 ```
@@ -713,6 +714,20 @@ Exempts users from the mentioned groups from this policy and they can fully down
 
 ```yaml
 Type: GUID[]
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ListsShowHeaderAndNavigation
+Set a property on a site collection to make all lists always load with the site elements intact.
+
+```yaml
+Type: Boolean
 Parameter Sets: Set Properties
 
 Required: False

--- a/src/Commands/Admin/SetTenantSite.cs
+++ b/src/Commands/Admin/SetTenantSite.cs
@@ -174,6 +174,9 @@ namespace PnP.PowerShell.Commands
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
         public Guid[] ExcludedBlockDownloadGroupIds;
 
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public bool? ListsShowHeaderAndNavigation;
+
         [Parameter(Mandatory = false)]
         public SwitchParameter Wait;
 
@@ -525,6 +528,12 @@ namespace PnP.PowerShell.Commands
             if (ParameterSpecified(nameof(ExcludedBlockDownloadGroupIds)) && ExcludedBlockDownloadGroupIds.Length > 0)
             {
                 props.ExcludedBlockDownloadGroupIds = ExcludedBlockDownloadGroupIds;
+                updateRequired = true;
+            }
+
+            if (ParameterSpecified(nameof(ListsShowHeaderAndNavigation)) && ListsShowHeaderAndNavigation.HasValue)
+            {
+                props.ListsShowHeaderAndNavigation = ListsShowHeaderAndNavigation.Value;
                 updateRequired = true;
             }
 

--- a/src/Commands/Base/ConnectOnline.cs
+++ b/src/Commands/Base/ConnectOnline.cs
@@ -723,7 +723,7 @@ namespace PnP.PowerShell.Commands.Base
                 }
                 return false;
             }
-            catch(Exception ex)
+            catch
             {
                 return false;
             }

--- a/src/Commands/Site/SetSite.cs
+++ b/src/Commands/Site/SetSite.cs
@@ -121,6 +121,9 @@ namespace PnP.PowerShell.Commands.Site
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
         public Guid[] ExcludedBlockDownloadGroupIds;
 
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public bool? ListsShowHeaderAndNavigation;
+
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_LOCKSTATE)]
         public SwitchParameter Wait;
 
@@ -397,6 +400,12 @@ namespace PnP.PowerShell.Commands.Site
                     executeQueryRequired = true;
                 }
 
+                if (ParameterSpecified(nameof(ListsShowHeaderAndNavigation)) && ListsShowHeaderAndNavigation.HasValue)
+                {
+                    siteProperties.ListsShowHeaderAndNavigation = ListsShowHeaderAndNavigation.Value;
+                    executeQueryRequired = true;
+                }
+
                 if (executeQueryRequired)
                 {
                     siteProperties.Update();
@@ -451,6 +460,7 @@ namespace PnP.PowerShell.Commands.Site
                 RequestFilesLinkEnabled.HasValue ||
                 BlockDownloadPolicy.HasValue ||
                 ExcludeBlockDownloadPolicySiteOwners.HasValue ||
-                ParameterSpecified(nameof(ExcludedBlockDownloadGroupIds));
+                ParameterSpecified(nameof(ExcludedBlockDownloadGroupIds)) ||
+                ListsShowHeaderAndNavigation.HasValue;
     }
 }


### PR DESCRIPTION
<!-- The PnP PowerShell team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->


## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #3227

## What is in this Pull Request ? ##
Added additional property to show lists header and navigation always if set.

## Summary 
<!-- cspell:disable-next-line -->
copilot:summary

## Details 
<!-- cspell:disable-next-line -->
copilot:walkthrough