### PR TITLE
Update post types used by Get-PnPServiceHealthIssue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Get-PnPAzureADAppSitePermission`, `Grant-PnPAzureADAppSitePermission` and `Revoke-PnPAzureADAppSitePermission` cmdlets throwing an error when the site URL is not specified and the app registration used only having Graph permissions [#4421](https://github.com/pnp/powershell/pull/4421)
 - Fixed `Get-PnPTerm` cmdlet not working correctly when `-ParentTerm` parameter is specified. [#4454](https://github.com/pnp/powershell/pull/4454)
 - Fixed the PnP PowerShell version check to only check nightly version in nightly builds and major version in release builds. [#4453](https://github.com/pnp/powershell/pull/4453)
+- Fixed `Get-PnPServiceHealthIssue` returning an error when certain service states were active [#4530](https://github.com/pnp/powershell/pull/4530)
 
 ### Removed
 

--- a/src/Commands/Model/ServiceHealth/Enums/ServiceHealthIssuePostType.cs
+++ b/src/Commands/Model/ServiceHealth/Enums/ServiceHealthIssuePostType.cs
@@ -9,10 +9,17 @@ namespace PnP.PowerShell.Commands.Model.ServiceHealth.Enums
         /// Quick update
         /// </summary>
         Quick,
-
         /// <summary>
         /// Regular update
         /// </summary>
-        Regular
+        Regular,
+        /// <summary>
+        /// Strategic update
+        /// </summary>
+        Strategic,
+        /// <summary>
+        /// Unknown post type
+        /// </summary>
+        UnknownFutureValue
     }
 }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #4529

## What is in this Pull Request ? ##
Update post types used by Get-PnPServiceHealthIssue . Graph documentation at https://learn.microsoft.com/en-us/graph/api/resources/servicehealthissuepost?view=graph-rest-1.0#properties shows values that the existing code didn't include, throwing an error when such post values where returned by Graph.
