### PR TITLE
Add `Invoke-PnPAdminRestMethod` cmdlet

### DIFF
--- a/documentation/Invoke-PnPAdminRestMethod.md
+++ b/documentation/Invoke-PnPAdminRestMethod.md
@@ -1,0 +1,140 @@
+---
+Module Name: PnP.PowerShell
+schema: 2.0.0
+applicable: SharePoint Online
+online version: https://pnp.github.io/powershell/cmdlets/Invoke-PnPAdminRestMethod.html
+external help file: PnP.PowerShell.dll-Help.xml
+title: Invoke-PnPAdminRestMethod
+---
+ 
+# Invoke-PnPAdminRestMethod
+
+## SYNOPSIS
+Invokes a REST request towards a SharePoint admin site.
+
+## SYNTAX 
+
+```powershell
+Invoke-PnPAdminRestMethod -Url <String>
+                          [-Method <HttpRequestMethod>]
+                          [-Content <Object>]
+                          [-ContentType <String>]
+                          [-Raw]
+                          [-Connection <PnPConnection>]
+                          [-ResponseHeadersVariable <String>]
+                          [-Batch <PnPBatch>]
+```
+
+## DESCRIPTION
+Invokes a REST request towards a SharePoint admin site.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Invoke-PnPAdminRestMethod -Url "/_api/StorageQuotas()?api-version=1.3.2"
+```
+
+This example retrieves the storage quota from the tenant admin site.
+
+## PARAMETERS
+
+### -Content
+A string or object to send.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Accept pipeline input: False
+```
+
+### -ContentType
+The content type of the object to send. Defaults to 'application/json'.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Accept pipeline input: False
+```
+
+### -Method
+The Http method to execute. Defaults to GET.
+
+```yaml
+Type: HttpRequestMethod
+Parameter Sets: (All)
+
+Required: False
+Position: 0
+Accept pipeline input: False
+```
+
+### -Url
+The url to execute
+
+```yaml
+Type: String
+Parameter Sets: (All)
+
+Required: True
+Position: 0
+Accept pipeline input: False
+```
+
+### -Raw
+If specified the returned data will not be converted to an object but returned as a JSON string.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: True
+Position: 0
+Accept pipeline input: False
+```
+
+### -Accept
+The Accept HTTP request header. Defaults to 'application/json;odata=nometadata'.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Accept pipeline input: False
+```
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Accept pipeline input: False
+```
+
+### -ResponseHeadersVariable
+Creates a variable containing a Response Headers Dictionary. Enter a variable name without the dollar sign ($) symbol. The keys of the dictionary contain the field names and values of the Response Header returned by the web server.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Required: False
+Position: Named
+Accept pipeline input: False
+```
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)
+

--- a/src/Commands/Admin/InvokeAdminRestMethod.cs
+++ b/src/Commands/Admin/InvokeAdminRestMethod.cs
@@ -1,0 +1,208 @@
+using Microsoft.SharePoint.Client;
+using PnP.Core.Model;
+using PnP.Core.Services;
+using PnP.Framework.Http;
+using PnP.Framework.Utilities;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Enums;
+using PnP.PowerShell.Commands.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace PnP.PowerShell.Commands.Admin
+{
+    [Cmdlet(VerbsLifecycle.Invoke, "PnPAdminRestMethod", DefaultParameterSetName = PARAMETERSET_Parsed)]
+    [OutputType(typeof(PSObject), ParameterSetName = new[] { PARAMETERSET_Parsed })]
+    [OutputType(typeof(string), ParameterSetName = new[] { PARAMETERSET_Raw })]
+    [OutputType(typeof(void), ParameterSetName = new[] { PARAMETERSET_Batch })]
+    public class InvokeAdminRestMethod : PnPAdminCmdlet
+    {
+        public const string PARAMETERSET_Parsed = "Parsed";
+        public const string PARAMETERSET_Raw = "Raw";
+        public const string PARAMETERSET_Batch = "Batch";
+
+        [Parameter(Mandatory = false, Position = 0, ParameterSetName = PARAMETERSET_Parsed)]
+        [Parameter(Mandatory = false, Position = 0, ParameterSetName = PARAMETERSET_Raw)]
+        [Parameter(Mandatory = false, Position = 0, ParameterSetName = PARAMETERSET_Batch)]
+        public HttpRequestMethod Method = HttpRequestMethod.Get;
+
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = PARAMETERSET_Parsed)]
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = PARAMETERSET_Raw)]
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = PARAMETERSET_Batch)]
+        public string Url;
+
+        [Parameter(Mandatory = false, ParameterSetName = PARAMETERSET_Parsed)]
+        [Parameter(Mandatory = false, ParameterSetName = PARAMETERSET_Raw)]
+        [Parameter(Mandatory = false, Position = 0, ParameterSetName = PARAMETERSET_Batch)]
+        public object Content;
+
+        [Parameter(Mandatory = false, ParameterSetName = PARAMETERSET_Parsed)]
+        [Parameter(Mandatory = false, ParameterSetName = PARAMETERSET_Raw)]
+        [Parameter(Mandatory = false, Position = 0, ParameterSetName = PARAMETERSET_Batch)]
+        public string ContentType = "application/json";
+
+        [Parameter(Mandatory = false, ParameterSetName = PARAMETERSET_Parsed)]
+        [Parameter(Mandatory = false, ParameterSetName = PARAMETERSET_Raw)]
+        [Parameter(Mandatory = false, Position = 0, ParameterSetName = PARAMETERSET_Batch)]
+        public string Accept = "application/json;odata=nometadata";
+
+        [Parameter(Mandatory = false, ParameterSetName = PARAMETERSET_Raw)]
+        public SwitchParameter Raw;
+
+        [Parameter(Mandatory = false, ParameterSetName = PARAMETERSET_Parsed)]
+        [Parameter(Mandatory = false, ParameterSetName = PARAMETERSET_Raw)]
+        public string ResponseHeadersVariable;
+
+        [Parameter(Mandatory = false, Position = 0, ParameterSetName = PARAMETERSET_Batch)]
+        public PnPBatch Batch;
+
+        protected override void ExecuteCmdlet()
+        {
+            if (Url.StartsWith("/"))
+            {
+                // prefix the url with the current web url
+                Url = UrlUtility.Combine(AdminContext.Url, Url);
+            }
+
+            var method = new HttpMethod(Method.ToString().ToUpper());
+
+            var requestUrl = Url;
+
+            if (string.IsNullOrEmpty(Accept))
+            {
+                Accept = "application/json;odata=nometadata";
+            }
+
+            if (string.IsNullOrEmpty(ContentType))
+            {
+                ContentType = "application/json";
+            }
+
+            if (ParameterSpecified(nameof(Batch)))
+            {
+                CallBatchRequest(method, requestUrl);
+            }
+            else
+            {
+                CallSingleRequest(method, requestUrl);
+            }
+        }
+
+        private void CallSingleRequest(HttpMethod method, string requestUrl)
+        {
+            var httpClient = PnPHttpClient.Instance.GetHttpClient(AdminContext);
+            bool isResponseHeaderRequired = !string.IsNullOrEmpty(ResponseHeadersVariable);
+
+            using (HttpRequestMessage request = new HttpRequestMessage(method, requestUrl))
+            {
+                request.Headers.Add("accept", Accept);
+
+                if (Method == HttpRequestMethod.Merge)
+                {
+                    request.Headers.Add("X-HTTP-Method", "MERGE");
+                }
+
+                if (Method == HttpRequestMethod.Merge || Method == HttpRequestMethod.Delete)
+                {
+                    request.Headers.Add("IF-MATCH", "*");
+                }
+                request.Version = new Version(2, 0);
+
+                PnPHttpClient.AuthenticateRequestAsync(request, AdminContext).GetAwaiter().GetResult();
+
+                if (Method == HttpRequestMethod.Post || Method == HttpRequestMethod.Merge || Method == HttpRequestMethod.Put || Method == HttpRequestMethod.Patch)
+                {
+
+                    var contentString = Content is string ? Content.ToString() :
+                        JsonSerializer.Serialize(Content, new JsonSerializerOptions() { ReferenceHandler = ReferenceHandler.IgnoreCycles, WriteIndented = true });
+                    request.Content = new StringContent(contentString, System.Text.Encoding.UTF8);
+                    request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(ContentType);
+                }
+                HttpResponseMessage response = httpClient.SendAsync(request, new System.Threading.CancellationToken()).Result;
+                Dictionary<string, string> responseHeaders = response?.Content?.Headers?.ToDictionary(a => a.Key, a => string.Join(";", a.Value));
+
+                if (response.IsSuccessStatusCode)
+                {
+                    var responseString = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+
+                    if (!string.IsNullOrEmpty(responseString))
+                    {
+                        if (!Raw)
+                        {
+                            var jsonElement = JsonSerializer.Deserialize<JsonElement>(responseString);
+
+                            string nextLink = string.Empty;
+                            if (jsonElement.TryGetProperty("odata.nextLink", out JsonElement nextLinkProperty))
+                            {
+                                nextLink = nextLinkProperty.ToString();
+                            }
+                            if (jsonElement.TryGetProperty("value", out JsonElement valueProperty))
+                            {
+                                var formattedObject = Utilities.JSON.Convert.ConvertToPSObject(valueProperty, "value");
+                                if (!string.IsNullOrEmpty(nextLink))
+                                {
+                                    formattedObject.Properties.Add(new PSNoteProperty("odata.nextLink", nextLink));
+                                }
+                                WriteObject(formattedObject, true);
+                            }
+                            else
+                            {
+                                WriteObject(Utilities.JSON.Convert.ConvertToPSObject(jsonElement, null), true);
+                            }
+                        }
+                        else
+                        {
+                            WriteObject(responseString);
+                        }
+                    }
+                    if (isResponseHeaderRequired)
+                    {
+                        SessionState.PSVariable.Set(ResponseHeadersVariable, responseHeaders.ToList());
+                    }
+                }
+                else
+                {
+                    if (isResponseHeaderRequired)
+                    {
+                        SessionState.PSVariable.Set(ResponseHeadersVariable, responseHeaders.ToList());
+                    }
+                    // Something went wrong...
+                    throw new Exception(response.Content.ReadAsStringAsync().GetAwaiter().GetResult());
+                }
+            }
+        }
+
+        private void CallBatchRequest(HttpMethod method, string requestUrl)
+        {
+            var web = PnPContext.Web;
+            string contentString = null;
+            if (ParameterSpecified(nameof(Content)))
+            {
+                contentString = Content is string ? Content.ToString() :
+                        JsonSerializer.Serialize(Content, new JsonSerializerOptions() { ReferenceHandler = ReferenceHandler.IgnoreCycles, WriteIndented = true });
+
+            }
+
+            Dictionary<string, string> extraHeaders = new() { { "Accept", Accept } };
+
+            if (Method == HttpRequestMethod.Merge)
+            {
+                extraHeaders.Add("X-HTTP-Method", "MERGE");
+            }
+
+            if (Method == HttpRequestMethod.Merge || Method == HttpRequestMethod.Delete)
+            {
+                extraHeaders.Add("IF-MATCH", "*");
+            }
+            extraHeaders.Add("Content-Type", ContentType);
+
+            web.WithHeaders(extraHeaders).ExecuteRequestBatch(Batch.Batch, new ApiRequest(method, ApiRequestType.SPORest, requestUrl, contentString));
+        }
+    }
+}

--- a/src/Tests/Admin/InvokePnPAdminRestMethodTests.cs
+++ b/src/Tests/Admin/InvokePnPAdminRestMethodTests.cs
@@ -1,0 +1,86 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Management.Automation.Runspaces;
+
+namespace PnP.PowerShell.Tests.Admin
+{
+    [TestClass]
+    public class InvokeSPRestMethodTests
+    {
+        #region Test Setup/CleanUp
+        [ClassInitialize]
+        public static void Initialize(TestContext testContext)
+        {
+            // This runs on class level once before all tests run
+            //using (var ctx = TestCommon.CreateClientContext())
+            //{
+            //}
+        }
+
+        [ClassCleanup]
+        public static void Cleanup(TestContext testContext)
+        {
+            // This runs on class level once
+            //using (var ctx = TestCommon.CreateClientContext())
+            //{
+            //}
+        }
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            using (var scope = new PSTestScope())
+            {
+                // Example
+                // scope.ExecuteCommand("cmdlet", new CommandParameter("param1", prop));
+            }
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            using (var scope = new PSTestScope())
+            {
+                try
+                {
+                    // Do Test Setup - Note, this runs PER test
+                }
+                catch (Exception)
+                {
+                    // Describe Exception
+                }
+            }
+        }
+        #endregion
+
+        #region Scaffolded Cmdlet Tests
+        //TODO: This is a scaffold of the cmdlet - complete the unit test
+        //[TestMethod]
+        public void InvokePnPAdminRestMethodTest()
+        {
+            using (var scope = new PSTestScope(true))
+            {
+                // Complete writing cmd parameters
+
+                // From Cmdlet Help: The Http method to execute. Defaults to GET.
+                var method = "";
+                // This is a mandatory parameter
+                // From Cmdlet Help: The url to execute.
+                var url = "";
+                // From Cmdlet Help: A string or object to send
+                var content = "";
+                // From Cmdlet Help: The content type of the object to send. Defaults to 'application/json'
+                var contentType = "";
+
+                var results = scope.ExecuteCommand("Invoke-PnPAdminRestMethod",
+                    new CommandParameter("Method", method),
+                    new CommandParameter("Url", url),
+                    new CommandParameter("Content", content),
+                    new CommandParameter("ContentType", contentType));
+                
+                Assert.IsNotNull(results);
+            }
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## What is in this Pull Request ? ##
This adds the Cmdlet `Invoke-PnPAdminRestMethod` to invoke a REST method in the admin context.

An example is for retrieving the SharePoint Storage Quotas of the tenant at `/_api/StorageQuotas()?api-version=1.3.2` of the tenant SharePoint Admin URL.

This code is a clone of the `Invoke-PnPSPRestMethod`, but using the AdminContext.
