### PR TITLE
Fix destination folder definition in build process on Mac dev machines

### DIFF
--- a/build/Build-Debug.ps1
+++ b/build/Build-Debug.ps1
@@ -126,9 +126,12 @@ if ($LASTEXITCODE -eq 0) {
 		# Load the Module in a new PowerShell session
 		$scriptBlock = {
 			$documentsFolder = [environment]::getfolderpath("mydocuments");
-
-			if ($IsLinux -or $isMacOS) {
+			
+			if ($IsLinux) {
 				$destinationFolder = "$documentsFolder/.local/share/powershell/Modules/PnP.PowerShell"
+			}
+			elseif ($IsMacOS) {
+				$destinationFolder = "~/.local/share/powershell/Modules/PnP.PowerShell"
 			}
 			else {
 				$destinationFolder = "$documentsFolder/PowerShell/Modules/PnP.PowerShell"


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##


## What is in this Pull Request ? ##
Fixes a small bug related to the destination folder path of the module. The error shows up while trying to build the implemented changes using `/build/Build-Debug.ps1` on a Mac dev machine:
![image](https://github.com/pnp/powershell/assets/69770609/7ee1b52d-fa57-43c1-94d3-2c6f7ff3c0a6)
