### PR TITLE
Added SiteId to the model since it was missing

### DIFF
--- a/src/Commands/Model/SPOSite.cs
+++ b/src/Commands/Model/SPOSite.cs
@@ -59,6 +59,7 @@ namespace PnP.PowerShell.Commands.Model
         public Microsoft.Online.SharePoint.TenantManagement.SharingDomainRestrictionModes SharingDomainRestrictionMode { get; set; }
         public bool ShowPeoplePickerSuggestionsForGuestUsers { get; set; }
         public Microsoft.Online.SharePoint.TenantManagement.SharingCapabilities SiteDefinedSharingCapability { get; set; }
+        public Guid SiteId { get; set; }
         public bool SocialBarOnSitePagesDisabled { get; set; }
         public string Status { get; set; }
         public long StorageQuota { get; set; }
@@ -157,6 +158,7 @@ namespace PnP.PowerShell.Commands.Model
             SharingDomainRestrictionMode = props.SharingDomainRestrictionMode;
             ShowPeoplePickerSuggestionsForGuestUsers = props.ShowPeoplePickerSuggestionsForGuestUsers;
             SiteDefinedSharingCapability = props.SiteDefinedSharingCapability;
+            SiteId = props.SiteId;
             SocialBarOnSitePagesDisabled = props.SocialBarOnSitePagesDisabled;
             Status = props.Status;
             StorageQuota = props.StorageMaximumLevel;


### PR DESCRIPTION

## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
SiteId was not included in the SPOSite model and therefore not possible to get back even though it is there under the covers. In my case I needed to merge some stuff with the SP usage reports which only has SiteId as a key. This is mentioned way back in #36   

## What is in this Pull Request ? ##
Two lines of code in the SPOSite object to include the SiteId