### PR TITLE
[FIX] #3569 Fixed fetching Azure AD User with apostrophe in UPN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed an issue when trying to download a file using `Get-PnPFile` from a location that's deeply nested into folders and/or has a really long filename [PnP Core #1290](https://github.com/pnp/pnpcore/pull/1290)
 - Fixed retrieving error detail in `Get-UPABulkImportStatus` cmdlet. [#3494](https://github.com/pnp/powershell/pull/3494)
 - Fixed `Rename-PnPTenantSite` cmdlet to allow support for vanity tenant URLs. [#3533](https://github.com/pnp/powershell/pull/3533)
- 
+- Fixed `Get-PnPAzureADUser`, `Get-PnPEntraIDUser`, `Add-PnPFlowOwner` and `Remove-PnPFlowOwner` not working when an UPN containing an apostrophe was passed in [#3570](https://github.com/pnp/powershell/pull/3570)
+
 ### Changed
 
 - Improved `Set-PnPListItem` cmdlet handling of Purview labels. [#3340](https://github.com/pnp/powershell/pull/3340)
@@ -86,6 +87,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Contributors
 
+- Dan Cecil [danielcecil]
 - Antti K. Koskela [koskila]
 - Christian Veenhuis [ChVeen]
 - Kunj Balkrishna Sangani [kunj-sangani]

--- a/src/Commands/AzureAD/GetAzureADUser.cs
+++ b/src/Commands/AzureAD/GetAzureADUser.cs
@@ -3,7 +3,6 @@ using PnP.PowerShell.Commands.Attributes;
 using PnP.PowerShell.Commands.Base;
 using System;
 using System.Management.Automation;
-using System.Net;
 
 namespace PnP.PowerShell.Commands.Principals
 {
@@ -70,22 +69,22 @@ namespace PnP.PowerShell.Commands.Principals
                 PnP.PowerShell.Commands.Model.AzureAD.User user;
                 if (Guid.TryParse(Identity, out Guid identityGuid))
                 {
-                    user = PnP.PowerShell.Commands.Utilities.AzureAdUtility.GetUser(AccessToken, identityGuid, ignoreDefaultProperties: IgnoreDefaultProperties, useBetaEndPoint: UseBeta.IsPresent, azureEnvironment: Connection.AzureEnvironment);
+                    user = Utilities.AzureAdUtility.GetUser(AccessToken, identityGuid, ignoreDefaultProperties: IgnoreDefaultProperties, useBetaEndPoint: UseBeta.IsPresent, azureEnvironment: Connection.AzureEnvironment);
                 }
                 else
                 {
-                    user = PnP.PowerShell.Commands.Utilities.AzureAdUtility.GetUser(AccessToken, WebUtility.UrlEncode(Identity.Replace("'","''")), Select, ignoreDefaultProperties: IgnoreDefaultProperties, useBetaEndPoint: UseBeta.IsPresent, azureEnvironment: Connection.AzureEnvironment);
+                    user = Utilities.AzureAdUtility.GetUser(AccessToken, Identity, Select, ignoreDefaultProperties: IgnoreDefaultProperties, useBetaEndPoint: UseBeta.IsPresent, azureEnvironment: Connection.AzureEnvironment);
                 }
                 WriteObject(user);
             }
             else if (ParameterSpecified(nameof(Delta)))
             {
-                var userDelta = PnP.PowerShell.Commands.Utilities.AzureAdUtility.ListUserDelta(AccessToken, DeltaToken, Filter, OrderBy, Select, StartIndex, EndIndex, useBetaEndPoint: UseBeta.IsPresent, azureEnvironment: Connection.AzureEnvironment);
+                var userDelta = Utilities.AzureAdUtility.ListUserDelta(AccessToken, DeltaToken, Filter, OrderBy, Select, StartIndex, EndIndex, useBetaEndPoint: UseBeta.IsPresent, azureEnvironment: Connection.AzureEnvironment);
                 WriteObject(userDelta);
             } 
             else
             {
-                var users = PnP.PowerShell.Commands.Utilities.AzureAdUtility.ListUsers(AccessToken, Filter, OrderBy, Select, ignoreDefaultProperties: IgnoreDefaultProperties, StartIndex, EndIndex, useBetaEndPoint: UseBeta.IsPresent, azureEnvironment: Connection.AzureEnvironment);
+                var users = Utilities.AzureAdUtility.ListUsers(AccessToken, Filter, OrderBy, Select, ignoreDefaultProperties: IgnoreDefaultProperties, StartIndex, EndIndex, useBetaEndPoint: UseBeta.IsPresent, azureEnvironment: Connection.AzureEnvironment);
                 WriteObject(users, true);
             }
         }

--- a/src/Commands/AzureAD/GetAzureADUser.cs
+++ b/src/Commands/AzureAD/GetAzureADUser.cs
@@ -74,7 +74,7 @@ namespace PnP.PowerShell.Commands.Principals
                 }
                 else
                 {
-                    user = PnP.PowerShell.Commands.Utilities.AzureAdUtility.GetUser(AccessToken, WebUtility.UrlEncode(Identity), Select, ignoreDefaultProperties: IgnoreDefaultProperties, useBetaEndPoint: UseBeta.IsPresent, azureEnvironment: Connection.AzureEnvironment);
+                    user = PnP.PowerShell.Commands.Utilities.AzureAdUtility.GetUser(AccessToken, WebUtility.UrlEncode(Identity.Replace("'","''")), Select, ignoreDefaultProperties: IgnoreDefaultProperties, useBetaEndPoint: UseBeta.IsPresent, azureEnvironment: Connection.AzureEnvironment);
                 }
                 WriteObject(user);
             }

--- a/src/Commands/Base/PnPAzureManagementApiCmdlet.cs
+++ b/src/Commands/Base/PnPAzureManagementApiCmdlet.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Management.Automation;
-using System.Net.Http;
+﻿using System.Management.Automation;
 using Microsoft.SharePoint.Client;
 using PnP.PowerShell.Commands.Model;
 

--- a/src/Commands/PowerPlatform/PowerAutomate/AddFlowOwner.cs
+++ b/src/Commands/PowerPlatform/PowerAutomate/AddFlowOwner.cs
@@ -3,7 +3,6 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 using PnP.PowerShell.Commands.Utilities.REST;
 using System;
 using System.Management.Automation;
-using System.Net;
 
 namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
 {
@@ -54,7 +53,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
             else
             {
                 WriteVerbose($"Looking up user through Microsoft Graph by user principal name {User}");
-                user = Utilities.AzureAdUtility.GetUser(graphAccessToken, WebUtility.UrlEncode(User), azureEnvironment: Connection.AzureEnvironment);
+                user = Utilities.AzureAdUtility.GetUser(graphAccessToken, User, azureEnvironment: Connection.AzureEnvironment);
             }
 
             if (user == null)

--- a/src/Commands/PowerPlatform/PowerAutomate/RemoveFlowOwner.cs
+++ b/src/Commands/PowerPlatform/PowerAutomate/RemoveFlowOwner.cs
@@ -3,7 +3,6 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 using PnP.PowerShell.Commands.Utilities.REST;
 using System;
 using System.Management.Automation;
-using System.Net;
 
 namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
 {
@@ -54,7 +53,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
             else
             {
                 WriteVerbose($"Looking up user through Microsoft Graph by user principal name {User}");
-                user = Utilities.AzureAdUtility.GetUser(graphAccessToken, WebUtility.UrlEncode(User), azureEnvironment: Connection.AzureEnvironment);
+                user = Utilities.AzureAdUtility.GetUser(graphAccessToken, User, azureEnvironment: Connection.AzureEnvironment);
             }
 
             if (user == null)

--- a/src/Commands/Utilities/AzureAdUtility.cs
+++ b/src/Commands/Utilities/AzureAdUtility.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using PnP.Framework;
 using PnP.PowerShell.Commands.Model.AzureAD;
 
@@ -83,7 +84,7 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <returns>User object</returns>
         public static User GetUser(string accessToken, string userPrincipalName, string[] selectProperties = null, bool ignoreDefaultProperties = false, int startIndex = 0, int? endIndex = 999, bool useBetaEndPoint = false, AzureEnvironment azureEnvironment = AzureEnvironment.Production)
         {
-            return PnP.Framework.Graph.UsersUtility.ListUsers(accessToken, $"userPrincipalName eq '{userPrincipalName}'", null, selectProperties, startIndex, endIndex, ignoreDefaultProperties: ignoreDefaultProperties, useBetaEndPoint: useBetaEndPoint, azureEnvironment: azureEnvironment).Select(User.CreateFrom).FirstOrDefault();
+            return PnP.Framework.Graph.UsersUtility.ListUsers(accessToken, $"userPrincipalName eq '{WebUtility.UrlEncode(userPrincipalName.Replace("'", "''"))}'", null, selectProperties, startIndex, endIndex, ignoreDefaultProperties: ignoreDefaultProperties, useBetaEndPoint: useBetaEndPoint, azureEnvironment: azureEnvironment).Select(User.CreateFrom).FirstOrDefault();
         }
 
         #endregion


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes (https://github.com/pnp/powershell/issues/3569)

## What is in this Pull Request ? ##
Added a String.Replace function to the Identity parameter on GetAzureADUser.cs to replace single apostrophe's with doubles. e.g. `John.O'Smith@contoso.com` becomes `John.O''Smith@contoso.com` as a result.

This ensures the apostrophes are correctly escapes. Note that UrlEncode does not achieve this fix.
