### PR TITLE
Fix #3236: Directly operate on List

### DIFF
--- a/src/Commands/ContentTypes/AddContentTypeToList.cs
+++ b/src/Commands/ContentTypes/AddContentTypeToList.cs
@@ -24,7 +24,7 @@ namespace PnP.PowerShell.Commands.ContentTypes
             var ct = ContentType?.GetContentTypeOrWarn(this, CurrentWeb);
             if (ct != null)
             {
-                CurrentWeb.AddContentTypeToList(list.Title, ct, DefaultContentType);
+                list.AddContentTypeToList(ct, DefaultContentType);
             }
         }
 


### PR DESCRIPTION
<!-- The PnP PowerShell team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #3236 

## What is in this Pull Request ? ##
The old code retrieved the List object, to then call a helper and pass the title of the list.
The helper, in turn, retrieves the list (again) by its title to then add the ContentType.
Since the method already has a reference to the list, we can forgo the helper.

## Summary 
<!-- cspell:disable-next-line -->
copilot:summary

## Details 
<!-- cspell:disable-next-line -->
copilot:walkthrough