### PR TITLE
Fix Add-PnPFileSensitivityLabel cmdlet to allow empty string value for resetting file sensitivity label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed the PnP PowerShell version check to only check nightly version in nightly builds and major version in release builds. [#4453](https://github.com/pnp/powershell/pull/4453)
 - Fixed `-ConsistencyLevelEventual` flag on `Invoke-PnPGraphMethod` to work correctly. [#4523](https://github.com/pnp/powershell/pull/4523)
 - Fixed `Get-PnPServiceHealthIssue` returning an error when certain service states were active [#4530](https://github.com/pnp/powershell/pull/4530)
+- Fixed `Add-PnPFileSensitivityLabel` cmdlet to allow empty string value to reset file sensitivity label.
 
 ### Removed
 

--- a/src/Commands/Files/AddFileSensitivityLabel.cs
+++ b/src/Commands/Files/AddFileSensitivityLabel.cs
@@ -18,6 +18,8 @@ namespace PnP.PowerShell.Commands.Files
         public FilePipeBind Identity;
 
         [Parameter(Mandatory = true)]
+        [AllowNull]
+        [AllowEmptyString]
         public string SensitivityLabelId;
 
         [Parameter(Mandatory = false)]


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #4565

## What is in this Pull Request ? ##
Fix sensitivity label to allow empty string