### PR TITLE
Fixed `Get-PnPChangeLog` not returning data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fix `Connect-PnPOnline` cmdlet not working with On Prem related cmdlets. [#4622](https://github.com/pnp/powershell/pull/4622)
 - Fix `Get\Invoke-PnPSiteTemplate` cmdlet not working in vanity domains. [#4630](https://github.com/pnp/powershell/pull/4630)
 - Fixed passing a `Get-PnPRecycleBinItem` result or a GUID to `Restore-PnPRecycleBinItem` not working correctly. [#4667](https://github.com/pnp/powershell/pull/4667)
+- Fixed `Get-PnPChangeLog` not returning the changelog
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fix `Connect-PnPOnline` cmdlet not working with On Prem related cmdlets. [#4622](https://github.com/pnp/powershell/pull/4622)
 - Fix `Get\Invoke-PnPSiteTemplate` cmdlet not working in vanity domains. [#4630](https://github.com/pnp/powershell/pull/4630)
 - Fixed passing a `Get-PnPRecycleBinItem` result or a GUID to `Restore-PnPRecycleBinItem` not working correctly. [#4667](https://github.com/pnp/powershell/pull/4667)
-- Fixed `Get-PnPChangeLog` not returning the changelog
+- Fixed `Get-PnPChangeLog` not returning the changelog [#4707](https://github.com/pnp/powershell/pull/4707)
 
 ### Removed
 

--- a/documentation/Get-PnPChangeLog.md
+++ b/documentation/Get-PnPChangeLog.md
@@ -14,12 +14,18 @@ Returns the changelog for PnP PowerShell
 
 ## SYNTAX
 
+### Current nightly
 ```powershell
-Get-PnPChangeLog [-Nightly]
+Get-PnPChangeLog -Nightly [-Verbose]
+```
+
+### Specific version
+```powershell
+Get-PnPChangeLog [-Version <String>] [-Verbose]
 ```
 
 ## DESCRIPTION
-This cmdlets returns the changelog in markdown format. It is retrieved dynamically from GitHub.
+This cmdlets returns what has changed in PnP PowerShell in a specific version in markdown format. It is retrieved dynamically from GitHub.
 
 ## EXAMPLES
 
@@ -28,7 +34,7 @@ This cmdlets returns the changelog in markdown format. It is retrieved dynamical
 Get-PnPChangeLog
 ```
 
-Returns the changelog for the currently released version.
+Returns the changelog for the latest released stable version.
 
 ### EXAMPLE 2
 ```powershell
@@ -37,10 +43,31 @@ Get-PnPChangeLog -Nightly
 
 Returns the changelog for the current nightly build.
 
+### EXAMPLE 3
+```powershell
+Get-PnPChangeLog -Version 2.12.0
+```
+
+Returns the changelog for the 2.12.0 release.
+
 ## PARAMETERS
 
 ### -Nightly
 Return the changelog for the nightly build
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Current nightly
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Verbose
+When provided, additional debug statements will be shown while executing the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -53,8 +80,20 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Version
+Return the changelog for a specific version. Be sure to use the correct version number in the format <#>.<#>.<#>, i.e. 2.12.0, otherwise the cmdlet will fail. If omitted, the latest stable version will be returned.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Specific version
+
+Required: False
+Position: Named
+Default value: Latest stable version
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ## RELATED LINKS
 
 [Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)
-
-


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Get-PnPChangelog was not returning data anymore. This has now been fixed.