### PR TITLE
Fix Get-PnPSiteTEmplate not exporting language resource files

### DIFF
--- a/src/Commands/Provisioning/Site/GetSiteTemplate.cs
+++ b/src/Commands/Provisioning/Site/GetSiteTemplate.cs
@@ -249,7 +249,7 @@ namespace PnP.PowerShell.Commands.Provisioning.Site
             {
                 creationInformation.ContentTypeGroupsToInclude = ContentTypeGroups.ToList();
             }
-            if (ParameterSpecified(nameof(PersistMultiLanguageResources)) && ContentTypeGroups != null)
+            if (ParameterSpecified(nameof(PersistMultiLanguageResources)))
             {
                 creationInformation.PersistMultiLanguageResources = PersistMultiLanguageResources;
             }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes https://github.com/pnp/powershell/issues/4300 and https://github.com/pnp/pnpframework/issues/999

## What is in this Pull Request ? ##
This PR fixes Get-PnPSiteTemplate not exporting language resource files when using .xml templates as output format and passing `-PersistMultiLanguageResources` parameter. This happened due to a copypaste error from the code above related to ContentTypeGroups, which is not relevant for `-PersistMultiLanguageResources` parameter.

Templates with .pnp extension didn't have this issue as PersistMultiLanguageResources is always set to true in that case.

How to reproduce steps:
- Go to Site Settings and then Language Settings. You can use /_layouts/15/muisetng.aspx relative url to reach the page.
- Enable "Enable translation into multiple languages"
- Add an additional language
- Export a template with `-PersistMultiLanguageResources` parameter
```powershell
Get-PnPSiteTemplate -Out "Template.xml" -PersistBrandingFiles -IncludeAllPages -PersistMultiLanguageResources
```

This is the result with this PR:
![image](https://github.com/user-attachments/assets/2e0412fc-eadc-4a7e-b10b-ef5b0d4fb42a)