### PR TITLE
feat: Add ExecuteQueryRetry to Admin commands for improved reliability

### DIFF
--- a/src/Commands/Admin/SetHomeSite.cs
+++ b/src/Commands/Admin/SetHomeSite.cs
@@ -46,7 +46,7 @@ namespace PnP.PowerShell.Commands.Admin
                         Tenant.RemoveTargetedSite(enumerable.First().SiteId);
                         AdminContext.ExecuteQueryRetry();
                         Tenant.AddHomeSite(HomeSiteUrl, 1, null);
-                        AdminContext.ExecuteQuery();
+                        AdminContext.ExecuteQueryRetry();
                         flag = true;
                     }
                     HomeSiteConfigurationParam configurationParam = new()

--- a/src/Commands/Admin/UnlockSensitivityLabelEncryptedFile.cs
+++ b/src/Commands/Admin/UnlockSensitivityLabelEncryptedFile.cs
@@ -1,22 +1,24 @@
+using Microsoft.SharePoint.Client;
 using PnP.PowerShell.Commands.Base;
 using System.Management.Automation;
 
 namespace PnP.PowerShell.Commands.Files
 {
-        [Cmdlet(VerbsCommon.Unlock, "PnPSensitivityLabelEncryptedFile")]
-        public class UnlockSensitivityLabelEncryptedFile : PnPAdminCmdlet
-        {
-            [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
-            public string Url = string.Empty;
-            [Parameter(Mandatory = true)]
-            public string JustificationText = string.Empty;
-            protected override void ExecuteCmdlet()
-            {
-                // Remove URL decoding from the Url as that will not work. We will encode the + character specifically, because if that is part of the filename, it needs to stay and not be decoded.
-                Url = Utilities.UrlUtilities.UrlDecode(Url.Replace("+", "%2B"));
+    [Cmdlet(VerbsCommon.Unlock, "PnPSensitivityLabelEncryptedFile")]
+    public class UnlockSensitivityLabelEncryptedFile : PnPAdminCmdlet
+    {
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+        public string Url = string.Empty;
 
-                Tenant.UnlockSensitivityLabelEncryptedFile(Url, JustificationText);
-                AdminContext.ExecuteQuery();
-            }
+        [Parameter(Mandatory = true)]
+        public string JustificationText = string.Empty;
+        protected override void ExecuteCmdlet()
+        {
+            // Remove URL decoding from the Url as that will not work. We will encode the + character specifically, because if that is part of the filename, it needs to stay and not be decoded.
+            Url = Utilities.UrlUtilities.UrlDecode(Url.Replace("+", "%2B"));
+
+            Tenant.UnlockSensitivityLabelEncryptedFile(Url, JustificationText);
+            AdminContext.ExecuteQueryRetry();
+        }
     }
 }

--- a/src/Commands/InformationManagement/ResetRetentionLabel.cs
+++ b/src/Commands/InformationManagement/ResetRetentionLabel.cs
@@ -68,7 +68,7 @@ namespace PnP.PowerShell.Commands.InformationManagement
 
                         WriteVerbose($"Clearing retention label on batch {rangeIndex} of items");
                         Microsoft.SharePoint.Client.CompliancePolicy.SPPolicyStoreProxy.SetComplianceTagOnBulkItems(ClientContext, range, rootUrl + list.RootFolder.ServerRelativeUrl, string.Empty);
-                        ClientContext.ExecuteQuery();
+                        ClientContext.ExecuteQueryRetry();
 
                         ItemIds.RemoveRange(0, itemsToProcess);
                     }

--- a/src/Commands/InformationManagement/SetRetentionLabel.cs
+++ b/src/Commands/InformationManagement/SetRetentionLabel.cs
@@ -71,8 +71,7 @@ namespace PnP.PowerShell.Commands.InformationManagement
                     if (ParameterSetName == ParamSet_BulkItems) 
                     {
                         PnPContext.Web.LoadAsync(i => i.Url);
-                        list.LoadAsync(i => i.RootFolder);
-                        
+                        list.LoadAsync(i => i.RootFolder);                        
 
                         var rootUrl = PnPContext.Web.Url.GetLeftPart(UriPartial.Authority);
                     
@@ -87,7 +86,7 @@ namespace PnP.PowerShell.Commands.InformationManagement
 
                             WriteVerbose($"Setting retention label to batch {rangeIndex} of items");
                             Microsoft.SharePoint.Client.CompliancePolicy.SPPolicyStoreProxy.SetComplianceTagOnBulkItems(ClientContext, range, rootUrl + list.RootFolder.ServerRelativeUrl, Label);
-                            ClientContext.ExecuteQuery();
+                            ClientContext.ExecuteQueryRetry();
                             ItemIds.RemoveRange(0, itemsToProcess);
                         }
                     }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
NA

## What is in this Pull Request ? ##

The Admin commands in the PnP.PowerShell library have been updated to include the ExecuteQueryRetry method. This change ensures that the ExecuteQuery method is retried in case of failures, improving the reliability of the commands. This change was made in the following files:
- SetHomeSite.cs
- UnlockSensitivityLabelEncryptedFile.cs
- ResetRetentionLabel.cs
- SetRetentionLabel.cs