### PR TITLE
Fix #3215 : issue with copy file/folder when moving to personal or multi-geo environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Set-PnPTerm` cmdlet throwing object reference error when only the term Id is specified. [#3341](https://github.com/pnp/powershell/pull/3341)
 - Fixed `New-PnPTeamsTeam` cmdlet throwing an error when specifying members [#3351](https://github.com/pnp/powershell/pull/3351)
 - Fixed `New-PnPTeamsTeam` cmdlet not working well with a managed identity [#3351](https://github.com/pnp/powershell/pull/3351)
-
+- Fixed `Copy-PnPFile`, `Copy-PnPFolder` and `Move-PnPFile` to better handle copying or moving operations to OneDrive or Multi-geo environments. [#3245](https://github.com/pnp/powershell/pull/3245)
+ 
 ### Changed
 
 - Improved `Set-PnPListItem` cmdlet handling of Purview labels. [#3340](https://github.com/pnp/powershell/pull/3340)

--- a/src/Commands/Files/CopyFile.cs
+++ b/src/Commands/Files/CopyFile.cs
@@ -42,8 +42,8 @@ namespace PnP.PowerShell.Commands.Files
             if (!SourceUrl.StartsWith("/"))
             {
                 SourceUrl = UrlUtility.Combine(webServerRelativeUrl, SourceUrl);
-            }
-            if (!TargetUrl.StartsWith("/"))
+            }            
+            if (!TargetUrl.StartsWith("https://") && !TargetUrl.StartsWith("/"))
             {
                 TargetUrl = UrlUtility.Combine(webServerRelativeUrl, TargetUrl);
             }
@@ -58,7 +58,16 @@ namespace PnP.PowerShell.Commands.Files
             Uri sourceUri = new Uri(currentContextUri, EncodePath(sourceFolder));
             Uri sourceWebUri = Microsoft.SharePoint.Client.Web.WebUrlFromFolderUrlDirect(ClientContext, sourceUri);
             Uri targetUri = new Uri(currentContextUri, EncodePath(targetFolder));
-            Uri targetWebUri = Microsoft.SharePoint.Client.Web.WebUrlFromFolderUrlDirect(ClientContext, targetUri);
+            Uri targetWebUri;
+            if (TargetUrl.StartsWith("https://"))
+            {
+                targetUri = new Uri(TargetUrl);
+                targetWebUri = targetUri;
+            }
+            else
+            {
+                targetWebUri = Microsoft.SharePoint.Client.Web.WebUrlFromFolderUrlDirect(ClientContext, targetUri);
+            }
 
             if (Force || ShouldContinue(string.Format(Resources.CopyFile0To1, SourceUrl, TargetUrl), Resources.Confirm))
             {
@@ -104,7 +113,7 @@ namespace PnP.PowerShell.Commands.Files
             {
                 sourceUrl = $"{source.Scheme}://{source.Host}/{sourceUrl.TrimStart('/')}";
             }
-            if (!targetUrl.StartsWith(destination.ToString()))
+            if (!targetUrl.StartsWith("https://") && !targetUrl.StartsWith(destination.ToString()))
             {
                 targetUrl = $"{destination.Scheme}://{destination.Host}/{targetUrl.TrimStart('/')}";
             }

--- a/src/Commands/Files/MoveFile.cs
+++ b/src/Commands/Files/MoveFile.cs
@@ -50,7 +50,7 @@ namespace PnP.PowerShell.Commands.Files
             {
                 SourceUrl = UrlUtility.Combine(webServerRelativeUrl, SourceUrl);
             }
-            if (!TargetUrl.StartsWith("/"))
+            if (!TargetUrl.StartsWith("https://") && !TargetUrl.StartsWith("/"))
             {
                 TargetUrl = UrlUtility.Combine(webServerRelativeUrl, TargetUrl);
             }
@@ -66,7 +66,16 @@ namespace PnP.PowerShell.Commands.Files
             Uri sourceUri = new Uri(currentContextUri, EncodePath(sourceFolder));
             Uri sourceWebUri = Web.WebUrlFromFolderUrlDirect(ClientContext, sourceUri);
             Uri targetUri = new Uri(currentContextUri, EncodePath(targetFolder));
-            Uri targetWebUri = Web.WebUrlFromFolderUrlDirect(ClientContext, targetUri);
+            Uri targetWebUri;
+            if (TargetUrl.StartsWith("https://"))
+            {
+                targetUri = new Uri(TargetUrl);
+                targetWebUri = targetUri;
+            }
+            else
+            {
+                targetWebUri = Microsoft.SharePoint.Client.Web.WebUrlFromFolderUrlDirect(ClientContext, targetUri);
+            }
 
             if (Force || ShouldContinue(string.Format(Resources.MoveFile0To1, SourceUrl, TargetUrl), Resources.Confirm))
             {
@@ -115,7 +124,7 @@ namespace PnP.PowerShell.Commands.Files
             {
                 sourceUrl = $"{source.Scheme}://{source.Host}/{sourceUrl.TrimStart('/')}";
             }
-            if (!targetUrl.StartsWith(destination.ToString()))
+            if (!targetUrl.StartsWith("https://") && !targetUrl.StartsWith(destination.ToString()))
             {
                 targetUrl = $"{destination.Scheme}://{destination.Host}/{targetUrl.TrimStart('/')}";
             }


### PR DESCRIPTION
<!-- The PnP PowerShell team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->


## Type ##
- [x] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #3215

## What is in this Pull Request ? ##
Fixed cmdlets to handle absolute URLs which enables copying/moving file and folders easily between OneDrive and Multigeo environments.

## Summary 
<!-- cspell:disable-next-line -->
copilot:summary

## Details 
<!-- cspell:disable-next-line -->
copilot:walkthrough