### PR TITLE
New Commands - Add-PnPFlowOwner & Remove-PnPFlowOwner

### DIFF
--- a/documentation/Add-PnPFlowOwner.md
+++ b/documentation/Add-PnPFlowOwner.md
@@ -1,0 +1,140 @@
+---
+Module Name: PnP.PowerShell
+schema: 2.0.0
+applicable: SharePoint Online
+online version: https://pnp.github.io/powershell/cmdlets/Add-PnPFlowOwner.html
+external help file: PnP.PowerShell.dll-Help.xml
+title: Add-PnPFlowOwner
+---
+  
+# Add-PnPFlowOwner
+
+## SYNOPSIS
+
+**Required Permissions**
+
+* Azure: management.azure.com
+
+Assigns/updates permissions to a Power Automate flow
+
+## SYNTAX
+
+### By Identity and User (default)
+```powershell
+Add-PnPFlowOwner [-Environment <PowerAutomateEnvironmentPipeBind>] [-Identity <PowerPlatformPipeBind>] [-User <String>] [-AsAdmin] [-RoleName <FlowUserRoleName>]
+```
+
+
+## DESCRIPTION
+This cmdlet assigns/updates permissions for a user to a power automate flow.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+$environment = Get-PnPPowerPlatformEnvironment
+Add-PnPFlowOwner -environment $environment -Identity f07c34a9-a586-4e58-91fb-e7ea19741b61 -User username@tenant.onmicrosoft.com -RoleName CanEdit
+```
+Assigns the specified useremail with 'CanEdit' access level to the specified flow
+
+### Example 2
+```powershell
+$environment = Get-PnPPowerPlatformEnvironment
+Add-PnPFlowOwner -environment $environment -Identity f07c34a9-a586-4e58-91fb-e7ea19741b61 -User 6844c04a-8ee7-40ad-af66-28f6e948cd04 -RoleName CanView
+```
+Assigns the specified user id with 'CanView' access level to the specified flow
+
+### Example 3
+```powershell
+$environment = Get-PnPPowerPlatformEnvironment
+Add-PnPFlowOwner -environment $environment -Identity f07c34a9-a586-4e58-91fb-e7ea19741b61 -User 6844c04a-8ee7-40ad-af66-28f6e948cd04 -RoleName CanViewWithShare
+```
+Assigns the specified user id with 'CanViewWithShare' access level to the specified flow
+
+### Example 4
+```powershell
+$environment = Get-PnPPowerPlatformEnvironment
+Add-PnPFlowOwner -environment $environment -Identity f07c34a9-a586-4e58-91fb-e7ea19741b61 -User username@tenant.onmicrosoft.com -AsAdmin -RoleName CanEdit
+```
+Assigns the specified useremail with 'CanEdit' access level to the specified flow as admin
+
+## PARAMETERS
+
+### -Environment
+The name of the Power Platform environment or an Environment object to retrieve the available flows for.
+
+```yaml
+Type: PowerAutomateEnvironmentPipeBind
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: The default environment
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+The Name/Id of the flow to retrieve.
+
+```yaml
+Type: PowerPlatformPipeBind
+Parameter Sets: By Identity
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -User
+Returns the user with the provided user id or username.
+
+```yaml
+Type: String
+Parameter Sets: Return by specific ID/UserName
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RoleName
+Allows specifying the type of access levels with which user should be added to the flow . Valid values: CanView, CanViewWithShare, CanEdit.
+
+```yaml
+Type: FlowUserRoleName
+Parameter Sets: All
+
+Required: True
+Position: Named
+Default value: All
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+
+
+### -AsAdmin
+If specified returns all the flows as admin. If not specified only the flows for the current user will be returned.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/documentation/Remove-PnPFlowOwner.md
+++ b/documentation/Remove-PnPFlowOwner.md
@@ -1,0 +1,141 @@
+---
+Module Name: PnP.PowerShell
+schema: 2.0.0
+applicable: SharePoint Online
+online version: https://pnp.github.io/powershell/cmdlets/Remove-PnPFlowOwner.html
+external help file: PnP.PowerShell.dll-Help.xml
+title: Remove-PnPFlowOwner
+---
+  
+# Remove-PnPFlowOwner
+
+## SYNOPSIS
+
+**Required Permissions**
+
+* Azure: management.azure.com
+
+Removes owner permissions to a Power Automate flow
+
+
+## SYNTAX
+
+### By Identity and User (default)
+```powershell
+Remove-PnPFlowOwner [-Environment <PowerAutomateEnvironmentPipeBind>] [-Identity <PowerPlatformPipeBind>] [-User <String>] [-AsAdmin] [-Force]
+```
+
+
+## DESCRIPTION
+This cmdlet removes owner permissions for a user to a power automate flow.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+$environment = Get-PnPPowerPlatformEnvironment
+Remove-PnPFlowOwner -environment $environment -Identity f07c34a9-a586-4e58-91fb-e7ea19741b61 -User username@tenant.onmicrosoft.com
+```
+Removes the specified user email with owner access level to the specified flow
+
+### Example 2
+```powershell
+$environment = Get-PnPPowerPlatformEnvironment
+Remove-PnPFlowOwner -environment $environment -Identity f07c34a9-a586-4e58-91fb-e7ea19741b61 -User 6844c04a-8ee7-40ad-af66-28f6e948cd04
+```
+Removes the specified user id with owner access level to the specified flow
+
+### Example 3
+```powershell
+$environment = Get-PnPPowerPlatformEnvironment
+Remove-PnPFlowOwner -environment $environment -Identity f07c34a9-a586-4e58-91fb-e7ea19741b61 -User username@tenant.onmicrosoft.com -AsAdmin
+```
+Removes the specified user email with owner access level to the specified flow as admin
+
+### Example 4
+```powershell
+$environment = Get-PnPPowerPlatformEnvironment
+Remove-PnPFlowOwner -environment $environment -Identity f07c34a9-a586-4e58-91fb-e7ea19741b61 -User username@tenant.onmicrosoft.com -AsAdmin -Force
+```
+Removes the specified user email with owner access level to the specified flow as admin, without confirmation
+
+## PARAMETERS
+
+### -Environment
+The name of the Power Platform environment or an Environment object to retrieve the available flows for.
+
+```yaml
+Type: PowerAutomateEnvironmentPipeBind
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: The default environment
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+The Name/Id of the flow to retrieve.
+
+```yaml
+Type: PowerPlatformPipeBind
+Parameter Sets: By Identity
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -User
+Returns the user with the provided user id or username.
+
+```yaml
+Type: String
+Parameter Sets: Return by specific ID/UserName
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+
+### -AsAdmin
+If specified returns all the flows as admin. If not specified only the flows for the current user will be returned.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+Specifying the Force parameter will skip the confirmation question.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/src/Commands/Enums/FlowUserRoleName.cs
+++ b/src/Commands/Enums/FlowUserRoleName.cs
@@ -1,0 +1,23 @@
+﻿namespace PnP.PowerShell.Commands.Enums
+{
+    /// <summary>
+    /// Scopes to which Access level for the user on the flow. 
+    /// </summary>
+    public enum FlowUserRoleName
+    {
+        /// <summary>
+        /// sets the view access level on the flow for the user/group
+        /// </summary>
+        CanView,
+
+        /// <summary>
+        /// sets the view with share access level on the flow for the user/group
+        /// </summary>
+        CanViewWithShare,
+
+        /// <summary>
+        /// sets the edit access level on the flow for the user/group
+        /// </summary>
+        CanEdit,
+    }
+}

--- a/src/Commands/PowerPlatform/PowerAutomate/AddFlowOwner.cs
+++ b/src/Commands/PowerPlatform/PowerAutomate/AddFlowOwner.cs
@@ -1,0 +1,94 @@
+﻿using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Base.PipeBinds;
+using PnP.PowerShell.Commands.Enums;
+using PnP.PowerShell.Commands.Utilities.REST;
+using System;
+using System.Management.Automation;
+using System.Net;
+
+namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
+{
+    [Cmdlet(VerbsCommon.Add, "PnPFlowOwner")]
+    public class AddFlowOwner : PnPAzureManagementApiCmdlet
+    {
+        private const string ParameterSet_BYID = "Return by specific ID/Username";
+
+        [Parameter(Mandatory = true)]
+        public PowerPlatformEnvironmentPipeBind Environment;
+
+        [Parameter(Mandatory = true)]
+        public PowerAutomateFlowPipeBind Identity;
+
+        [Parameter(Mandatory = true, ParameterSetName = ParameterSet_BYID)]
+        public string User;
+
+        [Parameter(Mandatory = true)]
+        public FlowUserRoleName RoleName = FlowUserRoleName.CanView;
+
+        [Parameter(Mandatory = false)]
+        public SwitchParameter AsAdmin;
+
+        protected override void ExecuteCmdlet()
+        {
+            string type = "User";
+            var environmentName = Environment.GetName();
+            if (string.IsNullOrEmpty(environmentName))
+            {
+                throw new PSArgumentException("Environment not found.");
+            }
+
+            var flowName = Identity.GetName();
+            if (string.IsNullOrEmpty(flowName))
+            {
+                throw new PSArgumentException("Flow not found.");
+            }
+
+            Guid idToAdd = Guid.Empty;
+            if (ParameterSpecified(nameof(User)))
+            {
+                var accessToken = TokenHandler.GetAccessToken(this, $"https://{Connection.GraphEndPoint}/.default", Connection);
+                PnP.PowerShell.Commands.Model.AzureAD.User user;
+                if (Guid.TryParse(User, out Guid identityGuid))
+                {
+                    user = PnP.PowerShell.Commands.Utilities.AzureAdUtility.GetUser(accessToken, identityGuid);
+                }
+                else
+                {
+                    user = PnP.PowerShell.Commands.Utilities.AzureAdUtility.GetUser(accessToken, WebUtility.UrlEncode(User));
+                }
+
+                if (user == null)
+                {
+                    throw new PSArgumentException("User not found.");
+                }
+                else
+                {
+                    idToAdd = (Guid)user.Id;
+                    //WriteObject($"Added {user.UserPrincipalName} to flow {flowName} with access level {RoleName}");
+                }
+            }
+
+
+            var payload = new
+            {
+                put = new[]
+                {
+                    new
+                    {
+                        properties = new
+                        {
+                            principal = new
+                            {
+                                id = idToAdd,
+                                type = type
+                            },
+                            roleName = RoleName
+                        }
+                    }
+                }
+            };
+
+            RestHelper.PostAsync(Connection.HttpClient, $"https://management.azure.com/providers/Microsoft.ProcessSimple{(AsAdmin ? "/scopes/admin" : "")}/environments/{environmentName}/flows/{flowName}/modifyPermissions?api-version=2016-11-01", AccessToken, payload).GetAwaiter().GetResult();
+        }
+    }
+}

--- a/src/Commands/PowerPlatform/PowerAutomate/RemoveFlowOwner.cs
+++ b/src/Commands/PowerPlatform/PowerAutomate/RemoveFlowOwner.cs
@@ -1,0 +1,87 @@
+﻿using AngleSharp.Css;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Base.PipeBinds;
+using PnP.PowerShell.Commands.Enums;
+using PnP.PowerShell.Commands.Utilities.REST;
+using System;
+using System.Management.Automation;
+using System.Net;
+
+namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
+{
+    [Cmdlet(VerbsCommon.Remove, "PnPFlowOwner")]
+    public class RemoveFlowOwner : PnPAzureManagementApiCmdlet
+    {
+        private const string ParameterSet_BYID = "Return by specific ID/Username";
+
+        [Parameter(Mandatory = true)]
+        public PowerPlatformEnvironmentPipeBind Environment;
+
+        [Parameter(Mandatory = true)]
+        public PowerAutomateFlowPipeBind Identity;
+
+        [Parameter(Mandatory = true, ParameterSetName = ParameterSet_BYID)]
+        public string User;
+
+        [Parameter(Mandatory = false)]
+        public SwitchParameter AsAdmin;
+
+        [Parameter(Mandatory = false)]
+        public SwitchParameter Force;
+
+        protected override void ExecuteCmdlet()
+        {
+            var environmentName = Environment.GetName();
+            if (string.IsNullOrEmpty(environmentName))
+            {
+                throw new PSArgumentException("Environment not found.");
+            }
+
+            var flowName = Identity.GetName();
+            if (string.IsNullOrEmpty(flowName))
+            {
+                throw new PSArgumentException("Flow not found.");
+            }
+
+            Guid idToRemove = Guid.Empty;
+            if (ParameterSpecified(nameof(User)))
+            {
+                var accessToken = TokenHandler.GetAccessToken(this, $"https://{Connection.GraphEndPoint}/.default", Connection);
+                PnP.PowerShell.Commands.Model.AzureAD.User user;
+                if (Guid.TryParse(User, out Guid identityGuid))
+                {
+                    user = PnP.PowerShell.Commands.Utilities.AzureAdUtility.GetUser(accessToken, identityGuid);
+                }
+                else
+                {
+                    user = PnP.PowerShell.Commands.Utilities.AzureAdUtility.GetUser(accessToken, WebUtility.UrlEncode(User));
+                }
+
+                if (user == null)
+                {
+                    throw new PSArgumentException("User not found.");
+                }
+                else
+                {
+                    idToRemove = (Guid)user.Id;
+                }
+            }
+
+            var payload = new
+            {
+                delete = new[]
+                {
+                    new
+                    {
+                        id = idToRemove,
+                    }
+                }
+            };
+
+            if(Force || ShouldContinue($"Remove flow owner with id '{idToRemove}' from flow '{flowName}'?", "Remove flow owner"))
+            {
+                RestHelper.PostAsync(Connection.HttpClient, $"https://management.azure.com/providers/Microsoft.ProcessSimple{(AsAdmin ? "/scopes/admin" : "")}/environments/{environmentName}/flows/{flowName}/modifyPermissions?api-version=2016-11-01", AccessToken, payload).GetAwaiter().GetResult();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #3335

## What is in this Pull Request ? ##
Added two new commands

# Add-PnPFlowOwner
Assigns/updates permissions to a Power Automate flow

### SYNTAX
```powershell
Add-PnPFlowOwner [-Environment <PowerAutomateEnvironmentPipeBind>] [-Identity <PowerPlatformPipeBind>] [-User <String>] [-AsAdmin] [-RoleName <FlowUserRoleName>]
```
### DESCRIPTION
This cmdlet assigns/updates permissions for a user to a power automate flow.

### EXAMPLES

### Example 1
```powershell
$environment = Get-PnPPowerPlatformEnvironment
Add-PnPFlowOwner -environment $environment -Identity f07c34a9-a586-4e58-91fb-e7ea19741b61 -User username@tenant.onmicrosoft.com -RoleName CanEdit
```
Assigns the specified useremail with 'CanEdit' access level to the specified flow

### Example 2
```powershell
$environment = Get-PnPPowerPlatformEnvironment
Add-PnPFlowOwner -environment $environment -Identity f07c34a9-a586-4e58-91fb-e7ea19741b61 -User 6844c04a-8ee7-40ad-af66-28f6e948cd04 -RoleName CanView
```
Assigns the specified user id with 'CanView' access level to the specified flow

### Example 3
```powershell
$environment = Get-PnPPowerPlatformEnvironment
Add-PnPFlowOwner -environment $environment -Identity f07c34a9-a586-4e58-91fb-e7ea19741b61 -User 6844c04a-8ee7-40ad-af66-28f6e948cd04 -RoleName CanViewWithShare
```
Assigns the specified user id with 'CanViewWithShare' access level to the specified flow

### Example 4
```powershell
$environment = Get-PnPPowerPlatformEnvironment
Add-PnPFlowOwner -environment $environment -Identity f07c34a9-a586-4e58-91fb-e7ea19741b61 -User username@tenant.onmicrosoft.com -AsAdmin -RoleName CanEdit
```
Assigns the specified useremail with 'CanEdit' access level to the specified flow as admin

# Remove-PnPFlowOwner
Removes owner permissions to a Power Automate flow

## SYNTAX
```powershell
Remove-PnPFlowOwner [-Environment <PowerAutomateEnvironmentPipeBind>] [-Identity <PowerPlatformPipeBind>] [-User <String>] [-AsAdmin] [-Force]
```

## DESCRIPTION
This cmdlet removes owner permissions for a user to a power automate flow.

## EXAMPLES

### Example 1
```powershell
$environment = Get-PnPPowerPlatformEnvironment
Remove-PnPFlowOwner -environment $environment -Identity f07c34a9-a586-4e58-91fb-e7ea19741b61 -User username@tenant.onmicrosoft.com
```
Removes the specified user email with owner access level to the specified flow

### Example 2
```powershell
$environment = Get-PnPPowerPlatformEnvironment
Remove-PnPFlowOwner -environment $environment -Identity f07c34a9-a586-4e58-91fb-e7ea19741b61 -User 6844c04a-8ee7-40ad-af66-28f6e948cd04
```
Removes the specified user id with owner access level to the specified flow

### Example 3
```powershell
$environment = Get-PnPPowerPlatformEnvironment
Remove-PnPFlowOwner -environment $environment -Identity f07c34a9-a586-4e58-91fb-e7ea19741b61 -User username@tenant.onmicrosoft.com -AsAdmin
```
Removes the specified user email with owner access level to the specified flow as admin

### Example 4
```powershell
$environment = Get-PnPPowerPlatformEnvironment
Remove-PnPFlowOwner -environment $environment -Identity f07c34a9-a586-4e58-91fb-e7ea19741b61 -User username@tenant.onmicrosoft.com -AsAdmin -Force
```
Removes the specified user email with owner access level to the specified flow as admin, without confirmation

## Summary 
<!-- cspell:disable-next-line -->
copilot:summary

## Details 
<!-- cspell:disable-next-line -->
copilot:walkthrough

Thanks,
Nishkalank Bezawada