### PR TITLE
Add missing switch parameter to Set-PnPTeamsTeam.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
  
 ### Contributors
 
+- [abwlodar]
 - [jgfgoncalves]
 - Stephen Cox [stephen-cox-nzx]
 - Marijn Somers [Marijnsomers]

--- a/documentation/Set-PnPTeamsTeam.md
+++ b/documentation/Set-PnPTeamsTeam.md
@@ -27,7 +27,7 @@ Set-PnPTeamsTeam -Identity <TeamsTeamPipeBind> [-DisplayName <String>] [-Descrip
  [-AllowGiphy <Boolean>] [-AllowGuestCreateUpdateChannels <Boolean>] [-AllowGuestDeleteChannels <Boolean>]
  [-AllowOwnerDeleteMessages <Boolean>] [-AllowStickersAndMemes <Boolean>] [-AllowTeamMentions <Boolean>]
  [-AllowUserDeleteMessages <Boolean>] [-AllowUserEditMessages <Boolean>]
- [-GiphyContentRating <TeamGiphyContentRating>] [-ShowInTeamsSearchAndSuggestions <Boolean>]
+ [-GiphyContentRating <TeamGiphyContentRating>] [-ShowInTeamsSearchAndSuggestions <Boolean>] [-AllowCreatePrivateChannels <Boolean>]
  [-Classification <String>]  
 ```
 
@@ -265,6 +265,20 @@ Accept wildcard characters: False
 
 ### -AllowUserEditMessages
 Setting that determines whether or not users can edit messages that they have posted.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AllowCreatePrivateChannels
+Determines whether private channel creation is allowed for the team.
 
 ```yaml
 Type: Boolean

--- a/src/Commands/Teams/SetTeamsTeam.cs
+++ b/src/Commands/Teams/SetTeamsTeam.cs
@@ -71,7 +71,7 @@ namespace PnP.PowerShell.Commands.Teams
         public bool? AllowUserEditMessages;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterAttribute.AllParameterSets)]
-        public Model.Teams.TeamGiphyContentRating GiphyContentRating;
+        public TeamGiphyContentRating GiphyContentRating;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterAttribute.AllParameterSets)]
         public bool? ShowInTeamsSearchAndSuggestions;
@@ -81,6 +81,7 @@ namespace PnP.PowerShell.Commands.Teams
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterAttribute.AllParameterSets)]
         public bool? AllowCreatePrivateChannels;
+
         protected override void ExecuteCmdlet()
         {
             var groupId = Identity.GetGroupId(GraphRequestHelper);


### PR DESCRIPTION
Add the "-AllowCreatePrivateChannels" switch to the documentation.

## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
\-

## What is in this Pull Request ? ##
This PR adds a parameter missing in the documentation. Source: https://learn.microsoft.com/en-us/powershell/module/teams/set-team?view=teams-ps#-allowcreateprivatechannels