### PR TITLE
Adding `-IsSharePointAddInsDisabled` to `Set-PnPTenant`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `-IncludeSensitivityLabels` parameter to `Get-PnPMicrosoft365Group` cmdlet to retrieve sensitivity labels assigned to M365 Groups. [#3991](https://github.com/pnp/powershell/pull/3991)
 - Added `Get-PnPFileSensitivityLabelInfo` cmdlet to retrieve sensitivity label information about a file in a SharePoint site. [#3994](https://github.com/pnp/powershell/pull/3994)
 - Added `Get-PnPTenantRestrictedSearchAllowedList` cmdlet to retrieve existing list of URLs in the allowed list. [#3997](https://github.com/pnp/powershell/pull/3997)
-- Added `-IsSharePointAddInsDisabled` to the `Set-PnPTenant` cmdlet which allows disabling SharePoint Add-ins
+- Added `-IsSharePointAddInsDisabled` to the `Set-PnPTenant` cmdlet which allows disabling SharePoint Add-ins [#4032](https://github.com/pnp/powershell/pull/4032)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `-IncludeSensitivityLabels` parameter to `Get-PnPMicrosoft365Group` cmdlet to retrieve sensitivity labels assigned to M365 Groups. [#3991](https://github.com/pnp/powershell/pull/3991)
 - Added `Get-PnPFileSensitivityLabelInfo` cmdlet to retrieve sensitivity label information about a file in a SharePoint site. [#3994](https://github.com/pnp/powershell/pull/3994)
 - Added `Get-PnPTenantRestrictedSearchAllowedList` cmdlet to retrieve existing list of URLs in the allowed list. [#3997](https://github.com/pnp/powershell/pull/3997)
+- Added `-IsSharePointAddInsDisabled` to the `Set-PnPTenant` cmdlet which allows disabling SharePoint Add-ins
 
 ### Fixed
 

--- a/documentation/Set-PnPTenant.md
+++ b/documentation/Set-PnPTenant.md
@@ -154,6 +154,7 @@ Set-PnPTenant [-SpecialCharactersStateInFileFolderNames <SpecialCharactersState>
  [-OneDriveDefaultLinkToExistingAccess <Boolean>]
  [-OneDriveBlockGuestsAsSiteAdmin <SharingState>]
  [-RecycleBinRetentionPeriod <Int32>]
+ [-IsSharePointAddInsDisabled <Boolean>] 
  [-Force] [-Connection <PnPConnection>]
 ```
 
@@ -692,6 +693,24 @@ Accept wildcard characters: False
 
 ### -IsDataAccessInCardDesignerEnabled
 Allows turning on support for data access in the Viva Connections Adaptive Card Designer.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsSharePointAddInsDisabled
+When the feature is enabled, all the add-ins features will be disabled.
+
+The valid values are:
+- False (default) - All the add-ins features are supported.
+- True - All the add-ins features will be disabled.
 
 ```yaml
 Type: Boolean

--- a/src/Commands/Admin/SetTenant.cs
+++ b/src/Commands/Admin/SetTenant.cs
@@ -469,6 +469,9 @@ namespace PnP.PowerShell.Commands.Admin
         [Parameter(Mandatory = false)]
         public int? RecycleBinRetentionPeriod { get; set; }
 
+        [Parameter(Mandatory = false)]
+        public bool? IsSharePointAddInsDisabled { get; set; }
+
         protected override void ExecuteCmdlet()
         {
             AdminContext.Load(Tenant);
@@ -1506,6 +1509,11 @@ namespace PnP.PowerShell.Commands.Admin
             if (RecycleBinRetentionPeriod.HasValue)
             {
                 Tenant.RecycleBinRetentionPeriod = RecycleBinRetentionPeriod.Value;
+                modified = true;
+            }
+            if (IsSharePointAddInsDisabled.HasValue)
+            {
+                Tenant.SharePointAddInsDisabled = IsSharePointAddInsDisabled.Value;
                 modified = true;
             }
             if (BlockDownloadFileTypePolicy.HasValue)


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Adding `-IsSharePointAddInsDisabled` to `Set-PnPTenant` which allows disabling SharePoint Add-Ins prior to the deprecation in 2026