### PR TITLE
Exclude pre-release versions in version check for stable releases

### DIFF
--- a/src/Commands/Utilities/VersionChecker.cs
+++ b/src/Commands/Utilities/VersionChecker.cs
@@ -158,7 +158,7 @@ namespace PnP.PowerShell.Commands.Utilities
             
             // Deliberately lowering timeout as the version check is not critical so in case of a slower or blocked internet connection, this should not block the cmdlet for too long
             httpClient.Timeout = TimeSpan.FromSeconds(VersionCheckTimeOut);
-            var request = new HttpRequestMessage(HttpMethod.Get, "https://www.powershellgallery.com/api/v2/FindPackagesById()?id='PnP.PowerShell'&$top=10&$orderby=Created%20desc");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"https://www.powershellgallery.com/api/v2/FindPackagesById()?id='PnP.PowerShell'&$top=10&$orderby=Created%20desc{(isNightly ? "" : "&$filter=IsPrerelease%20eq%20false")}");
             request.Version = new Version(2, 0);
             var response = httpClient.SendAsync(request).GetAwaiter().GetResult();
             if (response.IsSuccessStatusCode)


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #4408 after next release.

## What is in this Pull Request ? ##
Exclude pre-release versions in version check for stable releases by appending `$filter=IsPrerelease eq false` to the PowerShell Gallery feed url in those cases.
Nightly releases will continue to include pre-releases like they do already now.

This is the message displayed when simulating version 2.11.0 using url https://www.powershellgallery.com/api/v2/FindPackagesById()?id='PnP.PowerShell'&$top=10&$orderby=Created%20desc&$filter=IsPrerelease%20eq%20false :
![Screenshot 2024-10-19 180334](https://github.com/user-attachments/assets/a475bdaa-614c-4e3d-8fea-80b3d5724dae)


This is the message displayed when using a nightly build using url https://www.powershellgallery.com/api/v2/FindPackagesById()?id='PnP.PowerShell'&$top=10&$orderby=Created%20desc :
![image](https://github.com/user-attachments/assets/48f6b97c-9d40-4747-ad63-767fd882aea8)

