### PR TITLE
update get-pnpfolder to remove reference to Get-PnPFolderFile and Get-PnPFolderFolder 

### DIFF
--- a/documentation/Get-PnPFolderItem.md
+++ b/documentation/Get-PnPFolderItem.md
@@ -28,6 +28,8 @@ Get-PnPFolderItem [-Identity <FolderPipeBind>] [-ItemType <String>] [-ItemName <
 
 This cmdlet allows listing of all the content in a folder. It can be used to list all files and folders in a folder and optionally all its subfolders.
 
+Use [Get-PnPFileInFolder](Get-PnPFileInFolder.md) to retrieve only files and [Get-PnPFolderInFolder](Get-PnPFolderInFolder.md) to retrieve only folders allowing additional properties of the returned items to be requested.
+
 ## EXAMPLES
 
 ### EXAMPLE 1

--- a/documentation/Get-PnPFolderItem.md
+++ b/documentation/Get-PnPFolderItem.md
@@ -28,8 +28,6 @@ Get-PnPFolderItem [-Identity <FolderPipeBind>] [-ItemType <String>] [-ItemName <
 
 This cmdlet allows listing of all the content in a folder. It can be used to list all files and folders in a folder and optionally all its subfolders.
 
-Use [Get-PnPFolderFile](Get-PnPFolderFile.md) to retrieve only files and [Get-PnPFolderFolder](Get-PnPFolderFolder.md) to retrieve only folders allowing additional properties of the returned items to be requested.
-
 ## EXAMPLES
 
 ### EXAMPLE 1


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix

## What is in this Pull Request ? ##
Remove the following from docs as cmdlets Get-PnPFolderFile and Get-PnPFolderFolder does not exist

```
Use [Get-PnPFolderFile](Get-PnPFolderFile.md) to retrieve only files and [Get-PnPFolderFolder](Get-PnPFolderFolder.md) to retrieve only folders allowing additional properties of the returned items to be requested.
```
