### PR TITLE
Add EnableSensitivityLabelForPDF property to Tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `-BusinessConnectivityServiceDisabled` parameter to `Set-PnPTenant` cmdlt to allow disabling the Business Connectivity Service [#3562](https://github.com/pnp/powershell/pull/3562)
 - Added support for executing the 'Invoke-PnPSPRestMethod' cmdlet in a batch [#3565](https://github.com/pnp/powershell/pull/3565)
 - Added `Get-PnPSiteSetVersionPolicyProgress` cmdlet which allows for getting the progress of setting a version policy for existing document libraries on a site [#3564](https://github.com/pnp/powershell/pull/3564)
+- Added `EnableSensitivityLabelForPDF` to `Set-PnPTenant` and `Get-PnPTenant` [#3581](https://github.com/pnp/powershell/pull/3581)
 
 ### Fixed
 
@@ -96,6 +97,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Contributors
 
+- Konrad K. [wilecoyotegenius]
 - Dan Cecil [danielcecil]
 - Antti K. Koskela [koskila]
 - Christian Veenhuis [ChVeen]

--- a/documentation/Set-PnPTenant.md
+++ b/documentation/Set-PnPTenant.md
@@ -135,6 +135,7 @@ Set-PnPTenant [-SpecialCharactersStateInFileFolderNames <SpecialCharactersState>
  [-IncludeAtAGlanceInShareEmails <Boolean>]
  [-MassDeleteNotificationDisabled <Boolean>]
  [-BusinessConnectivityServiceDisabled <Boolean>]
+ [-EnableSensitivityLabelForPDF <Boolean>]
  [-Force] [-Connection <PnPConnection>]
 ```
 
@@ -285,6 +286,29 @@ Accept wildcard characters: False
 
 ### -BusinessConnectivityServiceDisabled
 Allows blocking of Business Connectivity Services to be used on SharePoint Online. This feature is set to be retired on September 30, 2024. [More information](https://techcommunity.microsoft.com/t5/microsoft-sharepoint-blog/support-update-for-business-connectivity-services-in-microsoft/ba-p/3938773).
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableSensitivityLabelForPDF
+Allows turning on support for PDFs with sensitivity labels for the following scenarios:
+
+- Applying a sensitivity label in Office for the web.
+- Uploading a labeled document, and then extracting and displaying that sensitivity label.
+- Search, eDiscovery, and data loss prevention.
+- Auto-labeling policies and default sensitivity labels for SharePoint document libraries.
+
+The valid values are:
+True - Enables support for PDFs.
+False (default) - Disables support for PDFs.
 
 ```yaml
 Type: Boolean

--- a/src/Commands/Admin/SetTenant.cs
+++ b/src/Commands/Admin/SetTenant.cs
@@ -404,6 +404,9 @@ namespace PnP.PowerShell.Commands.Admin
         [Parameter(Mandatory = false)]
         public bool? BusinessConnectivityServiceDisabled { get; set; }
 
+        [Parameter(Mandatory = false)]
+        public bool? EnableSensitivityLabelForPDF { get; set; }
+
         protected override void ExecuteCmdlet()
         {
             AdminContext.Load(Tenant);
@@ -1341,6 +1344,12 @@ namespace PnP.PowerShell.Commands.Admin
             if(BusinessConnectivityServiceDisabled.HasValue)
             {
                 Tenant.BusinessConnectivityServiceDisabled = BusinessConnectivityServiceDisabled.Value;
+                modified = true;
+            }
+
+            if (EnableSensitivityLabelForPDF.HasValue)
+            {
+                Tenant.EnableSensitivityLabelForPDF = EnableSensitivityLabelForPDF.Value;
                 modified = true;
             }
 

--- a/src/Commands/Model/SPOTenant.cs
+++ b/src/Commands/Model/SPOTenant.cs
@@ -181,6 +181,8 @@ namespace PnP.PowerShell.Commands.Model
 
         public bool? BusinessConnectivityServiceDisabled { private set; get; }
 
+        public bool? EnableSensitivityLabelForPDF { private set; get; }
+
         #endregion
 
         public SPOTenant(Tenant tenant, ClientContext clientContext)
@@ -642,6 +644,15 @@ namespace PnP.PowerShell.Commands.Model
             OneDriveRequestFilesLinkEnabled = tenant.OneDriveRequestFilesLinkEnabled;
             OneDriveRequestFilesLinkExpirationInDays = tenant.OneDriveRequestFilesLinkExpirationInDays;
             BusinessConnectivityServiceDisabled = tenant.BusinessConnectivityServiceDisabled;
+
+            try 
+            {
+                EnableSensitivityLabelForPDF = tenant.EnableSensitivityLabelForPDF;
+            }
+            catch 
+            {
+                EnableSensitivityLabelForPDF = false;
+            }
         }
     }
 }


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## What is in this Pull Request ? ##
Adds ability to get or set support for Sensitivity Labels in PDFs to match Microsoft Online Management Shell Get/Set-SPOTenant.

- Adds property EnableSensitivityLabelForPDF to Tenant
- Adds ability to get/set EnableSensitivityLabelForPDF using Get-PNPTenant and Set-PNPTenant

You may confirm whether this works by issuing Get-SPOTenant from Microsoft Online Management Shell.