### PR TITLE
Fix for bug #3589

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -387,6 +387,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `Get-PnPDeletedTeam` cmdlet to retrieve all deleted Microsoft Teams teams [#2487](https://github.com/pnp/powershell/pull/2487)
 - Added `-ServerRelativePath` and `-Path` parameters to `Set-PnPImageListItemColumn` cmdlet to allow for file to be uploaded for the Image type column. [#2503](https://github.com/pnp/powershell/pull/2503)
 - Added support for sovereign tenants in `Get-PnPTenandId` by utilizing the `-AzureEnvironment` parameter. [#2512](https://github.com/pnp/powershell/pull/2512)
+- Added `Set-PnPTeamsTeamPicture` which allows setting the picture of a Teams team [#3590](https://github.com/pnp/powershell/pull/3590)
 
 ### Changed
 

--- a/documentation/Set-PnPTeamsTeamPicture.md
+++ b/documentation/Set-PnPTeamsTeamPicture.md
@@ -67,4 +67,3 @@ Accept wildcard characters: False
 ## RELATED LINKS
 
 [Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)
-

--- a/src/Commands/Teams/SetTeamsTeamPicture.cs
+++ b/src/Commands/Teams/SetTeamsTeamPicture.cs
@@ -4,7 +4,6 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 using PnP.PowerShell.Commands.Utilities;
 using System.IO;
 using System.Management.Automation;
-using System.Threading.Tasks;
 
 namespace PnP.PowerShell.Commands.Teams
 {

--- a/src/Commands/Utilities/TeamsUtility.cs
+++ b/src/Commands/Utilities/TeamsUtility.cs
@@ -423,7 +423,7 @@ namespace PnP.PowerShell.Commands.Utilities
         {
             var byteArrayContent = new ByteArrayContent(bytes);
             byteArrayContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(contentType);
-            await GraphHelper.PutAsync<string>(connection, $"v1.0/groups/{groupId}/photo/$value", accessToken, byteArrayContent);
+            await GraphHelper.PutAsync<string>(connection, $"v1.0/teams/{groupId}/photo/$value", accessToken, byteArrayContent);
         }
 
         public static async Task<HttpResponseMessage> SetTeamArchivedStateAsync(PnPConnection connection, string accessToken, string groupId, bool archived, bool? setSiteReadOnly)

--- a/src/Commands/Utilities/TeamsUtility.cs
+++ b/src/Commands/Utilities/TeamsUtility.cs
@@ -419,11 +419,11 @@ namespace PnP.PowerShell.Commands.Utilities
             return await GraphHelper.PatchAsync<Group>(connection, accessToken, $"v1.0/groups/{groupId}", group);
         }
 
-        public static async Task SetTeamPictureAsync(PnPConnection connection, string accessToken, string groupId, byte[] bytes, string contentType)
+        public static async Task SetTeamPictureAsync(PnPConnection connection, string accessToken, string teamId, byte[] bytes, string contentType)
         {
             var byteArrayContent = new ByteArrayContent(bytes);
             byteArrayContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(contentType);
-            await GraphHelper.PutAsync<string>(connection, $"v1.0/teams/{groupId}/photo/$value", accessToken, byteArrayContent);
+            await GraphHelper.PutAsync<string>(connection, $"v1.0/teams/{teamId}/photo/$value", accessToken, byteArrayContent);
         }
 
         public static async Task<HttpResponseMessage> SetTeamArchivedStateAsync(PnPConnection connection, string accessToken, string groupId, bool archived, bool? setSiteReadOnly)


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix

## Related Issues? ##
Fixes #3589

## What is in this Pull Request ? ##
Update function SetTeamPictureAsync within file SetTeamsTeamPicture.cs to use v1.0/teams/ endpoint instead of v1.0/groups/.

public static async Task SetTeamPictureAsync(PnPConnection connection, string accessToken, string groupId, byte[] bytes, string contentType)
{
var byteArrayContent = new ByteArrayContent(bytes);
byteArrayContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(contentType);
await GraphHelper.PutAsync(connection, $"v1.0/teams/{groupId}/photo/$value", accessToken, byteArrayContent);
}

