### PR TITLE
Update SetTerm.cs to add support for tagging availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `-ReduceTempTokenLifetimeEnabled`, `-ReduceTempTokenLifetimeValue`, `-ViewersCanCommentOnMediaDisabled`, `-AllowGuestUserShareToUsersNotInSiteCollection`, `-ConditionalAccessPolicyErrorHelpLink`, `-CustomizedExternalSharingServiceUrl`, `-IncludeAtAGlanceInShareEmails` and `-MassDeleteNotificationDisabled` to `Set-PnPTenant` [#3348](https://github.com/pnp/powershell/pull/3348)
 - Added `Add-PnPFlowOwner` and `Remove-PnPFlowOwner` cmdlets which allow granting or removing permissions to a Power Automate flow [#3343](https://github.com/pnp/powershell/pull/3343)
 - Added `Get-PnPFlowOwner` cmdlet which allows retrieving the owners of a Power Automate flow [#3314](https://github.com/pnp/powershell/pull/3314)
+- Added `-AvailableForTagging` to `Set-PnPTerm` which allows the available for tagging property on a Term to be set [#3321](https://github.com/pnp/powershell/pull/3321)
 
 ### Fixed
 
@@ -58,6 +59,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Contributors
 
+- Jim Duncan [sparkitect]
 - Jonathan Smith [jonathan-m-smith]
 - Carl Joakim Damsleth [damsleth]
 - Rodel Pacurib [ryder-cayden]

--- a/documentation/Set-PnPTerm.md
+++ b/documentation/Set-PnPTerm.md
@@ -18,7 +18,7 @@ Updates a term
 ```
 Set-PnPTerm -Identity <Guid> [-Name <String>] [-Lcid <Int32>] [-Description <String>]
  [-CustomProperties <Hashtable>] [-LocalCustomProperties <Hashtable>] [-DeleteAllCustomProperties]
- [-DeleteAllLocalCustomProperties] [-Deprecated <bool>] [-TermStore <TaxonomyTermStorePipeBind>]
+ [-DeleteAllLocalCustomProperties] [-Deprecated <bool>] [-AvailableForTagging <bool>] [-TermStore <TaxonomyTermStorePipeBind>]
  
 ```
 
@@ -26,7 +26,7 @@ Set-PnPTerm -Identity <Guid> [-Name <String>] [-Lcid <Int32>] [-Description <Str
 ```
 Set-PnPTerm -Identity <String> [-Name <String>] [-Lcid <Int32>] [-Description <String>]
  [-CustomProperties <Hashtable>] [-LocalCustomProperties <Hashtable>] [-DeleteAllCustomProperties]
- [-DeleteAllLocalCustomProperties] [-Deprecated <bool>] -TermSet <TaxonomyTermSetPipeBind> -TermGroup <TaxonomyTermGroupPipeBind>
+ [-DeleteAllLocalCustomProperties] [-Deprecated <bool>] [-AvailableForTagging <bool>] -TermSet <TaxonomyTermSetPipeBind> -TermGroup <TaxonomyTermGroupPipeBind>
  [-TermStore <TaxonomyTermStorePipeBind>] 
 ```
 
@@ -64,6 +64,21 @@ Set-TermSet -Identity "Marketing" -TermSet "Departments" -TermGroup "Corporate" 
 Marks an existing term as deprecated, hiding it from users.
 
 ## PARAMETERS
+
+### -AvailableForTagging
+Sets a term to be available for tagging or not.
+
+```yaml
+Type: boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -CustomProperties
 Sets custom properties. 

--- a/src/Commands/Taxonomy/SetTerm.cs
+++ b/src/Commands/Taxonomy/SetTerm.cs
@@ -53,6 +53,9 @@ namespace PnP.PowerShell.Commands.Taxonomy
         [Parameter(Mandatory = false)]
         public bool Deprecated;
 
+        [Parameter(Mandatory = false)]
+        public bool AvailableForTagging;
+
         protected override void ExecuteCmdlet()
         {
             DefaultRetrievalExpressions = new Expression<Func<Term, object>>[] { g => g.Name, g => g.TermsCount, g => g.Id };
@@ -130,6 +133,12 @@ namespace PnP.PowerShell.Commands.Taxonomy
             {
                 term.Deprecate(Deprecated);
             }
+            
+            if (ParameterSpecified(nameof(AvailableForTagging)))
+            {
+                term.IsAvailableForTagging = AvailableForTagging;
+            }
+            
             ClientContext.Load(term);
             termStore.CommitAll();
             ClientContext.ExecuteQueryRetry();

--- a/src/Commands/Taxonomy/SetTerm.cs
+++ b/src/Commands/Taxonomy/SetTerm.cs
@@ -54,7 +54,7 @@ namespace PnP.PowerShell.Commands.Taxonomy
         public bool Deprecated;
 
         [Parameter(Mandatory = false)]
-        public bool AvailableForTagging;
+        public bool? AvailableForTagging;
 
         protected override void ExecuteCmdlet()
         {
@@ -134,9 +134,9 @@ namespace PnP.PowerShell.Commands.Taxonomy
                 term.Deprecate(Deprecated);
             }
             
-            if (ParameterSpecified(nameof(AvailableForTagging)))
+            if (ParameterSpecified(nameof(AvailableForTagging)) && AvailableForTagging.HasValue)
             {
-                term.IsAvailableForTagging = AvailableForTagging;
+                term.IsAvailableForTagging = AvailableForTagging.Value;
             }
             
             ClientContext.Load(term);
@@ -146,4 +146,3 @@ namespace PnP.PowerShell.Commands.Taxonomy
         }
     }
 }
-


### PR DESCRIPTION
Added support for "Available for Tagging" setting on a Term.

<!-- The PnP PowerShell team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
none known

## What is in this Pull Request ? ##
Added (untested) code to allow for specifying whether the Term should be "Available for Tagging"

## Summary 
<!-- cspell:disable-next-line -->
copilot:summary

## Details 
<!-- cspell:disable-next-line -->
copilot:walkthrough