### PR TITLE
Fixing `Get-PnPChangeLog -Version` not returing data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+### Fixed
+
+- Fixed `Get-PnPChangeLog -Version 2.3.0` not returning the changelog for that version
+
 ### Contributors
+
+- Koen Zomers [koenzomers]
 
 ## [2.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fixed `Get-PnPChangeLog -Version 2.3.0` not returning the changelog for that version
+- Fixed `Get-PnPChangeLog -Version 2.3.0` not returning the changelog for that version [#3804](https://github.com/pnp/powershell/pull/3804)
 
 ### Contributors
 

--- a/src/Commands/Base/GetChangeLog.cs
+++ b/src/Commands/Base/GetChangeLog.cs
@@ -20,7 +20,7 @@ namespace PnP.PowerShell.Commands
 
             if (MyInvocation.BoundParameters.ContainsKey(nameof(Release)))
             {
-                var url = $"https://api.github.com/repos/pnp/powershell/releases/tags/{Release.Major}.{Release.Minor}.{Release.Build}";
+                var url = $"https://api.github.com/repos/pnp/powershell/releases/tags/v{Release.Major}.{Release.Minor}.{Release.Build}";
                 var response = client.GetAsync(url).GetAwaiter().GetResult();
                 if (response.IsSuccessStatusCode)
                 {


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
`Get-PnPChangeLog -Version 2.3.0` did not return any data. This was because it was looking for a release tagged with 2.3.0 in this case while the releases are tagged at **v**2.3.0 instead. Fixed the code so it looks for the proper tag.