### PR TITLE
Improved exception handling when using `-ValidateConnection` with `Connect-PnPOnline`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - The `Publish-PnPCompanyApp` cmdlet is now obsolete. It will be removed in the next version. [#3349](https://github.com/pnp/powershell/pull/3349)
 - Verbose output will no longer show the access token [#3352](https://github.com/pnp/powershell/pull/3352)
 - Improved `Add-PnPFile` cmdlet. It will now automatically checkout the file if `-CheckinType` parameter is specified. [#3403](https://github.com/pnp/powershell/pull/3403)
+- Improved the error message thrown when using `-ValidateConnection` with `Connect-PnPOnline` and it failing due to i.e. an expired ClientSecret so the reason of the failed connect becomes more clear
 
 ### Removed
 


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample
- [X] Optimization

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Changed the implementation of `-ValidateConnection` on `Connect-PnPOnline` so instead of throwing a generic unclear error message, it will return the actual reason of the validation failing. I.e. for an expired client secret it will now return:

```
Connect-PnPOnline: ProtocolError: The remote server returned an error: (401) Unauthorized. Response received: {"error":"invalid_client","error_description":"AADSTS7000222: The provided client secret keys for app 'xxxxxxx-5020-46db-a07d-b2c3ca1dd94d' are expired. Visit the Azure portal to create new keys for your app: https://aka.ms/NewClientSecret, or consider using certificate credentials for added security: https://aka.ms/certCreds.\r\nTrace ID: xxxxxx-8f14-49e2-9a49-525618731c00\r\nCorrelation ID: xxxxx-62fb-4524-a314-e50866339b51\r\nTimestamp: 2023-09-26 14:02:13Z","error_codes":[7000222],"timestamp":"2023-09-26 14:02:13Z","trace_id":"xxxxx-8f14-49e2-9a49-525618731c00","correlation_id":"xxxxx-62fb-4524-a314-e50866339b51","error_uri":"https://accounts.accesscontrol.windows.net/error?code=7000222"}
```

as opposed to how it is now:

```
Connect-PnPOnline: Exception has been thrown by the target of an invocation.
```