### PR TITLE
[FileVersion] Add set site version policy commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `-SharingStatus` parameter to `Get-PnPFlow` which allows for filtering flows based on their sharing status. [#3287](https://github.com/pnp/powershell/pull/3287)
 - Added `-AzureADLoginEndPoint` and `-MicrosoftGraphEndPoint` parameters to `Connect-PnPOnline` cmdlet for use in custom Azure environments. [#2925](https://github.com/pnp/powershell/pull/2925)
 - Added `SiteOwnerManageLegacyServicePrincipalEnabled` parameter to `Set-PnPTenant` cmdlet. With this parameter site owners will not be able to register/update apps unless the tenant admin explicitly allows it. [#3318](https://github.com/pnp/powershell/pull/3318)
-
+- Added `-EnableAutoExpirationVersionTrim`, `-ExpireVersionsAfterDays`, `-MajorVersions`, `-MinorVersions`, `-InheritTenantVersionPolicySettings`, `-StartApplyVersionPolicySettingToExistingDocLibs` and `-CancelApplyVersionPolicySettingToExistingDocLibs` to `Set-PnPSite` to allow for time based version expiration on the site level [#3373](https://github.com/pnp/powershell/pull/3373)
+  
 ### Fixed
 
 - Fixed `Add-PnPContentTypeToList` cmdlet to better handle piped lists. [#3244](https://github.com/pnp/powershell/pull/3244)
@@ -45,6 +46,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Contributors
 
+- [msjennywu]
 - Reshmee Auckloo [reshmee011]
 - Per Østergaard [per-oestergaard]
 - Nishkalank Bezawada [NishkalankBezawada]

--- a/documentation/Set-PnPSite.md
+++ b/documentation/Set-PnPSite.md
@@ -47,6 +47,13 @@ Set-PnPSite [-Identity <String>]
  [-BlockDownloadPolicy <Boolean>] [-ExcludeBlockDownloadPolicySiteOwners <Boolean>]
  [-ExcludedBlockDownloadGroupIds <Guid[]>]
  [-ListsShowHeaderAndNavigation <Boolean>]
+ [-EnableAutoExpirationVersionTrim <Boolean>]
+ [-ExpireVersionsAfterDays <UInt32>]
+ [-MajorVersions <UInt32>]
+ [-MinorVersions <UInt32>]
+ [-InheritTenantVersionPolicySettings]
+ [-StartApplyVersionPolicySettingToExistingDocLibs]
+ [-CancelApplyVersionPolicySettingToExistingDocLibs]
  [-Connection <PnPConnection>]
 ```
 
@@ -102,6 +109,62 @@ Set-PnPSite -NoScriptSite $false
 ```
 
 Allows custom script on a specific site. See [Allow or prevent custom script](https://learn.microsoft.com/sharepoint/allow-or-prevent-custom-script) for more information.
+
+### EXAMPLE 7
+```powershell
+Set-PnPSite -EnableAutoExpirationVersionTrim $true
+```
+
+Set AutoExpiration file version trim mode for a site. The new document libraries will use this version setting.
+
+### EXAMPLE 8
+```powershell
+Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 100 -ExpireVersionsAfterDays 200
+```
+
+Set ExpireAfter file version trim mode for a site. The new document libraries will use this version setting.
+
+### EXAMPLE 9
+```powershell
+Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 300 -ExpireVersionsAfterDays 0
+```
+
+Set NoExpiration file version trim mode for a site. The new document libraries will use this version setting.
+
+### EXAMPLE 10
+```powershell
+Set-PnPSite -InheritTenantVersionPolicySettings
+```
+
+Clear the file version setting on a site. The new document libraries will use the tenant level setting.
+
+### EXAMPLE 11
+```powershell
+Set-PnPSite -EnableAutoExpirationVersionTrim $true -StartApplyVersionPolicySettingToExistingDocLibs
+```
+
+Create a request to set the file version trim mode as AutoExpiration for existing document libraries that enabled versioning.
+
+### EXAMPLE 12
+```powershell
+Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 100 -MinorVersions 5 -ExpireVersionsAfterDays 200 -StartApplyVersionPolicySettingToExistingDocLibs
+```
+
+Create a request to set the file version trim mode as ExpireAfter for existing document libraries that enabled versioning.
+
+### EXAMPLE 13
+```powershell
+Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 100 -MinorVersions 5 -ExpireVersionsAfterDays 0 -StartApplyVersionPolicySettingToExistingDocLibs
+```
+
+Create a request to set the file version trim mode as NoExpiration for existing document libraries that enabled versioning.
+
+### EXAMPLE 14
+```powershell
+Set-PnPSite -CancelApplyVersionPolicySettingToExistingDocLibs
+```
+
+Cancel the existing request which sets the file version trim mode for existing document libraries on a site.
 
 ## PARAMETERS
 
@@ -605,6 +668,109 @@ Wait for the operation to complete
 ```yaml
 Type: SwitchParameter
 Parameter Sets: Set Lock State
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableAutoExpirationVersionTrim
+Enable or disable AutoExpiration version trim for the document libraries on the site. Set to $true to enable, $false to disable.
+
+Parameter ExpireVersionsAfterDays is required when EnableAutoExpirationVersionTrim is false. Set it to 0 for NoExpiration, set it to greater or equal to 30 for ExpireAfter.
+
+Parameter MajorVersions is required when EnableAutoExpirationVersionTrim is false.
+Parameter MinorVersions is required when EnableAutoExpirationVersionTrim is false and StartApplyVersionPolicySettingToExistingDocLibs is specified. It is used when minor version is enabled on the document libraries.
+
+```yaml
+Type: Boolean
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExpireVersionsAfterDays
+Work with parameter EnableAutoExpirationVersionTrim. Please see description in EnableAutoExpirationVersionTrim.
+
+```yaml
+Type: UInt32
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MajorVersions
+Work with parameter EnableAutoExpirationVersionTrim. Please see description in EnableAutoExpirationVersionTrim.
+
+```yaml
+Type: UInt32
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MinorVersions
+Work with parameter EnableAutoExpirationVersionTrim and StartApplyVersionPolicySettingToExistingDocLibs. Please see description in EnableAutoExpirationVersionTrim.
+
+```yaml
+Type: UInt32
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InheritTenantVersionPolicySettings
+Clear the file version setting on a site. The new document libraries will use the tenant level setting.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -StartApplyVersionPolicySettingToExistingDocLibs
+Create a request to set the file version trim mode for existing document libraries that enabled versioning. Work with parameters EnableAutoExpirationVersionTrim, ExpireVersionsAfterDays, MajorVersions and MinorVersions.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CancelApplyVersionPolicySettingToExistingDocLibs
+Cancel the existing request which sets the file version trim mode for existing document libraries on a site.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Set Properties
 
 Required: False
 Position: Named


### PR DESCRIPTION
<!-- The PnP PowerShell team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## What is in this Pull Request ? ##
Add changes to let the Set-PnPSite supports to set version policy on site level.

# Valid scenarios
Set-PnPSite -EnableAutoExpirationVersionTrim $true
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 101 -ExpireVersionsAfterDays 201
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 300 -ExpireVersionsAfterDays 0
Set-PnPSite -InheritTenantVersionPolicySettings
Set-PnPSite -EnableAutoExpirationVersionTrim $true -StartApplyVersionPolicySettingToExistingDocLibs
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 102 -MinorVersions 52 -ExpireVersionsAfterDays 202 -StartApplyVersionPolicySettingToExistingDocLibs
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 300 -MinorVersions 70 -ExpireVersionsAfterDays 0 -StartApplyVersionPolicySettingToExistingDocLibs
Set-PnPSite -CancelApplyVersionPolicySettingToExistingDocLibs

# Invalid scenarios
--The VersionPolicy related parameters (EnableAutoExpirationVersionTrim, ExpireVersionsAfterDays, MajorVersions, MinorVersions StartApplyVersionPolicySettingToExistingDocLibs, CancelApplyVersionPolicySettingToExistingDocLibs) cannot be set when InheritTenantVersionPolicySettings is specified.
Set-PnPSite -InheritTenantVersionPolicySettings -EnableAutoExpirationVersionTrim $true
Set-PnPSite -InheritTenantVersionPolicySettings -MajorVersions 100
Set-PnPSite -InheritTenantVersionPolicySettings -MinorVersions 50
Set-PnPSite -InheritTenantVersionPolicySettings -ExpireVersionsAfterDays 100
Set-PnPSite -InheritTenantVersionPolicySettings -StartApplyVersionPolicySettingToExistingDocLibs
Set-PnPSite -InheritTenantVersionPolicySettings -CancelApplyVersionPolicySettingToExistingDocLibs

--The VersionPolicy related parameters (EnableAutoExpirationVersionTrim, ExpireVersionsAfterDays, MajorVersions, MinorVersions) cannot be set when CancelApplyVersionPolicySettingToExistingDocLibs is specified.
Set-PnPSite -CancelApplyVersionPolicySettingToExistingDocLibs -EnableAutoExpirationVersionTrim $true
Set-PnPSite -CancelApplyVersionPolicySettingToExistingDocLibs -MajorVersions 100
Set-PnPSite -CancelApplyVersionPolicySettingToExistingDocLibs -MinorVersions 100
Set-PnPSite -CancelApplyVersionPolicySettingToExistingDocLibs -ExpireVersionsAfterDays 100

--Don't specify both StartApplyVersionPolicySettingToExistingDocLibs and CancelApplyVersionPolicySettingToExistingDocLibs.
Set-PnPSite -CancelApplyVersionPolicySettingToExistingDocLibs -StartApplyVersionPolicySettingToExistingDocLibs

--You must specify EnableAutoExpirationVersionTrim when StartApplyVersionPolicySettingToExistingDocLibs is specified
Set-PnPSite -StartApplyVersionPolicySettingToExistingDocLibs

--You must specify ExpireVersionsAfterDays, MajorVersions and MinorVersions when EnableAutoExpirationVersionTrim is false.
Set-PnPSite -EnableAutoExpirationVersionTrim $false -StartApplyVersionPolicySettingToExistingDocLibs
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 100 -StartApplyVersionPolicySettingToExistingDocLibs
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MinorVersions 200 -StartApplyVersionPolicySettingToExistingDocLibs
Set-PnPSite -EnableAutoExpirationVersionTrim $false -ExpireVersionsAfterDays 200 -StartApplyVersionPolicySettingToExistingDocLibs
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 300 -MinorVersions 70 -StartApplyVersionPolicySettingToExistingDocLibs
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 300  -ExpireVersionsAfterDays 0 -StartApplyVersionPolicySettingToExistingDocLibs
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MinorVersions 70 -ExpireVersionsAfterDays 0 -StartApplyVersionPolicySettingToExistingDocLibs

--Don't specify both ExpireVersionsAfterDays and MajorVersions when EnableAutoExpirationVersionTrim is true.
Set-PnPSite -EnableAutoExpirationVersionTrim $true -MajorVersions 100
Set-PnPSite -EnableAutoExpirationVersionTrim $true -ExpireVersionsAfterDays 200
Set-PnPSite -EnableAutoExpirationVersionTrim $true -MajorVersions 100 -ExpireVersionsAfterDays 200

--You must specify both ExpireVersionsAfterDays and MajorVersions when EnableAutoExpirationVersionTrim is false.
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 100
Set-PnPSite -EnableAutoExpirationVersionTrim $false -ExpireVersionsAfterDays 200

--Don't specify MinorVersions when StartApplyVersionPolicySettingToExistingDocLibs is not specified.
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 100 -MinorVersions 40 -ExpireVersionsAfterDays 200
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MinorVersions 40 -ExpireVersionsAfterDays 200
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 100 -MinorVersions 40




