### PR TITLE
Adding `Remove-PnPAzureADUser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added in depth verbose logging to all cmdlets which is revealed by adding `-Verbose` to the cmdlet execution [#4023](https://github.com/pnp/powershell/pull/4023)
 - Added `-CoreDefaultShareLinkScope` and `-CoreDefaultShareLinkRole` parameters to `Set-PnPTenant` cmdlet. [#4067](https://github.com/pnp/powershell/pull/4067)
 - Added `-Identity` parameter to the `Get-PnPFileSharingLink` cmdlet allowing for the retrieval of sharing links based on the file's unique identifier, file instance, listitem instance, or server relative path and supporting retrieval of sharing links for multiple files, such as all in a document library [#4093](https://github.com/pnp/powershell/pull/4093)
+- Added `Remove-PnPAzureADUser` which allows removal of a user from Azure Active Directory / Entra ID
   
 ### Fixed
 - `Get-PnPTeamsChannel` and `Get-PnPTeamsPrimaryChannel` returning `unknownFutureValue` as MembershipType instead of `shared` [#4054]https://github.com/pnp/powershell/pull/4054

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   
 ### Fixed
 - `Get-PnPTeamsChannel` and `Get-PnPTeamsPrimaryChannel` returning `unknownFutureValue` as MembershipType instead of `shared` [#4054]https://github.com/pnp/powershell/pull/4054
+- Fixed using a AzureADUserPipeBind with `New-PnPAzureADUserTemporaryAccessPass`, `Get-PnPAvailableSensitivityLabel` and `Set-PnPSearchExternalItem` to not work when passing in the User ID GUID [#4123](https://github.com/pnp/powershell/pull/4123)
 
 ### Changed
 - Fixed `Update-PnPTeamsUser` cmdlet to throw a better error message when after a user is removed from a Team but is still in the connected M365 group, for the few seconds that the 2 are out of sync. [#4068](https://github.com/pnp/powershell/pull/4068)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added in depth verbose logging to all cmdlets which is revealed by adding `-Verbose` to the cmdlet execution [#4023](https://github.com/pnp/powershell/pull/4023)
 - Added `-CoreDefaultShareLinkScope` and `-CoreDefaultShareLinkRole` parameters to `Set-PnPTenant` cmdlet. [#4067](https://github.com/pnp/powershell/pull/4067)
 - Added `-Identity` parameter to the `Get-PnPFileSharingLink` cmdlet allowing for the retrieval of sharing links based on the file's unique identifier, file instance, listitem instance, or server relative path and supporting retrieval of sharing links for multiple files, such as all in a document library [#4093](https://github.com/pnp/powershell/pull/4093)
-- Added `Remove-PnPAzureADUser` which allows removal of a user from Azure Active Directory / Entra ID
+- Added `Remove-PnPAzureADUser` which allows removal of a user from Azure Active Directory / Entra ID [#4123](https://github.com/pnp/powershell/pull/4123)
   
 ### Fixed
 - `Get-PnPTeamsChannel` and `Get-PnPTeamsPrimaryChannel` returning `unknownFutureValue` as MembershipType instead of `shared` [#4054]https://github.com/pnp/powershell/pull/4054

--- a/documentation/Remove-PnPAzureADUser.md
+++ b/documentation/Remove-PnPAzureADUser.md
@@ -1,0 +1,121 @@
+---
+Module Name: PnP.PowerShell
+schema: 2.0.0
+applicable: SharePoint Online
+online version: https://pnp.github.io/powershell/cmdlets/Remove-PnPAzureADUser.html
+external help file: PnP.PowerShell.dll-Help.xml
+title: Remove-PnPAzureADUser
+---
+  
+# Remove-PnPAzureADUser
+
+## SYNOPSIS
+
+**Required Permissions**
+
+  * Microsoft Graph API: User.ReadWrite.All
+
+Removes a user from Azure Active Directory / Microsoft Entra ID.
+
+## SYNTAX
+
+```powershell
+Remove-PnPAzureADUser -Identity <AzureADUserPipeBind> [-WhatIf] [-Connection <PnPConnection>] [-Verbose]
+```
+
+## DESCRIPTION
+
+Allows a user to be removed from Azure Active Directory / Microsoft Entra ID. When the user is deleted, the user will be moved to the recycle bin and can be restored within 30 days. After 30 days the user will be permanently deleted.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Remove-PnPAzureADUser -Identity johndoe@contoso.onmicrosoft.com
+```
+
+The user with the provided UPN will be removed from Azure Active Directory.
+
+### EXAMPLE 2
+```powershell
+Remove-PnPAzureADUser -Identity 5a4c547a-1440-4f64-9952-a0c6f1c9e7ea
+```
+
+The user with the provided guid will be removed from Azure Active Directory.
+
+### EXAMPLE 3
+```powershell
+Get-PnPEntraIDUser | Where-Object { $_.OfficeLocation -eq "London" } | Remove-PnPAzureADUser
+```
+
+Removes all users that have their OfficeLocation set to London from Azure Active Directory.
+
+### EXAMPLE 4
+```powershell
+Get-PnPEntraIDUser -Filter "accountEnabled eq false" | Remove-PnPAzureADUser
+```
+
+Removes all disabled user accounts from Azure Active Directory.
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+The identity of the user to remove. This can be the UPN, the GUID or an instance of the user.
+
+```yaml
+Type: AzureADUserPipeBind
+Parameter Sets: (All)
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Verbose
+When provided, additional debug statements will be shown while executing the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+When used in combination with -Verbose, it will show what would happen if the cmdlet runs. The user will not be deleted.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/src/Commands/AzureAD/NewAzureADUserTemporaryAccessPass.cs
+++ b/src/Commands/AzureAD/NewAzureADUserTemporaryAccessPass.cs
@@ -28,7 +28,7 @@ namespace PnP.PowerShell.Commands.Graph
         {
             var accessPass = UsersUtility.RequestTemporaryAccessPass(
                                 accessToken: AccessToken,
-                                userId: Identity.User?.Id?.ToString() ?? Identity.Upn ?? Identity.UserId,
+                                userId: Identity.User?.Id?.ToString() ?? Identity.Upn ?? (Identity.UserId.HasValue ? Identity.UserId.Value.ToString() : null),
                                 startDateTime: StartDateTime,
                                 lifeTimeInMinutes: LifeTimeInMinutes,
                                 isUsableOnce: IsUsableOnce, azureEnvironment: Connection.AzureEnvironment);

--- a/src/Commands/AzureAD/RemoveAzureADUser.cs
+++ b/src/Commands/AzureAD/RemoveAzureADUser.cs
@@ -26,6 +26,7 @@ namespace PnP.PowerShell.Commands.Graph
             if (user == null)
             {
                 WriteWarning($"User provided through the {nameof(Identity)} parameter could not be found");
+                return;
             }
 
             if(WhatIf.ToBool())

--- a/src/Commands/AzureAD/RemoveAzureADUser.cs
+++ b/src/Commands/AzureAD/RemoveAzureADUser.cs
@@ -1,0 +1,51 @@
+﻿using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Base.PipeBinds;
+using System.Management.Automation;
+using PnP.PowerShell.Commands.Model.AzureAD;
+using PnP.PowerShell.Commands.Utilities.REST;
+
+namespace PnP.PowerShell.Commands.Graph
+{
+    [Cmdlet(VerbsCommon.Remove, "PnPAzureADUser")]
+    [RequiredMinimalApiPermissions("User.ReadWrite.All")]
+    [Alias("Remove-PnPEntraIDUser")]
+    public class RemoveAzureADUser : PnPGraphCmdlet
+    {
+        [Parameter(Mandatory = true, ValueFromPipeline = true)]
+        public AzureADUserPipeBind Identity;
+
+        [Parameter(Mandatory = false)]
+        public SwitchParameter WhatIf;
+
+        protected override void ExecuteCmdlet()
+        {
+            WriteVerbose($"Looking up user provided through the {nameof(Identity)} parameter");
+            User user = Identity.GetUser(AccessToken, Connection.AzureEnvironment);
+
+            if (user == null)
+            {
+                WriteWarning($"User provided through the {nameof(Identity)} parameter could not be found");
+            }
+
+            if(WhatIf.ToBool())
+            {
+                WriteVerbose($"Would delete user with Id {user.Id} if {nameof(WhatIf)} was not present");
+                return;
+            }
+
+            WriteVerbose($"Deleting user with Id {user.Id}");
+
+            var graphResult = GraphHelper.Delete(this, Connection, $"v1.0/users/{user.Id}", AccessToken);
+
+            if(graphResult.StatusCode == System.Net.HttpStatusCode.NoContent)
+            {
+                WriteVerbose("User deleted successfully");
+            }
+            else
+            {
+                throw new PSArgumentException("User could not be deleted", nameof(Identity));
+            }
+        }
+    }
+}

--- a/src/Commands/Base/PipeBinds/AzureADUserPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/AzureADUserPipeBind.cs
@@ -11,7 +11,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
     public class AzureADUserPipeBind
     {
         private readonly User _user;
-        private readonly string _userId;
+        private readonly Guid? _userId;
         private readonly string _upn;
 
         public AzureADUserPipeBind()
@@ -28,7 +28,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             Guid idValue;
             if (Guid.TryParse(input, out idValue))
             {
-                _userId = input;
+                _userId = idValue;
             }
             else
             {
@@ -49,7 +49,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
         /// <summary>
         /// GUID of the user account
         /// </summary>
-        public string UserId => _userId;
+        public Guid? UserId => _userId;
 
         /// <summary>
         /// Tries to return the User instace based on the information this pipe has available
@@ -63,13 +63,13 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             {
                 return _user;
             }
-            if (_userId != null)
+            if (_userId.HasValue)
             {
-                return User.CreateFrom(PnP.Framework.Graph.UsersUtility.GetUser(accessToken, _userId, azureEnvironment: azureEnvironment));
+                return User.CreateFrom(Framework.Graph.UsersUtility.GetUser(accessToken, _userId.Value, azureEnvironment: azureEnvironment));
             }
             if (_upn != null)
             {                
-                return User.CreateFrom(PnP.Framework.Graph.UsersUtility.GetUser(accessToken, WebUtility.UrlEncode(_upn), azureEnvironment: azureEnvironment));
+                return User.CreateFrom(Framework.Graph.UsersUtility.GetUser(accessToken, WebUtility.UrlEncode(_upn), azureEnvironment: azureEnvironment));
             }
             return null;
         }

--- a/src/Commands/Search/SetSearchExternalItem.cs
+++ b/src/Commands/Search/SetSearchExternalItem.cs
@@ -128,7 +128,7 @@ namespace PnP.PowerShell.Commands.Search
 
             foreach (var user in users)
             {
-                var userAclId = user.UserId ?? user.GetUser(AccessToken)?.Id.Value.ToString();
+                var userAclId = user.UserId.HasValue ? user.UserId.Value.ToString() : user.GetUser(AccessToken)?.Id.Value.ToString();
 
                 acls.Add(new Model.Graph.MicrosoftSearch.ExternalItemAcl
                 {


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
- Adding `Remove-PnPAzureADUser` which allows removal of a user from Azure Active Directory / Entra ID
- Fixed using a AzureADUserPipeBind with `New-PnPAzureADUserTemporaryAccessPass`, `Get-PnPAvailableSensitivityLabel` and `Set-PnPSearchExternalItem` to not work when passing in the User ID GUID