### PR TITLE
Fix retrieving error detail in Get-UPABulkImportStatus

### DIFF
--- a/src/Commands/UserProfiles/GetUPABulkImportStatus.cs
+++ b/src/Commands/UserProfiles/GetUPABulkImportStatus.cs
@@ -48,7 +48,7 @@ namespace PnP.PowerShell.Commands.UserProfiles
             {
                 var webUrl = Web.GetWebUrlFromPageUrl(AdminContext, job.LogFolderUri);
                 AdminContext.ExecuteQueryRetry();
-                string relativePath = job.LogFolderUri.Replace(webUrl.Value, "");
+                string relativePath = new Uri(job.LogFolderUri).LocalPath;
                 var webCtx = AdminContext.Clone(webUrl.Value);
                 if (webCtx.Web.DoesFolderExists(relativePath))
                 {

--- a/src/Commands/UserProfiles/GetUPABulkImportStatus.cs
+++ b/src/Commands/UserProfiles/GetUPABulkImportStatus.cs
@@ -60,8 +60,21 @@ namespace PnP.PowerShell.Commands.UserProfiles
                     string message = string.Empty;
                     foreach (var logFile in files)
                         message += "\r\n" + webCtx.Web.GetFileAsString(logFile.ServerRelativeUrl);
-                    job.ErrorMessage = message;
+                    TrySetJobErrorMessage(job, message);
                 }
+            }
+        }
+
+        private void TrySetJobErrorMessage(ImportProfilePropertiesJobInfo job, string message)
+        {
+            try
+            {
+                job.ErrorMessage = message;
+            }
+            catch (ClientRequestException)
+            {
+                // Setting the ErrorMessage property to ImportProfilePropertiesJobInfo returned by GetImportProfilePropertyJobs() throws an exception sometimes as the Path is property is null.
+                // In this case the generic error message with the file location of the log in SPO will be returned.
             }
         }
     }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
None

## What is in this Pull Request ? ##
This PR fixes the command `Get-UPABulkImportStatus -JobId "..." -IncludeErrorDetails` not showing the actual error detail.

Before the PR:
![image](https://github.com/pnp/powershell/assets/1153754/048dffd3-a691-47d9-838f-7d64c3e4b5c7)

After the PR:
![image](https://github.com/pnp/powershell/assets/1153754/9bed5037-8f49-4434-9126-a988cc0a2f3a)

The issue was caused by how the relative path of the log folder was handled.

This actually triggered a code path previously never triggered, with an exception happening sometimes when trying to overwrite the ErrorMessage property.
Out of 11 import jobs with an error message, 3 had this issue. In these cases the previous generic message will be displayed instead, with the location of the logs on SPO.
