### PR TITLE
Fix #3797:  group description in New-PnPGroup cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Enable/Disable-PnPPageScheduling` cmdlet to also work with Viva connections enabled site. [#3713](https://github.com/pnp/powershell/pull/3713)
 - Fixed `Register-PnPManagementShellAccess` and `Register-PnPAzureADApp` cmdlets to also work with custom environment. [#3763](https://github.com/pnp/powershell/pull/3763)
 - Fixed `Set-PnPPPage` cmdlet to only change layout of the page if the parameter is specified. [#3777](https://github.com/pnp/powershell/pull/3777)
+- Fixed `New-PnPGroup` cmdlet to correctly show the group description with HTML making it similar to `Set-PnPGroup`.
 
 ### Changed
 

--- a/src/Commands/Principals/NewGroup.cs
+++ b/src/Commands/Principals/NewGroup.cs
@@ -73,6 +73,30 @@ namespace PnP.PowerShell.Commands.Principals
                 dirty = true;
             }
 
+            if (!string.IsNullOrEmpty(Description))
+            {
+                var groupItem = CurrentWeb.SiteUserInfoList.GetItemById(group.Id);
+                CurrentWeb.Context.Load(groupItem, g => g["Notes"]);
+                CurrentWeb.Context.ExecuteQueryRetry();
+
+                var groupDescription = groupItem["Notes"]?.ToString();
+
+                if (groupDescription != Description)
+                {
+                    groupItem["Notes"] = Description;
+                    groupItem.Update();
+                    dirty = true;
+                }
+
+                var plainTextDescription = Framework.Utilities.PnPHttpUtility.ConvertSimpleHtmlToText(Description, int.MaxValue);
+                if (group.Description != plainTextDescription)
+                {
+                    //If the description is more than 512 characters long a server exception will be thrown.
+                    group.Description = plainTextDescription;                    
+                    dirty = true;
+                }
+            }
+
             if (dirty)
             {
                 group.Update();


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #3797

## What is in this Pull Request ? ##
Made it similar to Set-PnPGroup cmdlet to properly show HTML description of group