### PR TITLE
Add cmdlets to control profile card properties

### DIFF
--- a/documentation/Get-PnPProfileCardProperty.md
+++ b/documentation/Get-PnPProfileCardProperty.md
@@ -1,0 +1,91 @@
+---
+Module Name: PnP.PowerShell
+schema: 2.0.0
+applicable: SharePoint Online
+online version: https://pnp.github.io/powershell/cmdlets/Get-PnPProfileCardProperty.html
+external help file: PnP.PowerShell.dll-Help.xml
+title: Get-PnPProfileCardProperty
+---
+  
+# Get-PnPProfileCardProperty
+
+## SYNOPSIS
+
+**Required Permissions**
+
+  * Microsoft Graph API : One of PeopleSettings.Read.All, PeopleSettings.ReadWrite.All
+  
+Retrieves custom properties added to user profile cards
+
+## SYNTAX
+
+```powershell
+Get-PnPProfileCardProperty [-PropertyName <ProfileCardPropertyName>] [-Verbose] [-Connection <PnPConnection>] 
+```
+
+## DESCRIPTION
+
+This cmdlet may be used to retrieve custom properties added to user profile card.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-PnPProfileCardProperty
+```
+
+This will retrieve all custom properties added to user profile card.
+
+### EXAMPLE 2
+```powershell
+Get-PnPProfileCardProperty -PropertyName "pnppowershell"
+```
+
+This will return information about the specified property added to a profile card.
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing [Get-PnPConnection](Get-PnPConnection.md).
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+Name of the property to be retrieved. If not provided, all properties will be returned.
+
+```yaml
+Type: Commands.Enums.ProfileCardPropertyName
+Parameter Sets: (All)
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Verbose
+When provided, additional debug statements will be shown while executing the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)
+[Microsoft Graph documentation](https://learn.microsoft.com/en-us/graph/add-properties-profilecard)

--- a/documentation/New-PnpProfileCardProperty.md
+++ b/documentation/New-PnpProfileCardProperty.md
@@ -1,0 +1,116 @@
+---
+Module Name: PnP.PowerShell
+schema: 2.0.0
+applicable: SharePoint Online
+online version: https://pnp.github.io/powershell/cmdlets/New-PnpProfileCardProperty.html
+external help file: PnP.PowerShell.dll-Help.xml
+title: New-PnpProfileCardProperty
+---
+  
+# New-PnpProfileCardProperty
+
+## SYNOPSIS
+
+**Required Permissions**
+
+  * Microsoft Graph API : PeopleSettings.ReadWrite.All
+
+Adds a property to user profile card
+
+## SYNTAX
+
+```powershell
+New-PnpProfileCardProperty -PropertyName <ProfileCardPropertyName> -DisplayName <String> [-Localizations <Hashtable>] [-Verbose] [-Connection <PnPConnection>] 
+```
+## DESCRIPTION
+
+This cmdlet may be used to add a property to user profile card. Please note that it may take up to 24 hours to reflect the changes.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+New-PnpProfileCardProperty -PropertyName CustomAttribute1 -DisplayName "Cost Centre"
+```
+
+This cmdlet will add a property with a display name to user profile card.
+
+### EXAMPLE 2
+```powershell
+$localizations = @{ "pl" = "Centrum kosztów"; "de" = "Kostenstelle" }
+New-PnpProfileCardProperty -PropertyName CustomAttribute1 -DisplayName "Cost Centre" -Localizations $localizations
+```
+
+This cmdlet will add a property with a display name and specified localizations to user profile card.
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing [Get-PnPConnection](Get-PnPConnection.md).
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PropertyName
+Name of a property to be added
+
+```yaml
+Type: Commands.Enums.ProfileCardPropertyName
+Parameter Sets: (All)
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisplayName
+The display name of the property.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Required: True
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Localizations
+List of display name localizations
+
+```yaml
+Type: Hashtable
+Parameter Sets: (All)
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Verbose
+When provided, additional debug statements will be shown while executing the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)
+[Microsoft Graph documentation](https://learn.microsoft.com/en-us/graph/add-properties-profilecard)

--- a/documentation/Remove-PnPProfileCardProperty.md
+++ b/documentation/Remove-PnPProfileCardProperty.md
@@ -1,0 +1,84 @@
+---
+Module Name: PnP.PowerShell
+schema: 2.0.0
+applicable: SharePoint Online
+online version: https://pnp.github.io/powershell/cmdlets/Remove-PnPProfileCardProperty.html
+external help file: PnP.PowerShell.dll-Help.xml
+title: Remove-PnPProfileCardProperty
+---
+  
+# Remove-PnPProfileCardProperty
+
+## SYNOPSIS
+
+**Required Permissions**
+
+  * Microsoft Graph API : PeopleSettings.ReadWrite.All
+
+Removes a specific property from user profile card
+
+## SYNTAX
+
+```powershell
+Remove-PnPProfileCardProperty -PropertyName <ProfileCardPropertyName> [-Verbose] [-Connection <PnPConnection>] 
+```
+
+## DESCRIPTION
+
+This cmdlet can be used to remove a property from user profile card
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Remove-PnPProfileCardProperty -PropertyName CustomAttribute1
+```
+
+This will remove the connection to the external datasource with the specified identity from Microsoft Search.
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing [Get-PnPConnection](Get-PnPConnection.md).
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+Unique identifier or an instance of the external connection in Microsoft Search that needs to be removed.
+
+```yaml
+Type: SearchExternalConnectionPipeBind
+Parameter Sets: (All)
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True
+Accept wildcard characters: False
+```
+
+### -Verbose
+When provided, additional debug statements will be shown while executing the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)
+[Microsoft Graph documentation](https://learn.microsoft.com/en-us/graph/add-properties-profilecard)

--- a/src/Commands/Enums/ProfileCardPropertyName.cs
+++ b/src/Commands/Enums/ProfileCardPropertyName.cs
@@ -1,0 +1,31 @@
+namespace PnP.PowerShell.Commands.Enums
+{
+    /// <summary>
+    /// Custom properties available for customization on profile card
+    /// </summary>
+    /// <remarks>Documented at https://learn.microsoft.com/en-us/graph/add-properties-profilecard </remarks>
+    public enum ProfileCardPropertyName
+    {
+        CustomAttribute1,
+        CustomAttribute2,
+        CustomAttribute3,
+        CustomAttribute4,
+        CustomAttribute5,
+        CustomAttribute6,
+        CustomAttribute7,
+        CustomAttribute8,
+    	CustomAttribute9,
+    	CustomAttribute10,
+    	CustomAttribute12,
+    	CustomAttribute11,
+    	CustomAttribute13,
+    	CustomAttribute14,
+    	CustomAttribute15,
+        UserPrincipalName, 
+        FaxNumber, 
+        StreetAddress, 
+        PostalCode, 
+        State, 
+        MailNickname
+    }
+}

--- a/src/Commands/Model/Graph/ProfileCard/ProfileCardProperty.cs
+++ b/src/Commands/Model/Graph/ProfileCard/ProfileCardProperty.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using PnP.PowerShell.Commands.Enums;
+
+namespace PnP.PowerShell.Commands.Model.Graph.ProfileCard
+{
+    /// <summary>
+    /// Contains a profile card property information
+    /// </summary>
+    /// <remarks>See https://learn.microsoft.com/en-us/graph/api/resources/profilecardproperty</remarks>
+    public class ProfileCardProperty
+    {
+        /// <summary>
+        /// Directory property name
+        /// </summary>
+        [JsonPropertyName("directoryPropertyName")]
+        public string DirectoryPropertyName { get; set; }
+        
+        /// <summary>
+        /// Annotations
+        /// </summary>
+        [JsonPropertyName("annotations")]
+        public List<ProfileCardPropertyAnnotation> Annotations { get; set; }
+    }
+}

--- a/src/Commands/Model/Graph/ProfileCard/ProfileCardPropertyAnnotation.cs
+++ b/src/Commands/Model/Graph/ProfileCard/ProfileCardPropertyAnnotation.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using PnP.PowerShell.Commands.Enums;
+
+namespace PnP.PowerShell.Commands.Model.Graph.ProfileCard
+{
+    /// <summary>
+    /// Contains a profile card property annotation
+    /// </summary>
+    /// <remarks>See https://learn.microsoft.com/en-us/graph/api/resources/profilecardannotation</remarks>
+    public class ProfileCardPropertyAnnotation
+    {
+        /// <summary>
+        /// Unique identifier for the message
+        /// </summary>
+        [JsonPropertyName("displayName")]
+        public string DisplayName { get; set; }
+        
+        /// <summary>
+        /// The To: recipients for the message
+        /// </summary>
+        [JsonPropertyName("localizations")]
+        public List<ProfileCardPropertyLocalization> Localizations { get; set; }
+    }
+}

--- a/src/Commands/Model/Graph/ProfileCard/ProfileCardPropertylocalization.cs
+++ b/src/Commands/Model/Graph/ProfileCard/ProfileCardPropertylocalization.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using PnP.PowerShell.Commands.Enums;
+
+namespace PnP.PowerShell.Commands.Model.Graph.ProfileCard
+{
+    /// <summary>
+    /// Contains a profile card property localization
+    /// </summary>
+    /// <remarks>See https://learn.microsoft.com/en-us/graph/api/resources/displaynamelocalization</remarks>
+    public class ProfileCardPropertyLocalization
+    {
+        /// <summary>
+        /// Display name
+        /// </summary>
+        [JsonPropertyName("displayName")]
+        public string DisplayName { get; set; }
+        
+        /// <summary>
+        /// Language tag
+        /// <example>de</example>
+        /// <example>nl-NL</example>
+        /// </summary>
+        [JsonPropertyName("languageTag")]
+        public string LanguageTag { get; set; }
+    }
+}

--- a/src/Commands/PeopleSettings/GetProfileCardProperty.cs
+++ b/src/Commands/PeopleSettings/GetProfileCardProperty.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Management.Automation;
+using System.Collections.Generic;
+using PnP.PowerShell.Commands.Enums;
+using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+
+namespace PnP.PowerShell.Commands.PeopleSettings
+{
+    [Cmdlet(VerbsCommon.Get, "PnPProfileCardProperty")]
+    [RequiredApiDelegatedOrApplicationPermissions("graph/PeopleSettings.Read.All")]
+    [RequiredApiDelegatedOrApplicationPermissions("graph/PeopleSettings.ReadWrite.All")]
+    [OutputType(typeof(IEnumerable<Model.Graph.ProfileCard.ProfileCardProperty>))]
+    [OutputType(typeof(Model.Graph.ProfileCard.ProfileCardProperty))]
+    public class GetProfileCardProperty : PnPGraphCmdlet
+    {
+        [Parameter(Mandatory = false)]
+        public ProfileCardPropertyName PropertyName;
+
+        protected override void ExecuteCmdlet()
+        {
+            WriteVerbose("Getting access token for Microsoft Graph");
+            var requestUrl = $"/v1.0/admin/people/profileCardProperties";
+
+            if(ParameterSpecified(nameof(PropertyName)))
+            {
+                if (ParameterSpecified(nameof(PropertyName)))
+                {
+                    requestUrl += $"/{PropertyName.ToString()}";
+                }
+                WriteVerbose($"Retrieving profile card property '{PropertyName}'");
+
+                var propertyResult = Utilities.REST.GraphHelper.Get<Model.Graph.ProfileCard.ProfileCardProperty>(this, Connection, requestUrl, AccessToken);
+                WriteObject(propertyResult, false);
+            }
+            else
+            {
+                WriteVerbose("Retrieving all profile card properties");
+
+                var propertyResults = Utilities.REST.GraphHelper.GetResultCollection<Model.Graph.ProfileCard.ProfileCardProperty>(this, Connection, requestUrl, AccessToken);
+                WriteObject(propertyResults, true);
+            }
+        }
+    }
+}

--- a/src/Commands/PeopleSettings/NewProfileCardProperty.cs
+++ b/src/Commands/PeopleSettings/NewProfileCardProperty.cs
@@ -1,0 +1,66 @@
+using PnP.PowerShell.Commands.Enums;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Attributes;
+using System.Collections;
+using System.Management.Automation;
+using System.Collections.Generic;
+using System.Net.Http.Json;
+using System.Linq;
+
+namespace PnP.PowerShell.Commands.PeopleSettings
+{
+    [Cmdlet(VerbsCommon.New, "PnPProfileCardProperty")]
+    [RequiredApiDelegatedOrApplicationPermissions("graph/PeopleSettings.ReadWrite.All")]
+    [OutputType(typeof(Model.Graph.ProfileCard.ProfileCardProperty))]
+    public class NewProfileCardProperty : PnPGraphCmdlet
+    {
+        [Parameter(Mandatory = true)]
+        public ProfileCardPropertyName PropertyName;
+
+        [Parameter(Mandatory = true)]
+        public string DisplayName;
+
+        [Parameter(Mandatory = false)]
+        public Hashtable Localizations;
+        
+        protected override void ExecuteCmdlet()
+        {            
+            var bodyContent = new Model.Graph.ProfileCard.ProfileCardProperty
+            {
+                DirectoryPropertyName = PropertyName.ToString(),
+                Annotations = new List<Model.Graph.ProfileCard.ProfileCardPropertyAnnotation>
+                {
+                    new Model.Graph.ProfileCard.ProfileCardPropertyAnnotation
+                    { 
+                        DisplayName = DisplayName
+                    }
+                }
+            };
+
+            if(ParameterSpecified(nameof(Localizations)))
+            {
+                var localizations = new List<Model.Graph.ProfileCard.ProfileCardPropertyLocalization>();
+                foreach (var key in Localizations.Keys)
+                {
+                    localizations.Add(new Model.Graph.ProfileCard.ProfileCardPropertyLocalization
+                    {
+                        DisplayName = Localizations[key] as string,
+                        LanguageTag = key as string
+                    });
+                }
+
+                bodyContent.Annotations.First().Localizations = localizations;
+            }
+
+            var jsonContent = JsonContent.Create(bodyContent);
+            WriteVerbose($"Payload: {jsonContent.ReadAsStringAsync().GetAwaiter().GetResult()}");
+
+            var graphApiUrl = $"v1.0/admin/people/profileCardProperties";
+            var results = Utilities.REST.GraphHelper.Post(this, Connection, graphApiUrl, AccessToken, jsonContent);
+            var resultsContent = results.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            var propertyResult = System.Text.Json.JsonSerializer.Deserialize<Model.Graph.ProfileCard.ProfileCardProperty>(resultsContent);
+
+            WriteObject(propertyResult, false);
+        }
+    }
+}

--- a/src/Commands/PeopleSettings/RemoveProfileCardProperty.cs
+++ b/src/Commands/PeopleSettings/RemoveProfileCardProperty.cs
@@ -1,0 +1,27 @@
+using PnP.PowerShell.Commands.Enums;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Attributes;
+using System.Collections;
+using System.Management.Automation;
+using System.Collections.Generic;
+using System.Net.Http.Json;
+using System.Linq;
+
+namespace PnP.PowerShell.Commands.PeopleSettings
+{
+    [Cmdlet(VerbsCommon.Remove, "PnPProfileCardProperty")]
+    [RequiredApiDelegatedOrApplicationPermissions("graph/PeopleSettings.ReadWrite.All")]
+    [OutputType(typeof(void))]
+    public class RemoveProfileCardProperty : PnPGraphCmdlet
+    {
+        [Parameter(Mandatory = true)]
+        public ProfileCardPropertyName PropertyName;
+
+        protected override void ExecuteCmdlet()
+        {            
+            var graphApiUrl = $"v1.0/admin/people/profileCardProperties/{PropertyName.ToString()}";
+            
+            Utilities.REST.GraphHelper.Delete(this, Connection, graphApiUrl, AccessToken);
+        }
+    }
+}


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
None

## What is in this Pull Request ? ##
This PR add following commandlets allowing getting/adding/removing profile card properties:
- Get-PnPProfileCardProperty 
- New-PnPProfileCardProperty 
- Remove-PnPProfileCardProperty 

Cmdlets implement respective graph calls described [here](https://learn.microsoft.com/en-us/graph/add-properties-profilecard).