### PR TITLE
Added required permissions warning to Submit-PnPSearchQuery

### DIFF
--- a/documentation/Submit-PnPSearchQuery.md
+++ b/documentation/Submit-PnPSearchQuery.md
@@ -12,6 +12,14 @@ online version: https://pnp.github.io/powershell/cmdlets/Submit-PnPSearchQuery.h
 ## SYNOPSIS
 Executes an arbitrary search query against the SharePoint search index.
 
+**Required Permissions**
+
+|        Type      |                    API/ Permission Name                    |                    Admin consent required                    |
+| --------------- | --------------------------------------- | -------- |
+| Application       | sharepoint/Sites.Read.All | yes                               |
+| Delegated       | sharepoint/Sites.Search.All | yes                               |
+
+
 ## SYNTAX
 
 ### Limit (Default)

--- a/documentation/Submit-PnPSearchQuery.md
+++ b/documentation/Submit-PnPSearchQuery.md
@@ -14,9 +14,9 @@ Executes an arbitrary search query against the SharePoint search index.
 
 **Required Permissions**
 
-|        Type      |                    API/ Permission Name                    |                    Admin consent required                    |
+|        Type     |                    API/ Permission Name                    |                    Admin consent required                    |
 | --------------- | --------------------------------------- | -------- |
-| Application       | sharepoint/Sites.Read.All | yes                               |
+| Application     | sharepoint/Sites.Read.All, sharepoint/Sites.ReadWrite.All, sharepoint/Sites.Manage.All or sharepoint/Sites.FullControl.All | yes                               |
 | Delegated       | sharepoint/Sites.Search.All | yes                               |
 
 

--- a/src/Commands/Search/SubmitSearchQuery.cs
+++ b/src/Commands/Search/SubmitSearchQuery.cs
@@ -13,6 +13,9 @@ namespace PnP.PowerShell.Commands.Search
     [Cmdlet(VerbsLifecycle.Submit, "PnPSearchQuery", DefaultParameterSetName = "Limit")]
     [RequiredApiDelegatedPermissions("sharepoint/Sites.Search.All")]
     [RequiredApiApplicationPermissions("sharepoint/Sites.Read.All")]
+    [RequiredApiApplicationPermissions("sharepoint/Sites.ReadWrite.All")]
+    [RequiredApiApplicationPermissions("sharepoint/Sites.Manage.All")]
+    [RequiredApiApplicationPermissions("sharepoint/Sites.FullControl.All")]
     [Alias("Invoke-PnPSearchQuery")]
     public class SubmitSearchQuery : PnPWebCmdlet
     {

--- a/src/Commands/Search/SubmitSearchQuery.cs
+++ b/src/Commands/Search/SubmitSearchQuery.cs
@@ -6,10 +6,13 @@ using Microsoft.SharePoint.Client.Search.Query;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using PnP.PowerShell.Commands.Attributes;
 
 namespace PnP.PowerShell.Commands.Search
 {
     [Cmdlet(VerbsLifecycle.Submit, "PnPSearchQuery", DefaultParameterSetName = "Limit")]
+    [RequiredApiDelegatedPermissions("sharepoint/Sites.Search.All")]
+    [RequiredApiApplicationPermissions("sharepoint/Sites.Read.All")]
     [Alias("Invoke-PnPSearchQuery")]
     public class SubmitSearchQuery : PnPWebCmdlet
     {


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #X, partially fixes #Y, mentioned in #4472  and #4353, etc.

## What is in this Pull Request ? ##
Added required permissions warning to ```Submit-PnPSearchQuery``` command. 

## Test scenario ## 

1. Removed all the API permissions on the Azure AD App
2. Connected via Device Login using ClientID as below, 
```
PS C:\Research\PnPCommunity\powershell> Connect-PnPOnline -ClientId xxxx -Url "https://xxxx.sharepoint.com" -DeviceLogin -LaunchBrowser -Tenant xxx
WARNING:
  
  
 Code abcdefg has been copied to your clipboard and a new tab in the browser has been opened. Please paste this
 code in there and proceed.
  
  


PS C:\Research\PnPCommunity\powershell> Submit-PnPSearchQuery -Query "contentclass:STS_ListItem_DocumentLibrary" -SelectProperties ComplianceTag,InformationProtectionLabelId -All

Submit-PnPSearchQuery: The current principal does not have permission to execute queries on behalf of other users.
PS C:\Research\PnPCommunity\powershell>
```
3. Connected via App only context as below, 

```
PS C:\Research\PnPCommunity\powershell> Connect-PnPOnline -ClientId xxxx -Url "https://xxxx.sharepoint.com" -Tenant xxxx -Thumbprint ABCDEFG
PS C:\Research\PnPCommunity\powershell> Submit-PnPSearchQuery -Query "contentclass:STS_ListItem_DocumentLibrary" -SelectProperties ComplianceTag,InformationProtectionLabelId -All

Submit-PnPSearchQuery: The remote server returned an error: (401) Unauthorized.
PS C:\Research\PnPCommunity\powershell>
```

## After changes ##
1. Connected via Device Login using ClientID as below, 

```

PS C:\Research\PnPCommunity\powershell> Connect-PnPOnline -ClientId xxxxx -Url "https://xxxx.sharepoint.com" -DeviceLogin -LaunchBrowser -Tenant xxxx
WARNING:
  
  
 Code ABCDEF123 has been copied to your clipboard and a new tab in the browser has been opened. Please paste this
 code in there and proceed.
 
PS C:\Research\PnPCommunity\powershell> Submit-PnPSearchQuery -Query "contentclass:STS_ListItem_DocumentLibrary" -SelectProperties ComplianceTag,InformationProtectionLabelId -All
WARNING: Current access token lacks the following required delegated permission scope on the resource SharePoint Online:
Sites.Search.All

Submit-PnPSearchQuery: The current principal does not have permission to execute queries on behalf of other users.
PS C:\Research\PnPCommunity\powershell>
```

2. Connected via App only context as below, 

```
PS C:\Research\PnPCommunity\powershell> Connect-PnPOnline -ClientId xxxx -Url "https://xxxx.sharepoint.com" -Tenant xxxx -Thumbprint ABCDEFG
PS C:\Research\PnPCommunity\powershell> Submit-PnPSearchQuery -Query "contentclass:STS_ListItem_DocumentLibrary" -SelectProperties ComplianceTag,InformationProtectionLabelId -All

WARNING: Current access token lacks the following required application permission scope on the resource SharePoint Online:
Sites.Read.All


Submit-PnPSearchQuery: The remote server returned an error: (401) Unauthorized.
PS C:\Research\PnPCommunity\powershell>
```

## Required permissions ## 


|        Type      |                    API/ Permission Name                    |                    Admin consent required                    |
| --------------- | --------------------------------------- | -------- |
| Application       | sharepoint/Sites.Read.All | yes                               |
| Delegated       | sharepoint/Sites.Search.All | yes                               |
