### PR TITLE
Fix #4105: issue with null reference in Get-PnPFileSharingLink

### DIFF
--- a/src/Commands/Base/PipeBinds/FilePipeBind.cs
+++ b/src/Commands/Base/PipeBinds/FilePipeBind.cs
@@ -79,7 +79,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             {
                 cmdlet?.WriteVerbose("File will be retrieved based on CSOM ListItem instance");
                 ListItem.EnsureProperties(i => i.File, i => i.File.UniqueId);
-                return context.Web.GetFileById(ListItem.File.UniqueId);
+                return !ListItem.File.ServerObjectIsNull() ? context.Web.GetFileById(ListItem.File.UniqueId) : null;
             }
 
             if (Id.HasValue)

--- a/src/Commands/Security/GetFileSharingLink.cs
+++ b/src/Commands/Security/GetFileSharingLink.cs
@@ -50,7 +50,7 @@ namespace PnP.PowerShell.Commands.Security
             }
 
             WriteVerbose("Retrieving file sharing details from Microsoft Graph");
-            var sharingLinks = file.GetShareLinks();
+            var sharingLinks = file?.GetShareLinks();
 
             WriteObject(sharingLinks?.RequestedItems, true);
         }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #4105

## What is in this Pull Request ? ##
Fix issue with null reference in file sharing link when used with list pipebind