### PR TITLE
[FileVersion] Revision for set file version on site command

### DIFF
--- a/documentation/Set-PnPSite.md
+++ b/documentation/Set-PnPSite.md
@@ -51,9 +51,10 @@ Set-PnPSite [-Identity <String>]
  [-ExpireVersionsAfterDays <UInt32>]
  [-MajorVersions <UInt32>]
  [-MinorVersions <UInt32>]
- [-InheritTenantVersionPolicySettings]
- [-StartApplyVersionPolicySettingToExistingDocLibs]
- [-CancelApplyVersionPolicySettingToExistingDocLibs]
+ [-InheritTenantVPForNewDocLibs]
+ [-ApplyForNewLibs]
+ [-ApplyForExistingLibs]
+ [-CancelVPForExistingLibs]
  [-Connection <PnPConnection>]
 ```
 
@@ -115,53 +116,74 @@ Allows custom script on a specific site. See [Allow or prevent custom script](ht
 Set-PnPSite -EnableAutoExpirationVersionTrim $true
 ```
 
-Set AutoExpiration file version trim mode for a site. The new document libraries will use this version setting.
+Set AutoExpiration file version trim mode for a site. The new document libraries will use this version setting. Also create a request to set the file version trim mode as AutoExpiration for existing document libraries that enabled versioning.
 
 ### EXAMPLE 8
 ```powershell
-Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 100 -ExpireVersionsAfterDays 200
+Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 100 -MinorVersions 10 -ExpireVersionsAfterDays 200
 ```
 
-Set ExpireAfter file version trim mode for a site. The new document libraries will use this version setting.
+Set ExpireAfter file version trim mode for a site. The new document libraries will use this version setting. Also create a request to set the file version trim mode as ExpireAfter for existing document libraries that enabled versioning.
 
 ### EXAMPLE 9
 ```powershell
-Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 300 -ExpireVersionsAfterDays 0
+Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 300 -MinorVersions 20 -ExpireVersionsAfterDays 0
 ```
 
-Set NoExpiration file version trim mode for a site. The new document libraries will use this version setting.
+Set NoExpiration file version trim mode for a site. The new document libraries will use this version setting. Also create a request to set the file version trim mode as NoExpiration for existing document libraries that enabled versioning.
 
 ### EXAMPLE 10
 ```powershell
-Set-PnPSite -InheritTenantVersionPolicySettings
+Set-PnPSite -InheritTenantVPForNewDocLibs
 ```
 
 Clear the file version setting on a site. The new document libraries will use the tenant level setting.
 
 ### EXAMPLE 11
 ```powershell
-Set-PnPSite -EnableAutoExpirationVersionTrim $true -StartApplyVersionPolicySettingToExistingDocLibs
+Set-PnPSite -EnableAutoExpirationVersionTrim $true -ApplyForNewLibs
+```
+
+Set AutoExpiration file version trim mode for a site. The new document libraries will use this version setting.
+
+### EXAMPLE 12
+```powershell
+Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 100 -ExpireVersionsAfterDays 200 -ApplyForNewLibs
+```
+
+Set ExpireAfter file version trim mode for a site. The new document libraries will use this version setting.
+
+### EXAMPLE 13
+```powershell
+Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 300 -ExpireVersionsAfterDays 0 -ApplyForNewLibs
+```
+
+Set NoExpiration file version trim mode for a site. The new document libraries will use this version setting.
+
+### EXAMPLE 14
+```powershell
+Set-PnPSite -EnableAutoExpirationVersionTrim $true -ApplyForExistingLibs
 ```
 
 Create a request to set the file version trim mode as AutoExpiration for existing document libraries that enabled versioning.
 
-### EXAMPLE 12
+### EXAMPLE 15
 ```powershell
-Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 100 -MinorVersions 5 -ExpireVersionsAfterDays 200 -StartApplyVersionPolicySettingToExistingDocLibs
+Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 100 -MinorVersions 5 -ExpireVersionsAfterDays 200 -ApplyForExistingLibs
 ```
 
 Create a request to set the file version trim mode as ExpireAfter for existing document libraries that enabled versioning.
 
-### EXAMPLE 13
+### EXAMPLE 16
 ```powershell
-Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 100 -MinorVersions 5 -ExpireVersionsAfterDays 0 -StartApplyVersionPolicySettingToExistingDocLibs
+Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 100 -MinorVersions 5 -ExpireVersionsAfterDays 0 -ApplyForExistingLibs
 ```
 
 Create a request to set the file version trim mode as NoExpiration for existing document libraries that enabled versioning.
 
