### PR TITLE
Add support for LaunchBrowser in EntraID app creation

### DIFF
--- a/documentation/Register-PnPAzureADApp.md
+++ b/documentation/Register-PnPAzureADApp.md
@@ -41,6 +41,7 @@ Register-PnPAzureADApp -ApplicationName <String>
                                        [-MicrosoftGraphEndPoint <string>]
                                        [-EntraIDLoginEndPoint <string>]
                                        [-SignInAudience <EntraIDSignInAudience>]
+                                       [-LaunchBrowser <SwitchParameter>]
 ```
 
 ### Existing Certificate
@@ -59,6 +60,7 @@ Register-PnPAzureADApp  -CertificatePath <String>
                         [-CertificatePassword <SecureString>]
                         [-NoPopup]
                         [-LogoFilePath <string>]
+                        [-LaunchBrowser <SwitchParameter>]
 ```
 
 ## DESCRIPTION
@@ -434,6 +436,21 @@ Parameter Sets: Generate Certificate
 Required: False
 Position: Named
 Accept pipeline input: False
+```
+
+### -LaunchBrowser
+Launch a browser automatically and copy the code to enter to the clipboard
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: DeviceLogin
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
 ```
 
 ## RELATED LINKS

--- a/documentation/Register-PnPEntraIDAppForInteractiveLogin.md
+++ b/documentation/Register-PnPEntraIDAppForInteractiveLogin.md
@@ -28,6 +28,7 @@ Register-PnPEntraIDAppForInteractiveLogin -ApplicationName <String>
                                        [-MicrosoftGraphEndPoint <string>]
                                        [-EntraIDLoginEndPoint <string>]
                                        [-SignInAudience <EntraIDSignInAudience>]
+                                       [-LaunchBrowser <SwitchParameter>]
 ```
 
 ### Generate App using Device Login
@@ -42,6 +43,7 @@ Register-PnPEntraIDAppForInteractiveLogin -ApplicationName <String>
                                        [-NoPopup]
                                        [-LogoFilePath <string>]
                                        [-SignInAudience <EntraIDSignInAudience>]
+                                       [-LaunchBrowser <SwitchParameter>]
 ```
 
 ## DESCRIPTION
@@ -225,6 +227,21 @@ Parameter Sets: Generate Certificate
 Required: False
 Position: Named
 Accept pipeline input: False
+```
+
+### -LaunchBrowser
+Launch a browser automatically and copy the code to enter to the clipboard
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: DeviceLogin
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
 ```
 
 ## RELATED LINKS

--- a/src/Commands/AzureAD/RegisterAzureADApp.cs
+++ b/src/Commands/AzureAD/RegisterAzureADApp.cs
@@ -19,6 +19,7 @@ using PnP.PowerShell.Commands.Base;
 using System.Diagnostics;
 using System.Dynamic;
 using PnP.PowerShell.Commands.Enums;
