### PR TITLE
Added `Set-PnPSiteDocumentIdPrefix` cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `HidePeopleWhoHaveListsOpen` parameter to `Set-PnPSite` cmdlet to hide people who simultaneously have lists open [#4699](https://github.com/pnp/powershell/pull/4699)
 - Added `-WhoCanShareAllowListInTenant`, `-LegacyBrowserAuthProtocolsEnabled`, `-EnableDiscoverableByOrganizationForVideos`, `-RestrictedAccessControlforSitesErrorHelpLink`, `-Workflow2010Disabled`, `-AllowSharingOutsideRestrictedAccessControlGroups`, `-HideSyncButtonOnDocLib`, `-HideSyncButtonOnODB`, `-StreamLaunchConfig`, `-EnableMediaReactions`, `-ContentSecurityPolicyEnforcement` and `-DisableSpacesActivation` to `Set-PnPTenant` [#4681](https://github.com/pnp/powershell/pull/4681)
 - Added `Start-PnPEnterpriseAppInsightsReport` and `Get-PnPEnterpriseAppInsightsReport` which allow working with App Insights repors [#4713](https://github.com/pnp/powershell/pull/4713)
-- Added `Set-PnPSiteDocumentIdPrefix` which allows changing of the document id prefix on a site collection
+- Added `Set-PnPSiteDocumentIdPrefix` which allows changing of the document id prefix on a site collection [#4765](https://github.com/pnp/powershell/pull/4765)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `HidePeopleWhoHaveListsOpen` parameter to `Set-PnPSite` cmdlet to hide people who simultaneously have lists open [#4699](https://github.com/pnp/powershell/pull/4699)
 - Added `-WhoCanShareAllowListInTenant`, `-LegacyBrowserAuthProtocolsEnabled`, `-EnableDiscoverableByOrganizationForVideos`, `-RestrictedAccessControlforSitesErrorHelpLink`, `-Workflow2010Disabled`, `-AllowSharingOutsideRestrictedAccessControlGroups`, `-HideSyncButtonOnDocLib`, `-HideSyncButtonOnODB`, `-StreamLaunchConfig`, `-EnableMediaReactions`, `-ContentSecurityPolicyEnforcement` and `-DisableSpacesActivation` to `Set-PnPTenant` [#4681](https://github.com/pnp/powershell/pull/4681)
 - Added `Start-PnPEnterpriseAppInsightsReport` and `Get-PnPEnterpriseAppInsightsReport` which allow working with App Insights repors [#4713](https://github.com/pnp/powershell/pull/4713)
-- Added `Set-PnPSiteDocumentIdPref` which allows changing of the document id prefix on a site collection
+- Added `Set-PnPSiteDocumentIdPrefix` which allows changing of the document id prefix on a site collection
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `HidePeopleWhoHaveListsOpen` parameter to `Set-PnPSite` cmdlet to hide people who simultaneously have lists open [#4699](https://github.com/pnp/powershell/pull/4699)
 - Added `-WhoCanShareAllowListInTenant`, `-LegacyBrowserAuthProtocolsEnabled`, `-EnableDiscoverableByOrganizationForVideos`, `-RestrictedAccessControlforSitesErrorHelpLink`, `-Workflow2010Disabled`, `-AllowSharingOutsideRestrictedAccessControlGroups`, `-HideSyncButtonOnDocLib`, `-HideSyncButtonOnODB`, `-StreamLaunchConfig`, `-EnableMediaReactions`, `-ContentSecurityPolicyEnforcement` and `-DisableSpacesActivation` to `Set-PnPTenant` [#4681](https://github.com/pnp/powershell/pull/4681)
 - Added `Start-PnPEnterpriseAppInsightsReport` and `Get-PnPEnterpriseAppInsightsReport` which allow working with App Insights repors [#4713](https://github.com/pnp/powershell/pull/4713)
+- Added `Set-PnPSiteDocumentIdPref` which allows changing of the document id prefix on a site collection
 
 ### Changed
 

--- a/documentation/Set-PnPSiteDocumentIdPrefix.md
+++ b/documentation/Set-PnPSiteDocumentIdPrefix.md
@@ -46,6 +46,8 @@ This will change the document Id prefix to TEST for all existing and new documen
 ### -DocumentIdPrefix
 The new prefix you would like to start using for the Document ID feature in the current site collection.
 
+The Document ID prefix must be 4 to 12 characters long, and contain only digits (0-9) and letters.
+
 ```yaml
 Type: string
 Parameter Sets: (All)

--- a/documentation/Set-PnPSiteDocumentIdPrefix.md
+++ b/documentation/Set-PnPSiteDocumentIdPrefix.md
@@ -1,0 +1,88 @@
+---
+Module Name: PnP.PowerShell
+title: Set-PnPSiteDocumentIdPrefix
+schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/Set-PnPSiteDocumentIdPrefix.html
+---
+ 
+# Set-PnPSiteDocumentIdPrefix
+
+## SYNOPSIS
+Allows the document Id prefix for a site to be changed.
+
+## SYNTAX
+
+```powershell
+Set-PnPSiteDocumentIdPrefix -DocumentIdPrefix <string> [-ScheduleAssignment <boolean>] [-OverwriteExistingIds <boolean>] [-Verbose] [-Connection <PnPConnection>]
+```
+
+## DESCRIPTION
+This cmdlet allows changing of the document Id prefix that has been assigned to a site. It essentially does what you can also do using the page /_layouts/15/DocIdSettings.aspx in the SharePoint Online web interface.
+
+It also offers an option to reset the currently assigned document Ids of all files within a site.
+
+You need to be connected to the sitecollection of which you want to change the document Id prefix.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Set-PnPSiteDocumentIdPrefix "TEST"
+```
+
+This will change the document Id prefix to TEST for all new documents created in the current site collection.
+
+### EXAMPLE 2
+```powershell
+Set-PnPSiteDocumentIdPrefix "TEST" -ScheduleAssignment $true -OverwriteExistingIds $true
+```
+
+This will change the document Id prefix to TEST for all existing and new documents in the current site collection. Note that this will take a while (possibly up to 48 hours) to complete as SharePoint Online will need to recalculate and reassign the unique document Id of all files in the site collection.
+
+## PARAMETERS
+
+### -DocumentIdPrefix
+The new prefix you would like to start using for the Document ID feature in the current site collection.
+
+```yaml
+Type: string
+Parameter Sets: (All)
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True
+Accept wildcard characters: False
+```
+
+### -OverwriteExistingIds
+Boolean indicating whether the document Ids on existing documents within the site collection should be reassigned a new document Id using the new prefix. If set to true, all existing documents will be assigned a new document Id using the new prefix. If set to false, only new documents will be assigned a document Id using the new prefix.
+
+Type: boolean
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ScheduleAssignment
+Boolean indicating whether the change should be scheduled in a timerjob or not. If set to true, the change will be scheduled and will take effect within 48 hours. This might make the rename process more reliable, especially on sites with a lot of files. If set to false, the change might be applied sooner, though still could take some time to be processed.
+
+Type: boolean
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/documentation/Set-PnPSiteDocumentIdPrefix.md
+++ b/documentation/Set-PnPSiteDocumentIdPrefix.md
@@ -60,6 +60,7 @@ Accept wildcard characters: False
 ### -OverwriteExistingIds
 Boolean indicating whether the document Ids on existing documents within the site collection should be reassigned a new document Id using the new prefix. If set to true, all existing documents will be assigned a new document Id using the new prefix. If set to false, only new documents will be assigned a document Id using the new prefix.
 
+```yaml
 Type: boolean
 Parameter Sets: (All)
 
@@ -73,6 +74,7 @@ Accept wildcard characters: False
 ### -ScheduleAssignment
 Boolean indicating whether the change should be scheduled in a timerjob or not. If set to true, the change will be scheduled and will take effect within 48 hours. This might make the rename process more reliable, especially on sites with a lot of files. If set to false, the change might be applied sooner, though still could take some time to be processed.
 
+```yaml
 Type: boolean
 Parameter Sets: (All)
 

--- a/src/Commands/Files/SetSiteDocumentIdPrefix.cs
+++ b/src/Commands/Files/SetSiteDocumentIdPrefix.cs
@@ -1,0 +1,29 @@
+﻿using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using PnP.PowerShell.Commands.Utilities.REST;
+
+namespace PnP.PowerShell.Commands.Files
+{
+    [Cmdlet(VerbsCommon.Set, "PnPSiteDocumentIdPrefix")]
+    public class SetSiteDocumentIdPrefix : PnPWebCmdlet
+    {
+        [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
+        public string DocumentIdPrefix { get; set; }
+
+        [Parameter(Mandatory = false)]
+        public bool ScheduleAssignment = false;
+
+        [Parameter(Mandatory = false)]
+        public bool OverwriteExistingIds = false;
+
+        protected override void ExecuteCmdlet()
+        {
+            CurrentWeb.EnsureProperty(w => w.Url);
+
+            var docIdPrefixUrl = $"{CurrentWeb.Url}/_api/SP.DocumentManagement.DocumentId/SetDocIdSitePrefix(prefix='{DocumentIdPrefix}',scheduleAssignment={(ScheduleAssignment ? "true" : "false")},overwriteExistingIds={(OverwriteExistingIds ? "true" : "false")})";
+            WriteVerbose($"Making a POST request to {docIdPrefixUrl} to set the document ID prefix to {DocumentIdPrefix}");
+
+            RestHelper.Post(Connection.HttpClient, docIdPrefixUrl, ClientContext);
+        }
+    }
+}

--- a/src/Commands/Files/SetSiteDocumentIdPrefix.cs
+++ b/src/Commands/Files/SetSiteDocumentIdPrefix.cs
@@ -20,6 +20,11 @@ namespace PnP.PowerShell.Commands.Files
         {
             CurrentWeb.EnsureProperty(w => w.Url);
 
+            if(!System.Text.RegularExpressions.Regex.IsMatch(DocumentIdPrefix, @"^[a-zA-Z0-9]{4,12}$"))
+            {
+                WriteWarning($"{nameof(DocumentIdPrefix)} can only contain digits (0-9) and letters and must be between 4 and 12 characters in length.");
+            }
+
             var docIdPrefixUrl = $"{CurrentWeb.Url}/_api/SP.DocumentManagement.DocumentId/SetDocIdSitePrefix(prefix='{DocumentIdPrefix}',scheduleAssignment={(ScheduleAssignment ? "true" : "false")},overwriteExistingIds={(OverwriteExistingIds ? "true" : "false")})";
             WriteVerbose($"Making a POST request to {docIdPrefixUrl} to set the document ID prefix to {DocumentIdPrefix}");
 


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Added `Set-PnPSiteDocumentIdPrefix` cmdlet which allows for changing of the document id prefix assigned to a site collection and optionally resetting the document ids of all files within the site to match that new prefix
