### PR TITLE
Add message "Team Not found" if team is not returned 

### DIFF
--- a/src/Commands/Teams/GetTeamsTeam.cs
+++ b/src/Commands/Teams/GetTeamsTeam.cs
@@ -33,6 +33,10 @@ namespace PnP.PowerShell.Commands.Graph
                 {
                     WriteObject(TeamsUtility.GetTeamAsync(AccessToken, Connection, groupId).GetAwaiter().GetResult());
                 }
+                else
+                {
+                    this.WriteError(new PSArgumentException("Team not found"), ErrorCategory.ObjectNotFound);
+                }
             }
             else
             {


### PR DESCRIPTION
Enhances the behavior of the Get-PnPTeamsTeam cmdlet to return "Team Not Found" if no teams is returned to conform to other cmdlets Get-PnPTeamsTag and Get-PnPTeamsTab.
