### PR TITLE
Adding creation of cmdlet pages for alias cmdlets

### DIFF
--- a/build/Build-HelpFile.ps1
+++ b/build/Build-HelpFile.ps1
@@ -15,15 +15,20 @@ Try {
 		Write-Host "Importing PnP PowerShell assembly from $pnpDllLocation"
 		Import-Module -Name $pnpDllLocation -DisableNameChecking
 		$cmdlets = Get-Command -Module PnP.PowerShell | Where-Object CommandType -eq "Alias" | Select-Object -Property @{N="Alias";E={$_.Name}}, @{N="ReferencedCommand";E={$_.ReferencedCommand.Name}}
+		$cmdlets
 	}
 	$aliasCmdlets = Start-ThreadJob -ScriptBlock $scriptBlock | Receive-Job -Wait
 
-	$aliasTemplatePageContent = Get-Content -Path "./dev/pages/cmdlets/alias.md" -Raw
+	Write-Host "  - $($aliasCmdlets.Length) found" -ForegroundColor Yellow
+
+	$aliasTemplatePageContent = Get-Content -Path "../pages/cmdlets/alias.md" -Raw
 
 	ForEach($aliasCmdlet in $aliasCmdlets)
 	{
-		$aliasTemplatePageContent.Replace("%%cmdletname%%", $aliasCmdlet.Alias).Replace("%%referencedcmdletname%%", $aliasCmdlet.ReferencedCommand)`
-		| Out-File "./../documentation/$($aliasCmdlet.Alias).md"
+		$destinationFileName = "./../documentation/$($aliasCmdlet.Alias).md"
+
+		Write-Host "    - Creating page for $($aliasCmdlet.Alias) being an alias for $($aliasCmdlet.ReferencedCommand) as $destinationFileName" -ForegroundColor Yellow
+		$aliasTemplatePageContent.Replace("%%cmdletname%%", $aliasCmdlet.Alias).Replace("%%referencedcmdletname%%", $aliasCmdlet.ReferencedCommand) | Out-File $destinationFileName -Force
 	}
 }
 Catch {

--- a/build/Build-HelpFile.ps1
+++ b/build/Build-HelpFile.ps1
@@ -6,6 +6,31 @@ if($IsLinux -or $isMacOS)
 	$destinationFolder = "$documentsFolder\PowerShell\Modules\PnP.PowerShell"
 }
 
+Try {
+	Write-Host "Generating documentation files for alias cmdlets" -ForegroundColor Yellow
+	# Load the Module in a new PowerShell session
+	$scriptBlock = {
+		$pnpDllLocation = "$($using:destinationFolder)/Core/PnP.PowerShell.dll"
+
+		Write-Host "Importing PnP PowerShell assembly from $pnpDllLocation"
+		Import-Module -Name $pnpDllLocation -DisableNameChecking
+		$cmdlets = Get-Command -Module PnP.PowerShell | Where-Object CommandType -eq "Alias" | Select-Object -Property @{N="Alias";E={$_.Name}}, @{N="ReferencedCommand";E={$_.ReferencedCommand.Name}}
+	}
+	$aliasCmdlets = Start-ThreadJob -ScriptBlock $scriptBlock | Receive-Job -Wait
+
+	$aliasTemplatePageContent = Get-Content -Path "./dev/pages/cmdlets/alias.md" -Raw
+
+	ForEach($aliasCmdlet in $aliasCmdlets)
+	{
+		$aliasTemplatePageContent.Replace("%%cmdletname%%", $aliasCmdlet.Alias).Replace("%%referencedcmdletname%%", $aliasCmdlet.ReferencedCommand)`
+		| Out-File "./../documentation/$($aliasCmdlet.Alias).md"
+	}
+}
+Catch {
+	Write-Host "Error: Cannot generate alias documentation files"
+	exit 1
+}
+
 $tempFolder = [System.IO.Path]::GetTempPath()
 
 $runsInAction = $("$env:RUNSINACTION")

--- a/pages/Build-Site.ps1
+++ b/pages/Build-Site.ps1
@@ -78,7 +78,7 @@ foreach ($nightlycmdlet in $nightlycmdlets) {
 
 # Generate cmdlet toc
 
-$cmdletPages = Get-ChildItem -Path "./dev/pages/cmdlets/*.md" -Exclude "index.md"
+$cmdletPages = Get-ChildItem -Path "./dev/pages/cmdlets/*.md" -Exclude "index.md","alias.md"
 $toc = ""
 foreach ($cmdletPage in $cmdletPages) {
     $toc = $toc + "- name: $($cmdletPage.BaseName)`n  href: $($cmdletPage.Name)`n"

--- a/pages/cmdlets/alias.md
+++ b/pages/cmdlets/alias.md
@@ -1,0 +1,17 @@
+---
+Module Name: PnP.PowerShell
+title: %%cmdletname%%
+schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/%%cmdletname%%.html
+---
+ 
+# %%cmdletname%%
+
+## SYNOPSIS
+This is an alias for [%%referencedcmdletname%%](./%%referencedcmdletname%%.md)
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
This script change will automatically generate help pages for the aliases set on cmdlets pointing to the cmdlet for which it is an alias