+using TextCopy;
 
 namespace PnP.PowerShell.Commands.AzureAD
 {
@@ -103,6 +104,9 @@ namespace PnP.PowerShell.Commands.AzureAD
 
         [Parameter(Mandatory = false)]
         public EntraIDSignInAudience SignInAudience;
+
+        [Parameter(Mandatory = false, ParameterSetName = "DeviceLogin")]
+        public SwitchParameter LaunchBrowser;
 
         protected override void ProcessRecord()
         {
@@ -433,7 +437,7 @@ namespace PnP.PowerShell.Commands.AzureAD
             {
                 Task.Factory.StartNew(() =>
                 {
-                    token = AzureAuthHelper.AuthenticateDeviceLogin(cancellationTokenSource, messageWriter, NoPopup, AzureEnvironment, MicrosoftGraphEndPoint);
+                    token = AzureAuthHelper.AuthenticateDeviceLogin(cancellationTokenSource, messageWriter, NoPopup, AzureEnvironment, MicrosoftGraphEndPoint, launchBrowser: LaunchBrowser);
                     if (token == null)
                     {
                         messageWriter.WriteWarning("Operation cancelled or no token retrieved.");
@@ -683,10 +687,8 @@ namespace PnP.PowerShell.Commands.AzureAD
 
             if (OperatingSystem.IsWindows() && !NoPopup)
             {
-
                 if (!Stopping)
                 {
-
                     if (ParameterSpecified(nameof(Interactive)))
                     {
                         using (var authManager = AuthenticationManager.CreateWithInteractiveLogin(azureApp.AppId, (url, port) =>
@@ -694,6 +696,21 @@ namespace PnP.PowerShell.Commands.AzureAD
                              BrowserHelper.OpenBrowserForInteractiveLogin(url, port, true, cancellationTokenSource);
                          }, Tenant, "You successfully provided consent", "You failed to provide consent.", AzureEnvironment))
                         {
+                            authManager.ClearTokenCache();
+                            authManager.GetAccessToken(resource, Microsoft.Identity.Client.Prompt.Consent);
+                        }
+                    }
+                    else if (ParameterSpecified(nameof(DeviceLogin)) && LaunchBrowser)
+                    {
+                        using (var authManager = AuthenticationManager.CreateWithDeviceLogin(azureApp.AppId, Tenant, (deviceCodeResult) =>
+                        {
+                            ClipboardService.SetText(deviceCodeResult.UserCode);
+                            messageWriter.WriteWarning($"\n\nCode {deviceCodeResult.UserCode} has been copied to your clipboard and a new tab in the browser has been opened. Please paste this code in there and proceed.\n\n");
+                            BrowserHelper.OpenBrowserForInteractiveLogin(deviceCodeResult.VerificationUrl, BrowserHelper.FindFreeLocalhostRedirectUri(), false, cancellationTokenSource);
+                            return Task.FromResult(0);
+                        }, AzureEnvironment))
+                        {
+                            authManager.ClearTokenCache();
                             authManager.GetAccessToken(resource, Microsoft.Identity.Client.Prompt.Consent);
                         }
                     }

--- a/src/Commands/AzureAD/RegisterEntraIDAppForInteractiveLogin.cs
+++ b/src/Commands/AzureAD/RegisterEntraIDAppForInteractiveLogin.cs
@@ -15,6 +15,7 @@ using PnP.PowerShell.Commands.Base;
 using System.Diagnostics;
 using System.Dynamic;
 using PnP.PowerShell.Commands.Enums;
+using TextCopy;
 
 namespace PnP.PowerShell.Commands.AzureAD
 {
@@ -52,6 +53,9 @@ namespace PnP.PowerShell.Commands.AzureAD
 
         [Parameter(Mandatory = false)]
         public EntraIDSignInAudience SignInAudience;
+
+        [Parameter(Mandatory = false, ParameterSetName = "DeviceLogin")]
+        public SwitchParameter LaunchBrowser;
 
         protected override void ProcessRecord()
         {
@@ -354,7 +358,7 @@ namespace PnP.PowerShell.Commands.AzureAD
             {
                 Task.Factory.StartNew(() =>
                 {
-                    token = AzureAuthHelper.AuthenticateDeviceLogin(cancellationTokenSource, messageWriter, NoPopup, AzureEnvironment, MicrosoftGraphEndPoint);
+                    token = AzureAuthHelper.AuthenticateDeviceLogin(cancellationTokenSource, messageWriter, NoPopup, AzureEnvironment, MicrosoftGraphEndPoint, launchBrowser: LaunchBrowser);
                     if (token == null)
                     {
                         messageWriter.WriteWarning("Operation cancelled or no token retrieved.");
@@ -497,13 +501,10 @@ namespace PnP.PowerShell.Commands.AzureAD
             progressRecord.RecordType = ProgressRecordType.Completed;
             WriteProgress(progressRecord);
 
-
             if (OperatingSystem.IsWindows() && !NoPopup)
             {
-
                 if (!Stopping)
                 {
-
                     if (ParameterSpecified(nameof(Interactive)))
                     {
                         using (var authManager = AuthenticationManager.CreateWithInteractiveLogin(azureApp.AppId, (url, port) =>
@@ -511,6 +512,21 @@ namespace PnP.PowerShell.Commands.AzureAD
                              BrowserHelper.OpenBrowserForInteractiveLogin(url, port, true, cancellationTokenSource);
                          }, Tenant, "You successfully provided consent", "You failed to provide consent.", AzureEnvironment))
                         {
+                            authManager.ClearTokenCache();
+                            authManager.GetAccessToken(resource, Microsoft.Identity.Client.Prompt.Consent);
+                        }
+                    }
+                    else if (ParameterSpecified(nameof(DeviceLogin)) && LaunchBrowser)
+                    {
+                        using (var authManager = AuthenticationManager.CreateWithDeviceLogin(azureApp.AppId, Tenant, (deviceCodeResult) =>
+                        {
+                            ClipboardService.SetText(deviceCodeResult.UserCode);
+                            messageWriter.WriteWarning($"\n\nCode {deviceCodeResult.UserCode} has been copied to your clipboard and a new tab in the browser has been opened. Please paste this code in there and proceed.\n\n");
+                            BrowserHelper.OpenBrowserForInteractiveLogin(deviceCodeResult.VerificationUrl, BrowserHelper.FindFreeLocalhostRedirectUri(), false, cancellationTokenSource);
+                            return Task.FromResult(0);
+                        }, AzureEnvironment))
+                        {
+                            authManager.ClearTokenCache();
                             authManager.GetAccessToken(resource, Microsoft.Identity.Client.Prompt.Consent);
                         }
                     }

--- a/src/Commands/Utilities/AzureAuthHelper.cs
+++ b/src/Commands/Utilities/AzureAuthHelper.cs
@@ -17,7 +17,7 @@ namespace PnP.PowerShell.Commands.Utilities
                 throw new ArgumentException($"{nameof(tenantId)} is required");
             }
 
-            using (var authManager = PnP.Framework.AuthenticationManager.CreateWithCredentials(CLIENTID , username, password, azureEnvironment: azureEnvironment))
+            using (var authManager = PnP.Framework.AuthenticationManager.CreateWithCredentials(CLIENTID, username, password, azureEnvironment: azureEnvironment))
             {
                 var graphEndpoint = $"https://{AuthenticationManager.GetGraphEndPoint(azureEnvironment)}";
                 if (azureEnvironment == AzureEnvironment.Custom)
@@ -28,17 +28,22 @@ namespace PnP.PowerShell.Commands.Utilities
             }
         }
 
-        internal static string AuthenticateDeviceLogin(CancellationTokenSource cancellationTokenSource, CmdletMessageWriter messageWriter, bool noPopup, AzureEnvironment azureEnvironment, string clientId = "1950a258-227b-4e31-a9cf-717495945fc2", string customGraphEndpoint = "")
+        internal static string AuthenticateDeviceLogin(CancellationTokenSource cancellationTokenSource, CmdletMessageWriter messageWriter, bool noPopup, AzureEnvironment azureEnvironment, string clientId = "1950a258-227b-4e31-a9cf-717495945fc2", string customGraphEndpoint = "", bool launchBrowser = false)
         {
             try
-            {   
-                using (var authManager = PnP.Framework.AuthenticationManager.CreateWithDeviceLogin("1950a258-227b-4e31-a9cf-717495945fc2", (result) =>
+            {
+                using (var authManager = PnP.Framework.AuthenticationManager.CreateWithDeviceLogin(CLIENTID, (result) =>
                 {
-
-                    if (Utilities.OperatingSystem.IsWindows() && !noPopup)
+                    if (launchBrowser)
                     {
                         ClipboardService.SetText(result.UserCode);
-                        messageWriter.WriteWarning($"Please login.\n\nWe opened a browser and navigated to {result.VerificationUrl}\n\nEnter code: {result.UserCode} (we copied this code to your clipboard)\n\nNOTICE: close the popup after you authenticated successfully to continue the process.");
+                        messageWriter.WriteWarning($"Please login.\n\nWe opened a browser and navigated to {result.VerificationUrl}\n\nEnter code: {result.UserCode} (we copied this code to your clipboard)\n\nNOTICE: close the browser tab after you authenticated successfully to continue the process.");
+                        BrowserHelper.OpenBrowserForInteractiveLogin(result.VerificationUrl, BrowserHelper.FindFreeLocalhostRedirectUri(), false, cancellationTokenSource);
+                    }
+                    else if (!noPopup)
+                    {
+                        ClipboardService.SetText(result.UserCode);
+                        messageWriter.WriteWarning($"Please login.\n\nWe opened a popup window and navigated to {result.VerificationUrl}\n\nEnter code: {result.UserCode} (we copied this code to your clipboard)\n\nNOTICE: close the popup after you authenticated successfully to continue the process.");
                         BrowserHelper.GetWebBrowserPopup(result.VerificationUrl, "Please login for PnP PowerShell", cancellationTokenSource: cancellationTokenSource, cancelOnClose: false);
                     }
                     else
@@ -106,6 +111,6 @@ namespace PnP.PowerShell.Commands.Utilities
                 cancellationTokenSource.Cancel();
             }
             return null;
-        }        
+        }
     }
 }


### PR DESCRIPTION
- Added support for the `-LaunchBrowser` parameter to automatically launch a browser and copy the code to enter to the clipboard during app registration.
- Updated the documentation to include information about the new `-LaunchBrowser` parameter.

Related work items: #4299

Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [x] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #4299

## What is in this Pull Request ? ##
Additional param to open browser window