### PR TITLE
Files for new cmdlets Set-PnPTenantRestrictedSearchMode and GetTenantRestrictedSearchMode.cs

### DIFF
--- a/documentation/Get-PnPTenantRestrictedSearchMode.md
+++ b/documentation/Get-PnPTenantRestrictedSearchMode.md
@@ -1,0 +1,58 @@
+---
+Module Name: PnP.PowerShell
+title: Get-PnPTenantRestrictedSearchMode
+schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/Get-PnPTenantRestrictedSearchMode.html
+---
+ 
+# Get-PnPTenantRestrictedSearchMode
+
+## SYNOPSIS
+
+**Required Permissions**
+
+  *  Global Administrator or SharePoint Administrator 
+
+Returns Restricted Search mode.
+
+## SYNTAX
+
+```powershell
+Get-PnPTenantRestrictedSearchMode [-Connection <PnPConnection>] 
+```
+
+## DESCRIPTION
+
+Returns Restricted Search mode. Restricted SharePoint Search is disabled by default.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Get-PnPTenantRestrictedSearchMode
+```
+
+Returns Restricted Search mode.
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/documentation/Set-PnPTenantRestrictedSearchMode.md
+++ b/documentation/Set-PnPTenantRestrictedSearchMode.md
@@ -1,0 +1,83 @@
+---
+Module Name: PnP.PowerShell
+title: Set-PnPTenantRestrictedSearchMode
+schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/Set-PnPTenantRestrictedSearchMode.html
+---
+ 
+# Set-PnPTenantRestrictedSearchMode
+
+## SYNOPSIS
+
+**Required Permissions**
+
+  *  Global Administrator or SharePoint Administrator 
+
+Returns Restricted Search mode.
+
+## SYNTAX
+
+```powershell
+Set-PnPTenantRestrictedSearchMode -Mode <RestrictedSearchMode> [-Connection <PnPConnection>]
+```
+
+## DESCRIPTION
+
+Returns Restricted Search mode. Restricted SharePoint Search is disabled by default.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Set-PnPTenantRestrictedSearchMode -Mode Enabled
+```
+
+Sets or enables the Restricted Tenant Search mode for the tenant.
+
+### EXAMPLE 2
+
+```powershell
+Set-PnPTenantRestrictedSearchMode -Mode Disabled
+```
+
+Disables the Restricted Tenant Search mode for the tenant.
+
+## PARAMETERS
+
+### -Mode
+
+Sets the mode for the Restricted Tenant Search.
+
+```yaml
+Type: RestrictedSearchMode
+Parameter Sets: (All)
+Accepted values: Enabled, Disabled
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Connection
+
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/src/Commands/Admin/GetTenantRestrictedSearchMode.cs
+++ b/src/Commands/Admin/GetTenantRestrictedSearchMode.cs
@@ -1,0 +1,17 @@
+using Microsoft.Online.SharePoint.TenantAdministration;
+using PnP.PowerShell.Commands.Base;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Files
+{
+    [Cmdlet(VerbsCommon.Get, "PnPTenantRestrictedSearchMode")]
+    public class GetTenantRestrictedSearchMode : PnPAdminCmdlet
+    {
+        protected override void ExecuteCmdlet()
+        {
+            var results = Tenant.GetSPORestrictedSearchMode();
+            AdminContext.ExecuteQuery();
+            WriteObject(results, true);
+        }
+    }
+}

--- a/src/Commands/Admin/SetTenantRestrictedSearchMode.cs
+++ b/src/Commands/Admin/SetTenantRestrictedSearchMode.cs
@@ -1,0 +1,18 @@
+using Microsoft.Online.SharePoint.TenantAdministration;
+using PnP.PowerShell.Commands.Base;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Files
+{
+    [Cmdlet(VerbsCommon.Set, "PnPTenantRestrictedSearchMode")]
+    public class SetTenantRestrictedSearchMode : PnPAdminCmdlet
+    {
+        [Parameter(Position = 0, ValueFromPipeline = true, Mandatory = true)]
+        public RestrictedSearchMode mode;
+        protected override void ExecuteCmdlet()
+        {
+            Tenant.SetSPORestrictedSearchMode(mode);
+            AdminContext.ExecuteQuery();
+        }
+    }
+}


### PR DESCRIPTION
## Type ##
- [ ] New Feature

## What is in this Pull Request ? ##
Two cmdlets for Get-PnPTenantRestrictedSearchMode and Set-PnPTenantRestrictedSearchMode 
Refer to https://learn.microsoft.com/en-us/sharepoint/restricted-sharepoint-search-admin-script to the feature details to restrict SharePoint search 

Files added 
- documentation\Set-PnPTenantRestrictedSearchMode.md
- documentation\Get-PnPTenantRestrictedSearchMode.md
- src\Commands\Admin\GetTenantRestrictedSearchMode.cs
- src\Commands\Admin\SetTenantRestrictedSearchMode.cs
