### PR TITLE
Handle cases where site creation fails in New-PnPSite

### DIFF
--- a/src/Commands/Admin/NewSite.cs
+++ b/src/Commands/Admin/NewSite.cs
@@ -130,7 +130,8 @@ namespace PnP.PowerShell.Commands
 
                 if (ClientContext.GetContextSettings()?.Type != Framework.Utilities.Context.ClientContextType.SharePointACSAppOnly)
                 {
-                    var returnedContext = Framework.Sites.SiteCollection.Create(ClientContext, creationInformation, noWait: !Wait, graphAccessToken: GraphAccessToken, azureEnvironment: Connection?.AzureEnvironment ?? Framework.AzureEnvironment.Production);
+                    var returnedContext = Framework.Sites.SiteCollection.Create(ClientContext, creationInformation, noWait: !Wait, graphAccessToken: GraphAccessToken, azureEnvironment: Connection?.AzureEnvironment ?? Framework.AzureEnvironment.Production) ?? throw new Exception("An error occurred while creating the site. Some settings might have not been set.");
+
                     if (ParameterSpecified(nameof(TimeZone)))
                     {
                         returnedContext.Web.EnsureProperties(w => w.RegionalSettings, w => w.RegionalSettings.TimeZones);


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Improves #4082

## What is in this Pull Request ? ##
Handle cases where site creation fails in New-PnPSite by throwing a clearer exception.
The previous code would try to dereference `returnedContext` even when null, throwing a `Object reference not set to an instance of an object.` exception. This happens because `Framework.Sites.SiteCollection.Create()` returns null in some cases, like if the site url was not retrieved after enough tries.

I'm not sure if the message should be changed. At this point of the callstack we have no idea what went wrong during the creation and if the site was fully created and configured or not. It might be that there was an issue only when retrieving the SPO ClientContext but everything else worked fine.
In any case, anything should be better than an unhandled null exception 😃 