### PR TITLE
Add Get-PnPFileSensitivityLabel cmdlet for retrieving file sensitivity labels in SharePoint

### DIFF
--- a/documentation/Get-PnPFileSensitivityLabel.md
+++ b/documentation/Get-PnPFileSensitivityLabel.md
@@ -1,0 +1,58 @@
+---
+Module Name: PnP.PowerShell
+schema: 2.0.0
+applicable: SharePoint Online
+online version: https://pnp.github.io/powershell/cmdlets/Get-PnPFileSensitivityLabel.html
+external help file: PnP.PowerShell.dll-Help.xml
+title: Get-PnPFileSensitivityLabel
+---
+
+# Get-PnPFileSensitivityLabel
+
+## SYNOPSIS
+
+**Required Permissions**
+
+  * Microsoft Graph API : One of Files.Read.All, Sites.Read.All, Files.ReadWrite.All, Sites.ReadWrite.All
+
+Retrieves the sensitivity label information for a file in SharePoint.
+
+## SYNTAX
+```powershell
+Get-PnPFileSensitivityLabel -Url <String>
+```
+
+## DESCRIPTION
+
+The Get-PnPFileSensitivityLabel cmdlet retrieves the sensitivity label information for a file in SharePoint using Microsoft Graph. It takes a URL as input, decodes it, and specifically encodes the '+' character if it is part of the filename.
+
+## EXAMPLES
+
+### Example 1
+This example retrieves the sensitivity label information for the file at the specified URL.
+
+```powershell
+Get-PnPFileSensitivityLabel -Url "/sites/Marketing/Shared Documents/Report.pptx"
+```
+
+This example retrieves the sensitivity label information for the file at the specified URL.
+
+## PARAMETERS
+
+### -Url
+Specifies the URL of the file for which to retrieve the sensitivity label information.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True
+Accept wildcard characters: False
+```
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/src/Commands/Files/GetFileSensitivityLabel.cs
+++ b/src/Commands/Files/GetFileSensitivityLabel.cs
@@ -1,0 +1,57 @@
+﻿using PnP.Framework.Utilities;
+using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Model.Graph.Purview;
+using PnP.PowerShell.Commands.Utilities.REST;
+using System;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Files
+{
+    [Cmdlet(VerbsCommon.Get, "PnPFileSensitivityLabel")]
+    [RequiredApiDelegatedOrApplicationPermissions("graph/Files.Read.All")]
+    [RequiredApiDelegatedOrApplicationPermissions("graph/Sites.Read.All")]
+    [RequiredApiDelegatedOrApplicationPermissions("graph/Files.ReadWrite.All")]
+    [RequiredApiDelegatedOrApplicationPermissions("graph/Sites.ReadWrite.All")]
+    [OutputType(typeof(SensitivityLabels))]
+    public class GetFileSensitivityLabel : PnPGraphCmdlet
+    {
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+        public string Url = string.Empty;
+
+        protected override void ExecuteCmdlet()
+        {
+            var serverRelativeUrl = string.Empty;
+
+            if (Uri.IsWellFormedUriString(Url, UriKind.Absolute))
+            {
+                // We can't deal with absolute URLs
+                Url = UrlUtility.MakeRelativeUrl(Url);
+            }
+
+            // Remove URL decoding from the Url as that will not work. We will encode the + character specifically, because if that is part of the filename, it needs to stay and not be decoded.
+            Url = Utilities.UrlUtilities.UrlDecode(Url.Replace("+", "%2B"));
+
+            Connection.PnPContext.Web.EnsureProperties(w => w.ServerRelativeUrl);
+
+            var webUrl = Connection.PnPContext.Web.ServerRelativeUrl;
+
+            if (!Url.ToLower().StartsWith(webUrl.ToLower()))
+            {
+                serverRelativeUrl = UrlUtility.Combine(webUrl, Url);
+            }
+            else
+            {
+                serverRelativeUrl = Url;
+            }
+
+            var file = Connection.PnPContext.Web.GetFileByServerRelativeUrl(Url);
+            file.EnsureProperties(f => f.VroomDriveID, f => f.VroomItemID);
+
+            var requestUrl = $"v1.0/drives/{file.VroomDriveID}/items/{file.VroomItemID}/extractSensitivityLabels";
+
+            var results = GraphHelper.Post<SensitivityLabels>(this, Connection, requestUrl, AccessToken);
+            WriteObject(results.Labels, true);
+        }
+    }
+}

--- a/src/Commands/Model/Graph/Purview/SensitivityLabel.cs
+++ b/src/Commands/Model/Graph/Purview/SensitivityLabel.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace PnP.PowerShell.Commands.Model.Graph.Purview
+{
+    public class SensitivityLabel
+    {
+        [JsonPropertyName("sensitivityLabelId")]
+        public string SensitivityLabelId { get; set; }
+
+        [JsonPropertyName("assignmentMethod")]
+        public string AssignmentMethod { get; set; }
+
+        [JsonPropertyName("tenantId")]
+        public string TenantId { get; set; }
+    }
+
+    public class SensitivityLabels
+    {
+        [JsonPropertyName("@odata.type")]
+        public string Odatatype { get; set; }
+
+        [JsonPropertyName("labels")]
+        public List<SensitivityLabel> Labels { get; set; }
+    }
+}


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
NA

## What is in this Pull Request ? ##
New cmdlet to fetch file sensititivity labels