### PR TITLE
Fix error handling in Remove-PnPTeamsChannel

### DIFF
--- a/src/Commands/Teams/RemoveTeamsChannel.cs
+++ b/src/Commands/Teams/RemoveTeamsChannel.cs
@@ -48,15 +48,15 @@ namespace PnP.PowerShell.Commands.Teams
                                 WriteError(new ErrorRecord(new Exception($"Channel remove failed"), "REMOVEFAILED", ErrorCategory.InvalidResult, this));
                             }
                         }
-                        else
-                        {
-                            throw new PSArgumentException("Channel not found");
-                        }
                     }
                     else
                     {
-                        throw new PSArgumentException("Team not found");
+                        throw new PSArgumentException("Channel not found");
                     }
+                }
+                else
+                {
+                    throw new PSArgumentException("Team not found");
                 }
             }
         }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #4035

## What is in this Pull Request ? ##
Fix Remove-PnPTeamsChannel error handling mismatch between "Team not found", "Channel not found" and no error.
A badly positioned `}` was:
- throwing "Team not found" when the channel was not found
- throwing "Channel not found" when the channel was found and deleted
- no error when the team was not found and nothing was deleted

Before:
![image](https://github.com/pnp/powershell/assets/1153754/a4454d56-1b14-407e-a669-c9d2b813d834)

After:
![image](https://github.com/pnp/powershell/assets/1153754/c8674506-cc2b-4e2a-906b-7375bb2285bf)