-### EXAMPLE 14
+### EXAMPLE 17
 ```powershell
-Set-PnPSite -CancelApplyVersionPolicySettingToExistingDocLibs
+Set-PnPSite -CancelVPForExistingLibs
 ```
 
 Cancel the existing request which sets the file version trim mode for existing document libraries on a site.
@@ -682,7 +704,8 @@ Enable or disable AutoExpiration version trim for the document libraries on the 
 Parameter ExpireVersionsAfterDays is required when EnableAutoExpirationVersionTrim is false. Set it to 0 for NoExpiration, set it to greater or equal to 30 for ExpireAfter.
 
 Parameter MajorVersions is required when EnableAutoExpirationVersionTrim is false.
-Parameter MinorVersions is required when EnableAutoExpirationVersionTrim is false and StartApplyVersionPolicySettingToExistingDocLibs is specified. It is used when minor version is enabled on the document libraries.
+
+Parameter MinorVersions is required when EnableAutoExpirationVersionTrim is false and the setting is for document libraries that including existing ones. It is used when minor version is enabled on the document libraries.
 
 ```yaml
 Type: Boolean
@@ -724,7 +747,7 @@ Accept wildcard characters: False
 ```
 
 ### -MinorVersions
-Work with parameter EnableAutoExpirationVersionTrim and StartApplyVersionPolicySettingToExistingDocLibs. Please see description in EnableAutoExpirationVersionTrim.
+Work with parameter EnableAutoExpirationVersionTrim. Please see description in EnableAutoExpirationVersionTrim.
 
 ```yaml
 Type: UInt32
@@ -737,7 +760,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -InheritTenantVersionPolicySettings
+### -InheritTenantVPForNewDocLibs
 Clear the file version setting on a site. The new document libraries will use the tenant level setting.
 
 ```yaml
@@ -751,7 +774,21 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -StartApplyVersionPolicySettingToExistingDocLibs
+### -ApplyForNewLibs
+Set site version policy for new document libraries. Work with parameters EnableAutoExpirationVersionTrim, ExpireVersionsAfterDays, MajorVersions and MinorVersions.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ApplyForExistingLibs
 Create a request to set the file version trim mode for existing document libraries that enabled versioning. Work with parameters EnableAutoExpirationVersionTrim, ExpireVersionsAfterDays, MajorVersions and MinorVersions.
 
 ```yaml
@@ -765,7 +802,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -CancelApplyVersionPolicySettingToExistingDocLibs
+### -CancelVPForExistingLibs
 Cancel the existing request which sets the file version trim mode for existing document libraries on a site.
 
 ```yaml


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [x] Revision
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample

## What is in this Pull Request ? ##
Revision for the set site version policy commands

## Test scenarios ##

----Valid scenarios----
----Apply to both new and existing doc libs
--AutoExpiration
Set-PnPSite -EnableAutoExpirationVersionTrim $true
Set-PnPSite -EnableAutoExpirationVersionTrim $true -ApplyForNewLibs -ApplyForExistingLibs

--ExpireAfter
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 100 -MinorVersions 10 -ExpireVersionsAfterDays 200
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 101 -MinorVersions 11 -ExpireVersionsAfterDays 201 -ApplyForNewLibs -ApplyForExistingLibs

--NoExpiration
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 300 -MinorVersions 20 -ExpireVersionsAfterDays 0
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 300 -MinorVersions 11 -ExpireVersionsAfterDays 0 -ApplyForNewLibs -ApplyForExistingLibs


--Apply to new doc libs only
--AutoExpiration
Set-PnPSite -EnableAutoExpirationVersionTrim $true -ApplyForNewLibs

--ExpireAfter
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 100 -ExpireVersionsAfterDays 200 -ApplyForNewLibs

--NoExpiration
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 300 -ExpireVersionsAfterDays 0 -ApplyForNewLibs

--Clear
Set-PnPSite -InheritTenantVPForNewDocLibs

----Apply to existing doc libs only
--AutoExpiration
Set-PnPSite -EnableAutoExpirationVersionTrim $true -ApplyForExistingLibs

--ExpireAfter
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 101 -MinorVersions 11 -ExpireVersionsAfterDays 201 -ApplyForExistingLibs

--NoExpiration
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 300 -MinorVersions 11 -ExpireVersionsAfterDays 0 -ApplyForExistingLibs

--Cancel request for existing doc libs
Set-PnPSite -CancelVPForExistingLibs

