### PR TITLE
Fixes issue #4754 with regards to `Add-PnPApplicationCustomizer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `Start-PnPEnterpriseAppInsightsReport` and `Get-PnPEnterpriseAppInsightsReport` which allow working with App Insights repors [#4713](https://github.com/pnp/powershell/pull/4713)
 - Added `Set-PnPSiteDocumentIdPrefix` which allows changing of the document id prefix on a site collection [#4765](https://github.com/pnp/powershell/pull/4765)
 - Added `Get-PnPMicrosoft365Roadmap` which allows retrieval of the Microsoft 365 Roadmap items [#4764](https://github.com/pnp/powershell/pull/4764)
+- Added `-Name` parameter to `Add-PnPApplicationCustomizer` cmdlet to allow for specifying the name of the application customizer
 
 ### Changed
 
@@ -111,6 +112,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fix `Get\Invoke-PnPSiteTemplate` cmdlet not working in vanity domains. [#4630](https://github.com/pnp/powershell/pull/4630)
 - Fixed passing a `Get-PnPRecycleBinItem` result or a GUID to `Restore-PnPRecycleBinItem` not working correctly. [#4667](https://github.com/pnp/powershell/pull/4667)
 - Fixed `Get-PnPChangeLog` not returning the changelog [#4707](https://github.com/pnp/powershell/pull/4707)
+- Fixed `-Description` and `-Sequence` not being applied when providing these through `Add-PnPApplicationCustomizer`
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `Start-PnPEnterpriseAppInsightsReport` and `Get-PnPEnterpriseAppInsightsReport` which allow working with App Insights repors [#4713](https://github.com/pnp/powershell/pull/4713)
 - Added `Set-PnPSiteDocumentIdPrefix` which allows changing of the document id prefix on a site collection [#4765](https://github.com/pnp/powershell/pull/4765)
 - Added `Get-PnPMicrosoft365Roadmap` which allows retrieval of the Microsoft 365 Roadmap items [#4764](https://github.com/pnp/powershell/pull/4764)
-- Added `-Name` parameter to `Add-PnPApplicationCustomizer` cmdlet to allow for specifying the name of the application customizer
+- Added `-Name` parameter to `Add-PnPApplicationCustomizer` cmdlet to allow for specifying the name of the application customizer [#4767](https://github.com/pnp/powershell/pull/4767)
 
 ### Changed
 
@@ -112,7 +112,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fix `Get\Invoke-PnPSiteTemplate` cmdlet not working in vanity domains. [#4630](https://github.com/pnp/powershell/pull/4630)
 - Fixed passing a `Get-PnPRecycleBinItem` result or a GUID to `Restore-PnPRecycleBinItem` not working correctly. [#4667](https://github.com/pnp/powershell/pull/4667)
 - Fixed `Get-PnPChangeLog` not returning the changelog [#4707](https://github.com/pnp/powershell/pull/4707)
-- Fixed `-Description` and `-Sequence` not being applied when providing these through `Add-PnPApplicationCustomizer`
+- Fixed `-Description` and `-Sequence` not being applied when providing these through `Add-PnPApplicationCustomizer` [#4767](https://github.com/pnp/powershell/pull/4767)
 
 ### Removed
 

--- a/documentation/Add-PnPApplicationCustomizer.md
+++ b/documentation/Add-PnPApplicationCustomizer.md
@@ -15,7 +15,7 @@ Adds a SharePoint Framework client side extension application customizer to a sp
 ## SYNTAX
 
 ```powershell
-Add-PnPApplicationCustomizer [-Title <String>] [-Description <String>] [-Sequence <Int32>]
+Add-PnPApplicationCustomizer [-Name <String>] [-Title <String>] [-Description <String>] [-Sequence <Int32>]
  [-Scope <CustomActionScope>] -ClientSideComponentId <Guid> [-ClientSideComponentProperties <String>]
  [-ClientSideHostProperties <String>] [-Connection <PnPConnection>] 
 ```
@@ -88,6 +88,19 @@ Accept wildcard characters: False
 
 ### -Description
 The description of the application customizer
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+The name of the application customizer
 
 ```yaml
 Type: String

--- a/src/Commands/Apps/AddApplicationCustomizer.cs
+++ b/src/Commands/Apps/AddApplicationCustomizer.cs
@@ -13,6 +13,9 @@ namespace PnP.PowerShell.Commands.Branding
         public string Title = string.Empty;
 
         [Parameter(Mandatory = false)]
+        public string Name = string.Empty;
+
+        [Parameter(Mandatory = false)]
         public string Description = string.Empty;
 
         [Parameter(Mandatory = false)]
@@ -35,6 +38,9 @@ namespace PnP.PowerShell.Commands.Branding
             CustomActionEntity ca = new CustomActionEntity
             {
                 Title = Title,
+                Name = Name,
+                Description = Description,
+                Sequence = Sequence,
                 Location = "ClientSideExtension.ApplicationCustomizer",
                 ClientSideComponentId = ClientSideComponentId,
                 ClientSideComponentProperties = ClientSideComponentProperties,


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #4754 

## What is in this Pull Request ? ##
- Fixed `-Description` and `-Sequence` not being applied when providing these through `Add-PnPApplicationCustomizer`
- Added `-Name` parameter to `Add-PnPApplicationCustomizer` cmdlet to allow for specifying the name of the application customizer