### PR TITLE
Fixing permissions on Get-PnPSearchExternalItem to match reality

### DIFF
--- a/documentation/Get-PnPSearchExternalItem.md
+++ b/documentation/Get-PnPSearchExternalItem.md
@@ -13,7 +13,7 @@ title: Get-PnPSearchExternalItem
 
 **Required Permissions**
 
-  * Microsoft Graph API: One of ExternalItem.ReadWrite.OwnedBy, ExternalItem.Read.All, ExternalItem.ReadWrite.All under a delegated context. Application context is not supported.
+  * Microsoft Graph API: ExternalItem.Read.All under a delegated context. Note that ExternalItem.ReadWrite.All will not work. Application context is not supported.
 
 Returns the external items indexed for a specific connector in Microsoft Search
 

--- a/src/Commands/Search/GetSearchExternalItem.cs
+++ b/src/Commands/Search/GetSearchExternalItem.cs
@@ -12,8 +12,6 @@ namespace PnP.PowerShell.Commands.Search
 {
     [Cmdlet(VerbsCommon.Get, "PnPSearchExternalItem")]
     [RequiredApiDelegatedPermissions("graph/ExternalItem.Read.All")]
-    [RequiredApiDelegatedPermissions("graph/ExternalItem.ReadWrite.All")]
-    [RequiredApiDelegatedPermissions("graph/ExternalItem.ReadWrite.OwnedBy")]
     [ApiNotAvailableUnderApplicationPermissions]
     [OutputType(typeof(Model.Graph.MicrosoftSearch.ExternalItem[]))]
     public class GetSearchExternalItem : PnPGraphCmdlet


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
`Get-PnPSearchExternalItem` incorrectly mentioned to work with the ExternalItem.ReadWrite.All permission as well. It must have the ExternalItem.Read.All permission, as it turns out. Removing the ReadWrite permission.