### PR TITLE
Fix Add-PnPDataRowsToSiteTemplate setting KeyColumn to null

### DIFF
--- a/src/Commands/Provisioning/Site/AddDataRowsToSiteTemplate.cs
+++ b/src/Commands/Provisioning/Site/AddDataRowsToSiteTemplate.cs
@@ -83,7 +83,7 @@ namespace PnP.PowerShell.Commands.Provisioning.Site
                 throw new ApplicationException("List does not exist in the template file!");
             }
 
-            if (string.IsNullOrEmpty(KeyColumn))
+            if (!string.IsNullOrEmpty(KeyColumn))
             {
                 listInstance.DataRows.KeyColumn = KeyColumn;
             }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes https://github.com/pnp/pnpframework/issues/1020

## What is in this Pull Request ? ##
This PR fixes Add-PnPDataRowsToSiteTemplate setting KeyColumn to null when the -KeyColumn parameter is not passed. It also fixes the case of -KeyColumn parameter value being ignored.
The old code was updating `listInstance.DataRows.KeyColumn` only when the `-KeyColumn` parameter was null, but it should update it only when it's not null.

How to reproduce steps:
1. Get a list template
```powershell
Get-PnPSiteTemplate -ListsToExtract "Test simple list" -Handlers Lists -Out "list.xml"
```
2. Manually add a DataRows section to the ListInstance with KeyColumn value set
```xml
<pnp:DataRows UpdateBehavior="Overwrite" KeyColumn="Title">
</pnp:DataRows>
```
3. Call Add-PnPDataRowsToSiteTemplate without -KeyColumn parameter
```powershell
Add-PnPDataRowsToSiteTemplate -List "Test simple list" -Path "list.xml"
```
4. Check the KeyColumn attribute in the template