### PR TITLE
Fixed `Get-PnPAzureADAppSitePermission`, `Grant-PnPAzureADAppSitePermission` and `Revoke-PnPAzureADAppSitePermission` cmdlets throwing an error when the site URL is not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fix `Add-PnPDataRowsToSiteTemplate` setting keyColumn to null when not passed. [#4325](https://github.com/pnp/powershell/pull/4325)
 - Fix `Connect-PnPOnline` not working correctly when `-DeviceLogin` and `-LaunchBrowser` both are specified. It used to open it in a popup. Now it correctly launches the browser. [#4325](https://github.com/pnp/powershell/pull/4345)
 - `Export-PnPUserInfo`, `Export-PnPUserProfile` and `Remove-PnPUserProfile` cmdlets now work properly with proper `-Connection` parameter if specified. [#4389](https://github.com/pnp/powershell/pull/4389)
- 
+- Fixed `Get-PnPAzureADAppSitePermission`, `Grant-PnPAzureADAppSitePermission` and `Revoke-PnPAzureADAppSitePermission` cmdlets throwing an error when the site URL is not specified and the app registration used only having Graph permissions
+
 ### Removed
 
 - Removed `Publish-PnPCompanyApp` cmdlet as it was not supported anymore. [#4387](https://github.com/pnp/powershell/pull/4387)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fix `Add-PnPDataRowsToSiteTemplate` setting keyColumn to null when not passed. [#4325](https://github.com/pnp/powershell/pull/4325)
 - Fix `Connect-PnPOnline` not working correctly when `-DeviceLogin` and `-LaunchBrowser` both are specified. It used to open it in a popup. Now it correctly launches the browser. [#4325](https://github.com/pnp/powershell/pull/4345)
 - `Export-PnPUserInfo`, `Export-PnPUserProfile` and `Remove-PnPUserProfile` cmdlets now work properly with proper `-Connection` parameter if specified. [#4389](https://github.com/pnp/powershell/pull/4389)
-- Fixed `Get-PnPAzureADAppSitePermission`, `Grant-PnPAzureADAppSitePermission` and `Revoke-PnPAzureADAppSitePermission` cmdlets throwing an error when the site URL is not specified and the app registration used only having Graph permissions
+- Fixed `Get-PnPAzureADAppSitePermission`, `Grant-PnPAzureADAppSitePermission` and `Revoke-PnPAzureADAppSitePermission` cmdlets throwing an error when the site URL is not specified and the app registration used only having Graph permissions [#4421](https://github.com/pnp/powershell/pull/4421)
 
 ### Removed
 

--- a/src/Commands/Apps/GetAzureADAppSitePermission.cs
+++ b/src/Commands/Apps/GetAzureADAppSitePermission.cs
@@ -11,7 +11,7 @@ using PnP.PowerShell.Commands.Utilities.REST;
 namespace PnP.PowerShell.Commands.Apps
 {
     [Cmdlet(VerbsCommon.Get, "PnPAzureADAppSitePermission", DefaultParameterSetName = ParameterSet_ALL)]
-    [RequiredApiApplicationPermissions("graph/Sites.FullControl.All")]
+    [RequiredApiDelegatedOrApplicationPermissions("graph/Sites.FullControl.All")]
     [Alias("Get-PnPEntraIDAppSitePermission")]
     public class GetPnPAzureADAppSitePermission : PnPGraphCmdlet
     {
@@ -41,7 +41,7 @@ namespace PnP.PowerShell.Commands.Apps
             }
             else
             {
-                siteId = PnPContext.Site.Id;
+                siteId = new SitePipeBind(Connection.Url).GetSiteIdThroughGraph(Connection, AccessToken);
             }
 
             if (siteId != Guid.Empty)

--- a/src/Commands/Apps/GrantAzureADAppSitePermission.cs
+++ b/src/Commands/Apps/GrantAzureADAppSitePermission.cs
@@ -12,7 +12,7 @@ using PnP.PowerShell.Commands.Utilities;
 namespace PnP.PowerShell.Commands.Apps
 {
     [Cmdlet(VerbsSecurity.Grant, "PnPAzureADAppSitePermission")]
-    [RequiredApiApplicationPermissions("graph/Sites.FullControl.All")]
+    [RequiredApiDelegatedOrApplicationPermissions("graph/Sites.FullControl.All")]
     [Alias("Grant-PnPEntraIDAppSitePermission")]
     [OutputType(typeof(AzureADAppPermissionInternal))]
     public class GrantPnPAzureADAppSitePermission : PnPGraphCmdlet
@@ -44,7 +44,7 @@ namespace PnP.PowerShell.Commands.Apps
             else
             {
                 WriteVerbose($"No specific site passed in through -{nameof(Site)}, taking the currently connected to site");
-                siteId = PnPContext.Site.Id;
+                siteId = new SitePipeBind(Connection.Url).GetSiteIdThroughGraph(Connection, AccessToken);
                 WriteVerbose($"Currently connected to site has Id {siteId}");
             }
 

--- a/src/Commands/Apps/RevokeAzureADAppSitePermission.cs
+++ b/src/Commands/Apps/RevokeAzureADAppSitePermission.cs
@@ -7,7 +7,7 @@ using PnP.PowerShell.Commands.Base.PipeBinds;
 namespace PnP.PowerShell.Commands.Apps
 {
     [Cmdlet(VerbsSecurity.Revoke, "PnPAzureADAppSitePermission")]
-    [RequiredApiApplicationPermissions("graph/Sites.FullControl.All")]
+    [RequiredApiDelegatedOrApplicationPermissions("graph/Sites.FullControl.All")]
     [Alias("Revoke-PnPEntraIDAppSitePermission")]
     public class RevokePnPAzureADAppSitePermission : PnPGraphCmdlet
     {
@@ -31,14 +31,14 @@ namespace PnP.PowerShell.Commands.Apps
             }
             else
             {
-                siteId = PnPContext.Site.Id;
+                siteId = new SitePipeBind(Connection.Url).GetSiteIdThroughGraph(Connection, AccessToken);
             }
 
             if (siteId != Guid.Empty)
             {
                 if (Force || ShouldContinue("Are you sure you want to revoke the permissions?", string.Empty))
                 {
-                    var results = PnP.PowerShell.Commands.Utilities.REST.RestHelper.Delete(Connection.HttpClient, $"https://{Connection.GraphEndPoint}/v1.0/sites/{siteId}/permissions/{PermissionId}", AccessToken);
+                    var results = Utilities.REST.RestHelper.Delete(Connection.HttpClient, $"https://{Connection.GraphEndPoint}/v1.0/sites/{siteId}/permissions/{PermissionId}", AccessToken);
                 }
             }
         }


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Fixed `Get-PnPAzureADAppSitePermission`, `Grant-PnPAzureADAppSitePermission` and `Revoke-PnPAzureADAppSitePermission` cmdlets throwing an error when the site URL is not specified and the app registration used only having Graph permissions. This error occurred as it used the SharePoint API to get the current site Id if no site was provided. This would require SharePoint permissions as well. By rewriting it to use Graph to get the site Id, it only needs Graph permissions, which it needed already anyway to work with the sitepermissions, which is more secure.