### PR TITLE
Set-PnPPage - Remove the Name parameter

### DIFF
--- a/documentation/Set-PnPPage.md
+++ b/documentation/Set-PnPPage.md
@@ -15,7 +15,7 @@ Sets parameters of a page
 ## SYNTAX
 
 ```powershell
-Set-PnPPage [-Identity] <PagePipeBind> [-Name <String>] [-Title <String>]
+Set-PnPPage [-Identity] <PagePipeBind> [-Title <String>]
  [-LayoutType <PageLayoutType>] [-PromoteAs <PagePromoteType>] [-CommentsEnabled]
  [-Publish] [-HeaderType <PageHeaderType>] [-HeaderLayoutType <PageHeaderLayoutType>] [-ScheduledPublishDate <DateTime>] 
  [-RemoveScheduledPublish] [-ContentType <ContentTypePipeBind>] [-ThumbnailUrl <String>] [-ShowPublishDate <Boolean>]

--- a/documentation/Set-PnPPage.md
+++ b/documentation/Set-PnPPage.md
@@ -234,20 +234,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Name
-Sets the name of the page.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -PromoteAs
 Allows to promote the page for a specific purpose (None | HomePage | NewsArticle | Template)
 

--- a/src/Commands/Pages/SetPage.cs
+++ b/src/Commands/Pages/SetPage.cs
@@ -16,9 +16,6 @@ namespace PnP.PowerShell.Commands.Pages
         public PagePipeBind Identity;
 
         [Parameter(Mandatory = false)]
-        public string Name = null;
-
-        [Parameter(Mandatory = false)]
         public string Title = null;
 
         [Parameter(Mandatory = false)]
@@ -91,7 +88,7 @@ namespace PnP.PowerShell.Commands.Pages
             }
 
             // We need to have the page name, if not found, raise an error
-            string name = PageUtilities.EnsureCorrectPageName(Name ?? Identity?.Name);
+            string name = PageUtilities.EnsureCorrectPageName(Identity?.Name);
             if (name == null)
                 throw new Exception("Insufficient arguments to update a client side page");
 


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #3787 

## What is in this Pull Request ? ##
Remove the `-Name` parameter from the Set-PnPPage.
Today, when providing a value for this parameter, a new page is created.
