### PR TITLE
Fix exception in Get-PnPDiagnostics

### DIFF
--- a/src/Commands/Base/GetDiagnostics.cs
+++ b/src/Commands/Base/GetDiagnostics.cs
@@ -81,7 +81,7 @@ namespace PnP.PowerShell.Commands.Base
                 var correlationId = string.Empty;
                 if (exception.Exception.Data.Contains("CorrelationId"))
                 {
-                    correlationId = exception.Exception.Data["CorrelationId"].ToString();
+                    correlationId = exception.Exception.Data["CorrelationId"]?.ToString();
                 }
                 var timeStampUtc = DateTime.MinValue;
                 if (exception.Exception.Data.Contains("TimeStampUtc"))


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
No related issues

## What is in this Pull Request ? ##
Fix exception in Get-PnPDiagnostics happening when there is no Correlation Id.

This is the exception from Visual Studio:
![image](https://github.com/user-attachments/assets/f5312604-3b6b-494b-acee-64cd09a92d1d)

After the PR the command works correctly:
![image](https://github.com/user-attachments/assets/0a5fdd07-0d8a-4fac-be5d-5bd6e12bc950)


