### PR TITLE
Adding support for vanity domains to several cmdlets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `Unlock-PnPSensitivityLabelEncryptedFile` which allows the encryption to be removed from a file [#3864](https://github.com/pnp/powershell/pull/3864)
 - Added `Get-PnPLibraryFileVersionBatchDeleteJobStatus` and `Get-PnPSiteFileVersionBatchDeleteJobStatus` to check on the status of applying file based version expiration based on age on a library and site level [#3828](https://github.com/pnp/powershell/pull/3828)
 - Added support for `Get-PnPSiteCollectionAppCatalog` and `Get-PnPTenantSite` to be used with vanity domain tenants [#3895](https://github.com/pnp/powershell/pull/3895)
-- Added support for using vanity domain tenants with `Grant-PnPTenantServicePrincipalPermission`, `Revoke-PnPTenantServicePrincipalPermission`, `Set-PnPWebTheme`, `Invoke-PnPListDesign`, `Set-PnPSite`, `Add-PnPSiteDesignTask`, `Get-PnPSiteDesignRun`, `Get-PnPSiteDesignTask` and `Invoke-PnPSiteDesign` cmdlets
+- Added support for using vanity domain tenants with `Grant-PnPTenantServicePrincipalPermission`, `Revoke-PnPTenantServicePrincipalPermission`, `Set-PnPWebTheme`, `Invoke-PnPListDesign`, `Set-PnPSite`, `Add-PnPSiteDesignTask`, `Get-PnPSiteDesignRun`, `Get-PnPSiteDesignTask` and `Invoke-PnPSiteDesign` cmdlets [#3898](https://github.com/pnp/powershell/pull/3898)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `Unlock-PnPSensitivityLabelEncryptedFile` which allows the encryption to be removed from a file [#3864](https://github.com/pnp/powershell/pull/3864)
 - Added `Get-PnPLibraryFileVersionBatchDeleteJobStatus` and `Get-PnPSiteFileVersionBatchDeleteJobStatus` to check on the status of applying file based version expiration based on age on a library and site level [#3828](https://github.com/pnp/powershell/pull/3828)
 - Added support for `Get-PnPSiteCollectionAppCatalog` and `Get-PnPTenantSite` to be used with vanity domain tenants [#3895](https://github.com/pnp/powershell/pull/3895)
+- Added support for using vanity domain tenants with `Grant-PnPTenantServicePrincipalPermission`, `Revoke-PnPTenantServicePrincipalPermission`, `Set-PnPWebTheme`, `Invoke-PnPListDesign`, `Set-PnPSite`, `Add-PnPSiteDesignTask`, `Get-PnPSiteDesignRun`, `Get-PnPSiteDesignTask` and `Invoke-PnPSiteDesign` cmdlets
 
 ### Fixed
 

--- a/src/Commands/Apps/GrantTenantServicePrincipalPermission.cs
+++ b/src/Commands/Apps/GrantTenantServicePrincipalPermission.cs
@@ -21,7 +21,7 @@ namespace PnP.PowerShell.Commands.Apps
         public string Resource = "Microsoft Graph";
         protected override void ExecuteCmdlet()
         {
-            var tenantUrl = UrlUtilities.GetTenantAdministrationUrl(ClientContext.Url);
+            var tenantUrl = Connection.TenantAdminUrl ?? UrlUtilities.GetTenantAdministrationUrl(ClientContext.Url);
             using (var tenantContext = ClientContext.Clone(tenantUrl))
             {
                 var spoWebAppServicePrincipal = new SPOWebAppServicePrincipal(tenantContext);

--- a/src/Commands/Apps/RevokeTenantServicePrincipalPermission.cs
+++ b/src/Commands/Apps/RevokeTenantServicePrincipalPermission.cs
@@ -25,8 +25,7 @@ namespace PnP.PowerShell.Commands.Apps
 
         protected override void ExecuteCmdlet()
         {
-
-            var tenantUrl = UrlUtilities.GetTenantAdministrationUrl(ClientContext.Url);
+            var tenantUrl = Connection.TenantAdminUrl ?? UrlUtilities.GetTenantAdministrationUrl(ClientContext.Url);
             using (var tenantContext = ClientContext.Clone(tenantUrl))
             {
                 var spoWebAppServicePrincipal = new SPOWebAppServicePrincipal(tenantContext);

--- a/src/Commands/Branding/SetWebTheme.cs
+++ b/src/Commands/Branding/SetWebTheme.cs
@@ -22,7 +22,7 @@ namespace PnP.PowerShell.Commands.Branding
         protected override void ExecuteCmdlet()
         {
             var url = CurrentWeb.EnsureProperty(w => w.Url);
-            var tenantUrl = UrlUtilities.GetTenantAdministrationUrl(ClientContext.Url);
+            var tenantUrl = Connection.TenantAdminUrl ?? UrlUtilities.GetTenantAdministrationUrl(ClientContext.Url);
             using (var tenantContext = ClientContext.Clone(tenantUrl))
             {
                 var tenant = new Tenant(tenantContext);

--- a/src/Commands/ListDesign/InvokeListDesign.cs
+++ b/src/Commands/ListDesign/InvokeListDesign.cs
@@ -19,7 +19,7 @@ namespace PnP.PowerShell.Commands
         protected override void ExecuteCmdlet()
         {
             var url = CurrentWeb.EnsureProperty(w => w.Url);
-            var tenantUrl = UrlUtilities.GetTenantAdministrationUrl(ClientContext.Url);
+            var tenantUrl = Connection.TenantAdminUrl ?? UrlUtilities.GetTenantAdministrationUrl(ClientContext.Url);
             using (var tenantContext = ClientContext.Clone(tenantUrl))
             {
                 var tenant = new Tenant(tenantContext);

--- a/src/Commands/Site/SetSite.cs
+++ b/src/Commands/Site/SetSite.cs
@@ -237,7 +237,7 @@ namespace PnP.PowerShell.Commands.Site
 
             if (IsTenantProperty())
             {
-                var tenantAdminUrl = UrlUtilities.GetTenantAdministrationUrl(context.Url);
+                var tenantAdminUrl = Connection.TenantAdminUrl ?? UrlUtilities.GetTenantAdministrationUrl(context.Url);
                 context = context.Clone(tenantAdminUrl);
 
                 executeQueryRequired = false;

--- a/src/Commands/SiteDesigns/AddSiteDesignTask.cs
+++ b/src/Commands/SiteDesigns/AddSiteDesignTask.cs
@@ -19,7 +19,7 @@ namespace PnP.PowerShell.Commands.SiteDesigns
         protected override void ExecuteCmdlet()
         {
             var url = CurrentWeb.EnsureProperty(w => w.Url);
-            var tenantUrl = UrlUtilities.GetTenantAdministrationUrl(ClientContext.Url);
+            var tenantUrl = Connection.TenantAdminUrl ?? UrlUtilities.GetTenantAdministrationUrl(ClientContext.Url);
             using (var tenantContext = ClientContext.Clone(tenantUrl))
             {
                 var webUrl = url;

--- a/src/Commands/SiteDesigns/GetSiteDesignRun.cs
+++ b/src/Commands/SiteDesigns/GetSiteDesignRun.cs
@@ -19,7 +19,7 @@ namespace PnP.PowerShell.Commands.SiteDesigns
         protected override void ExecuteCmdlet()
         {
             var url = CurrentWeb.EnsureProperty(w => w.Url);
-            var tenantUrl = UrlUtilities.GetTenantAdministrationUrl(ClientContext.Url);
+            var tenantUrl = Connection.TenantAdminUrl ?? UrlUtilities.GetTenantAdministrationUrl(ClientContext.Url);
             using (var tenantContext = ClientContext.Clone(tenantUrl))
             {
                 var tenant = new Tenant(tenantContext);

--- a/src/Commands/SiteDesigns/GetSiteDesignTask.cs
+++ b/src/Commands/SiteDesigns/GetSiteDesignTask.cs
@@ -19,7 +19,7 @@ namespace PnP.PowerShell.Commands.SiteDesigns
         protected override void ExecuteCmdlet()
         {
             var url = CurrentWeb.EnsureProperty(w => w.Url);
-            var tenantUrl = UrlUtilities.GetTenantAdministrationUrl(ClientContext.Url);
+            var tenantUrl = Connection.TenantAdminUrl ?? UrlUtilities.GetTenantAdministrationUrl(ClientContext.Url);
             using (var tenantContext = ClientContext.Clone(tenantUrl))
             {
                 if (Identity != null)

--- a/src/Commands/SiteDesigns/InvokeSiteDesign.cs
+++ b/src/Commands/SiteDesigns/InvokeSiteDesign.cs
@@ -19,7 +19,7 @@ namespace PnP.PowerShell.Commands
         protected override void ExecuteCmdlet()
         {
             var url = CurrentWeb.EnsureProperty(w => w.Url);
-            var tenantUrl = UrlUtilities.GetTenantAdministrationUrl(ClientContext.Url);
+            var tenantUrl = Connection.TenantAdminUrl ?? UrlUtilities.GetTenantAdministrationUrl(ClientContext.Url);
             using (var tenantContext = ClientContext.Clone(tenantUrl))
             {
                 var tenant = new Tenant(tenantContext);


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Adding support for vanity domains by checking if a TenantAdminUrl has been passed in with the Connect-PnPOnline and if so, using that instead of trying to guess the tenant admin url based on the contoso-admin syntax.

This PR will fix it for:

- `Grant-PnPTenantServicePrincipalPermission`
- `Revoke-PnPTenantServicePrincipalPermission`
- `Set-PnPWebTheme`
- `Invoke-PnPListDesign`
- `Set-PnPSite`
- `Add-PnPSiteDesignTask`
- `Get-PnPSiteDesignRun`
- `Get-PnPSiteDesignTask`
- `Invoke-PnPSiteDesign`