### PR TITLE
Fix exceptions in Restore-PnPRecycleBinItem

### DIFF
--- a/src/Commands/Base/PipeBinds/RecycleBinItemPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/RecycleBinItemPipeBind.cs
@@ -21,6 +21,7 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
         public RecycleBinItemPipeBind(RecycleBinItem item)
         {
             _item = item;
+            _id = item?.Id;
         }
 
         public RecycleBinItemPipeBind(RecycleResult result)
@@ -31,6 +32,12 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
         public RecycleBinItemPipeBind(IRecycleBinItem result)
         {
             _recycleBinItem = result;
+            _id = result?.Id;
+        }
+
+        public RecycleBinItemPipeBind(Guid guid)
+        {
+            _id = guid;
         }
 
         public RecycleBinItemPipeBind(string id)

--- a/src/Commands/RecycleBin/RestoreRecycleBinItem.cs
+++ b/src/Commands/RecycleBin/RestoreRecycleBinItem.cs
@@ -25,6 +25,11 @@ namespace PnP.PowerShell.Commands.RecycleBin
             {
                 var recycleBinItem = Identity.GetRecycleBinItem(Connection.PnPContext);
 
+                if (recycleBinItem == null)
+                {
+                    throw new PSArgumentException("Recycle bin item not found with the ID specified", nameof(Identity));
+                }
+
                 if (Force || ShouldContinue(string.Format(Resources.RestoreRecycleBinItem, recycleBinItem.LeafName), Resources.Confirm))
                 {
                     recycleBinItem.Restore();


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #4664

## What is in this Pull Request ? ##
Fix some exceptions in Restore-PnPRecycleBinItem :
- A type conversion error was thrown when passing a System.Guid object as RecycleBinItemPipeBind parameter class didn't have a constructor for System.Guid, only for String.
- _id field of RecycleBinItemPipeBind is used when fetching the recycle item using PnP.Core but it wasn't initialized when passing a Microsoft.SharePoint.Client.RecycleBinItem object, which is what Get-PnPRecycleBinItem returns .
- A null exception was thrown when RecycleBinItemPipeBind failed to find the item, now the message "Recycle bin item not found with the ID specified" is displayed instead  
![Screenshot 2025-01-07 203231](https://github.com/user-attachments/assets/6b3a5bc5-1bde-4ff6-a375-cd43255b694a)


This is the result with these fixes:
- Passing to Restore-PnPRecycleBinItem the result of Get-PnPRecycleBinItem
  ![image](https://github.com/user-attachments/assets/40f4a95c-7956-4f81-a22e-ba7ca13b6f19)
- Passing to Restore-PnPRecycleBinItem a System.Guid object
  ![Screenshot 2025-01-07 203515](https://github.com/user-attachments/assets/e110ad37-3fda-457d-a3f2-fbc1d349d093)
