### PR TITLE
Make New-PnPTeamsTeam work with Managed Identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `New-PnPTeamsTeam` cmdlet, it will now throw error if it fails to teamify a Microsoft 365 group. [#3310](https://github.com/pnp/powershell/pull/3310)
 - Fixed `Connect-PnPOnline` cmdlet throwing host not reachable errors. [#3337](https://github.com/pnp/powershell/pull/3337)
 - Fixed `Set-PnPTerm` cmdlet throwing object reference error when only the term Id is specified. [#3341](https://github.com/pnp/powershell/pull/3341)
+- Fixed `New-PnPTeamsTeam` cmdlet throwing an error when specifying members [#3351](https://github.com/pnp/powershell/pull/3351)
+- Fixed `New-PnPTeamsTeam` cmdlet not working well with a managed identity [#3351](https://github.com/pnp/powershell/pull/3351)
 
 ### Changed
 
@@ -47,6 +49,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Contributors
 
+- Carl Joakim Damsleth [damsleth]
 - Rodel Pacurib [ryder-cayden]
 - [CatSchneider]
 - [msjennywu]

--- a/src/Commands/Utilities/TeamsUtility.cs
+++ b/src/Commands/Utilities/TeamsUtility.cs
@@ -195,33 +195,6 @@ namespace PnP.PowerShell.Commands.Utilities
             }
             if (group != null)
             {
-                // Construct a list of all owners and members to add
-                var teamOwnersAndMembers = new List<TeamChannelMember>();
-                if (owners != null && owners.Length > 0)
-                {
-                    foreach (var owner in owners)
-                    {
-                        teamOwnersAndMembers.Add(new TeamChannelMember { Roles = new List<string> { "owner" }, UserIdentifier = $"https://{connection.GraphEndPoint}/v1.0/users('{owner}')" });
-                    }
-                }
-
-                if (members != null && members.Length > 0)
-                {
-                    foreach (var member in members)
-                    {
-                        teamOwnersAndMembers.Add(new TeamChannelMember { Roles = new List<string>(), UserIdentifier = $"https://{connection.GraphEndPoint}/v1.0/users('{member}')" });
-                    }
-                }
-
-                if (teamOwnersAndMembers.Count > 0)
-                {
-                    var ownersAndMembers = BatchUtility.Chunk(teamOwnersAndMembers, 200);
-                    foreach (var chunk in ownersAndMembers)
-                    {
-                        await GraphHelper.PostAsync(connection, $"v1.0/teams/{group.Id}/members/add", new { values = chunk.ToList() }, accessToken);
-                    }
-                }
-                
                 Team team = teamCI.ToTeam(group.Visibility.Value);
                 var retry = true;
                 var iteration = 0;
@@ -251,7 +224,34 @@ namespace PnP.PowerShell.Commands.Utilities
                     {
                         retry = false;
                     }
-                }                
+                }
+
+                // Construct a list of all owners and members to add
+                var teamOwnersAndMembers = new List<TeamChannelMember>();
+                if (owners != null && owners.Length > 0)
+                {
+                    foreach (var owner in owners)
+                    {
+                        teamOwnersAndMembers.Add(new TeamChannelMember { Roles = new List<string> { "owner" }, UserIdentifier = $"https://{connection.GraphEndPoint}/v1.0/users('{owner}')" });
+                    }
+                }
+
+                if (members != null && members.Length > 0)
+                {
+                    foreach (var member in members)
+                    {
+                        teamOwnersAndMembers.Add(new TeamChannelMember { Roles = new List<string>(), UserIdentifier = $"https://{connection.GraphEndPoint}/v1.0/users('{member}')" });
+                    }
+                }
+
+                if (teamOwnersAndMembers.Count > 0)
+                {
+                    var ownersAndMembers = BatchUtility.Chunk(teamOwnersAndMembers, 200);
+                    foreach (var chunk in ownersAndMembers)
+                    {
+                        await GraphHelper.PostAsync(connection, $"v1.0/teams/{group.Id}/members/add", new { values = chunk.ToList() }, accessToken);
+                    }
+                }
             }
             return returnTeam;
         }
@@ -293,7 +293,7 @@ namespace PnP.PowerShell.Commands.Utilities
             }
 
             // Check if by now we've identified a user Id to become the owner
-            if (!string.IsNullOrEmpty(ownerId))
+            if (string.IsNullOrEmpty(ownerId))
             {
                 var contextSettings = connection.Context.GetContextSettings();
 


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #2977, #1807 

## What is in this Pull Request ? ##
* Adds team owners and members _after_ team creation, since calling the `/teams/{group.Id}/members/add` endpoint when there is no team fails with `New-PnPTeamsTeam: Not Found (404): No Team found with Group id: {groupId}`
* Inverts the boolean on [L296](https://github.com/pnp/powershell/blob/ccee58d064da543e40a4a7a872ad9574f8a108ed/src/Commands/Utilities/TeamsUtility.cs#L296) in TeamsUtility.cs, avoiding calls to the `/me` endpoint when an owner is already resolved. This is particularly useful when using a managed identity, since `/me` calls are only valid with a delegated auth flow.