---- Invalid scenarios----
--(1) Don't specify version policy related parameters (EnableAutoExpirationVersionTrim, ExpireVersionsAfterDays, MajorVersions, MinorVersions, ApplyForNewLibs, ApplyForExistingLibs, CancelVPForExistingLibs) when InheritTenantVPForNewDocLibs is specified.
Set-PnPSite -InheritTenantVPForNewDocLibs -EnableAutoExpirationVersionTrim $true
Set-PnPSite -InheritTenantVPForNewDocLibs -MajorVersions 100
Set-PnPSite -InheritTenantVPForNewDocLibs -MinorVersions 50
Set-PnPSite -InheritTenantVPForNewDocLibs -ExpireVersionsAfterDays 100
Set-PnPSite -InheritTenantVPForNewDocLibs -ApplyForNewLibs
Set-PnPSite -InheritTenantVPForNewDocLibs -ApplyForExistingLibs
Set-PnPSite -InheritTenantVPForNewDocLibs -CancelVPForExistingLibs

--(2) Don't specify the VersionPolicy related parameters (ApplyForNewLibs, ApplyForExistingLibs, EnableAutoExpirationVersionTrim, ExpireVersionsAfterDays, MajorVersions) when CancelVPForExistingLibs is specified.
Set-PnPSite -CancelVPForExistingLibs -ApplyForNewLibs
Set-PnPSite -CancelVPForExistingLibs -ApplyForExistingLibs
Set-PnPSite -CancelVPForExistingLibs -EnableAutoExpirationVersionTrim $true
Set-PnPSite -CancelVPForExistingLibs -MajorVersions 100
Set-PnPSite -CancelVPForExistingLibs -MinorVersions 100
Set-PnPSite -CancelVPForExistingLibs -ExpireVersionsAfterDays 100

--(3) Don't specify ExpireVersionsAfterDays, MajorVersions and MinorVersions when EnableAutoExpirationVersionTrim is true.
Set-PnPSite -EnableAutoExpirationVersionTrim $true -MajorVersions 100
Set-PnPSite -EnableAutoExpirationVersionTrim $true -MinorVersions 5
Set-PnPSite -EnableAutoExpirationVersionTrim $true -ExpireVersionsAfterDays 200
Set-PnPSite -EnableAutoExpirationVersionTrim $true -MajorVersions 100 -ExpireVersionsAfterDays 200
Set-PnPSite -EnableAutoExpirationVersionTrim $true -MajorVersions 100 -ExpireVersionsAfterDays 200 -MinorVersions 5

--(4) You must specify ExpireVersionsAfterDays, MajorVersions and don't specify MinorVersions when EnableAutoExpirationVersionTrim is false for new document libraries only.
Set-PnPSite -ApplyForNewLibs -EnableAutoExpirationVersionTrim $false
Set-PnPSite -ApplyForNewLibs -EnableAutoExpirationVersionTrim $false -ExpireVersionsAfterDays 100 -MajorVersions 200 -MinorVersions 5
Set-PnPSite -ApplyForNewLibs -EnableAutoExpirationVersionTrim $false -MinorVersions 5

--(5) You must specify ExpireVersionsAfterDays, MajorVersions and MinorVersions when EnableAutoExpirationVersionTrim is false for document libraries that including existing ones.
Set-PnPSite -EnableAutoExpirationVersionTrim $false -ApplyForExistingLibs
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 100 -ApplyForExistingLibs
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MinorVersions 200 -ApplyForExistingLibs
Set-PnPSite -EnableAutoExpirationVersionTrim $false -ExpireVersionsAfterDays 200 -ApplyForExistingLibs
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 300 -MinorVersions 70 -ApplyForExistingLibs
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 300  -ExpireVersionsAfterDays 0 -ApplyForExistingLibs
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MinorVersions 70 -ExpireVersionsAfterDays 0 -ApplyForExistingLibs

Set-PnPSite -EnableAutoExpirationVersionTrim $false
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 100
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MinorVersions 200
Set-PnPSite -EnableAutoExpirationVersionTrim $false -ExpireVersionsAfterDays 200
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 300 -MinorVersions 70
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MajorVersions 300  -ExpireVersionsAfterDays 0
Set-PnPSite -EnableAutoExpirationVersionTrim $false -MinorVersions 70 -ExpireVersionsAfterDays 0

--(6) You must specify EnableAutoExpirationVersionTrim and other version policy related parameters (ExpireVersionsAfterDays, MajorVersions, MinorVersions) when ApplyForNewLibs or ApplyForExistingLibs is specified.
Set-PnPSite -ApplyForNewLibs
Set-PnPSite -ApplyForExistingLibs

--(7) You must specify EnableAutoExpirationVersionTrim when ExpireVersionsAfterDays, MajorVersions or MinorVersions is specified.
Set-PnPSite -ExpireVersionsAfterDays 100
Set-PnPSite -MajorVersions 300
Set-PnPSite -MinorVersions 10

