### PR TITLE
Fix #3305 - issue with null reference when creating Azure AD groups

### DIFF
--- a/src/Commands/AzureAD/NewAzureADGroup.cs
+++ b/src/Commands/AzureAD/NewAzureADGroup.cs
@@ -62,8 +62,8 @@ namespace PnP.PowerShell.Commands.Graph
 
             if (forceCreation)
             {
-                var ownerData = Microsoft365GroupsUtility.GetUsersDataBindValueAsync(Connection, AccessToken, Owners).GetAwaiter().GetResult();
-                var memberData = Microsoft365GroupsUtility.GetUsersDataBindValueAsync(Connection, AccessToken, Members).GetAwaiter().GetResult();
+                string[] ownerData = null;
+                string[] memberData = null;
 
                 var postData = new Dictionary<string, object>() {
                     { "description" , string.IsNullOrEmpty(Description) ? null : Description },
@@ -71,10 +71,19 @@ namespace PnP.PowerShell.Commands.Graph
                     { "groupTypes", new List<string>(){} },
                     { "mailEnabled", IsMailEnabled.ToBool() },
                     { "mailNickname" , MailNickname },
-                    { "securityEnabled", IsSecurityEnabled.ToBool() },
-                    { "owners@odata.bind", ownerData },
-                    { "members@odata.bind", memberData },
+                    { "securityEnabled", IsSecurityEnabled.ToBool() }                    
                 };
+
+                if (Owners?.Length > 0)
+                {
+                    ownerData = Microsoft365GroupsUtility.GetUsersDataBindValueAsync(Connection, AccessToken, Owners).GetAwaiter().GetResult();
+                    postData.Add("owners@odata.bind", ownerData);
+                }
+                if (Members?.Length > 0)
+                {
+                    memberData = Microsoft365GroupsUtility.GetUsersDataBindValueAsync(Connection, AccessToken, Members).GetAwaiter().GetResult();
+                    postData.Add("members@odata.bind", memberData);
+                }               
 
                 var data = JsonSerializer.Serialize(postData);
                 var stringContent = new StringContent(data);


### PR DESCRIPTION
<!-- The PnP PowerShell team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #3305 

## What is in this Pull Request ? ##
Fix issue with provisioning Azure AD groups throwing null reference errors.

## Summary 
<!-- cspell:disable-next-line -->
copilot:summary

## Details 
<!-- cspell:disable-next-line -->
copilot:walkthrough