### PR TITLE
Fixed issue with `Set-PnPSearchExternalSchema` cmdlet when used with the `-Wait` parameter throwing a warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed issue with `Set-PnPSearchExternalSchema` cmdlet when used with the `-Wait` parameter throwing a warning
+  
 ### Removed
 
 ### Contributors
 
+- Koen Zomers [koenzomers]
 
 ## [2.12.0]
 

--- a/src/Commands/Model/Graph/OperationStatus.cs
+++ b/src/Commands/Model/Graph/OperationStatus.cs
@@ -1,5 +1,4 @@
-using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace PnP.PowerShell.Commands.Model.Graph
 {
@@ -11,19 +10,19 @@ namespace PnP.PowerShell.Commands.Model.Graph
         /// <summary>
         /// Unique identifier of the operation
         /// </summary>
-        [JsonProperty("id")]
-        public Guid? Id { get; set; }
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
 
         /// <summary>
         /// The status of the operation
         /// </summary>
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public string Status { get; set; }
 
         /// <summary>
         /// The error message, if anything went wrong
         /// </summary>
-        [JsonProperty("error")]
+        [JsonPropertyName("error")]
         public string Error { get; set; }
     }
 }


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Fixed issue with `Set-PnPSearchExternalSchema` cmdlet when used with the `-Wait` parameter throwing a warning