### PR TITLE
Fixes `Get-PnPSiteScriptFromWeb` throwing a file not found error when providing a web URL through `-Url` that differs from the connected to URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Get-PnPChangeLog` not returning the changelog [#4707](https://github.com/pnp/powershell/pull/4707)
 - Fixed `-Description` and `-Sequence` not being applied when providing these through `Add-PnPApplicationCustomizer` [#4767](https://github.com/pnp/powershell/pull/4767)
 - Fixed `-RetryCount` parameter being ignored with `Submit-PnPSearchQuery` [#4784](https://github.com/pnp/powershell/pull/4784)
+- Fixed `Get-PnPSiteScriptFromWeb` throwing a file not found error when providing a web URL through `-Url` that differed from the connected to URL
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Get-PnPChangeLog` not returning the changelog [#4707](https://github.com/pnp/powershell/pull/4707)
 - Fixed `-Description` and `-Sequence` not being applied when providing these through `Add-PnPApplicationCustomizer` [#4767](https://github.com/pnp/powershell/pull/4767)
 - Fixed `-RetryCount` parameter being ignored with `Submit-PnPSearchQuery` [#4784](https://github.com/pnp/powershell/pull/4784)
-- Fixed `Get-PnPSiteScriptFromWeb` throwing a file not found error when providing a web URL through `-Url` that differed from the connected to URL
+- Fixed `Get-PnPSiteScriptFromWeb` throwing a file not found error when providing a web URL through `-Url` that differed from the connected to URL [#4785](https://github.com/pnp/powershell/pull/4785)
 
 ### Removed
 

--- a/src/Commands/SiteDesigns/GetSiteScriptFromWeb.cs
+++ b/src/Commands/SiteDesigns/GetSiteScriptFromWeb.cs
@@ -15,42 +15,40 @@ namespace PnP.PowerShell.Commands
         private const string ParameterSet_ALLLISTS = "All lists";
         private const string ParameterSet_SPECIFICCOMPONENTS = "Specific components";
 
-        [Parameter(ParameterSetName = ParameterSet_BASICCOMPONENTS)]
-        [Parameter(ParameterSetName = ParameterSet_ALLCOMPONENTS)]
-        [Parameter(ParameterSetName = ParameterSet_ALLLISTS)]
-        [Parameter(ParameterSetName = ParameterSet_SPECIFICCOMPONENTS)]
-        [Parameter(Mandatory = false, ValueFromPipeline = true)]
+        [Parameter(Mandatory = false, ValueFromPipeline = true, ParameterSetName = ParameterSet_BASICCOMPONENTS)]
+        [Parameter(Mandatory = false, ValueFromPipeline = true, ParameterSetName = ParameterSet_ALLCOMPONENTS)]
+        [Parameter(Mandatory = false, ValueFromPipeline = true, ParameterSetName = ParameterSet_ALLLISTS)]
+        [Parameter(Mandatory = false, ValueFromPipeline = true, ParameterSetName = ParameterSet_SPECIFICCOMPONENTS)]
         public string Url;
 
-        [Parameter(ParameterSetName = ParameterSet_BASICCOMPONENTS)]
-        [Parameter(ParameterSetName = ParameterSet_ALLCOMPONENTS)]
-        [Parameter(ParameterSetName = ParameterSet_SPECIFICCOMPONENTS)]
-        [Parameter(Mandatory = false)]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_BASICCOMPONENTS)]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_ALLCOMPONENTS)]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_SPECIFICCOMPONENTS)]
         public string[] Lists;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_ALLCOMPONENTS)]
         public SwitchParameter IncludeAll;
 
-        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_ALLLISTS)]
-        public SwitchParameter IncludeAllLists;        
+        [Parameter(Mandatory = true, ParameterSetName = ParameterSet_ALLLISTS)]
+        public SwitchParameter IncludeAllLists;
 
-        [Parameter(ParameterSetName = ParameterSet_ALLLISTS)]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_ALLLISTS)]
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_SPECIFICCOMPONENTS)]
         public SwitchParameter IncludeBranding;
         
-        [Parameter(ParameterSetName = ParameterSet_ALLLISTS)]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_ALLLISTS)]
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_SPECIFICCOMPONENTS)]
         public SwitchParameter IncludeLinksToExportedItems;
         
-        [Parameter(ParameterSetName = ParameterSet_ALLLISTS)]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_ALLLISTS)]
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_SPECIFICCOMPONENTS)]
         public SwitchParameter IncludeRegionalSettings;
         
-        [Parameter(ParameterSetName = ParameterSet_ALLLISTS)]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_ALLLISTS)]
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_SPECIFICCOMPONENTS)]
         public SwitchParameter IncludeSiteExternalSharingCapability;
 
-        [Parameter(ParameterSetName = ParameterSet_ALLLISTS)]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_ALLLISTS)]
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_SPECIFICCOMPONENTS)]
         public SwitchParameter IncludeTheme;
 
@@ -61,13 +59,23 @@ namespace PnP.PowerShell.Commands
             {
                 Url = Connection.Url;
             }
+            
+            WriteVerbose($"Creating site script from web {Url}");
 
-            if(IncludeAllLists || IncludeAll)
+            if (IncludeAllLists || IncludeAll)
             {
-                ClientContext.Load(ClientContext.Web.Lists, lists => lists.Where(list => !list.Hidden && !list.IsCatalog && !list.IsSystemList && !list.IsPrivate && !list.IsApplicationList && !list.IsSiteAssetsLibrary && !list.IsEnterpriseGalleryLibrary).Include(list => list.RootFolder.ServerRelativeUrl));
-                ClientContext.ExecuteQueryRetry();
+                var targetWebContext = Url != Connection.Url ? Connection.CloneContext(Url) : ClientContext;
 
-                Lists = ClientContext.Web.Lists.Select(l => System.Text.RegularExpressions.Regex.Replace(l.RootFolder.ServerRelativeUrl, @"\/(?:sites|teams)\/.*?\/", string.Empty)).ToArray();
+                targetWebContext.Load(targetWebContext.Web.Lists, lists => lists.Where(list => !list.Hidden && !list.IsCatalog && !list.IsSystemList && !list.IsPrivate && !list.IsApplicationList && !list.IsSiteAssetsLibrary && !list.IsEnterpriseGalleryLibrary).Include(list => list.RootFolder.ServerRelativeUrl));
+                targetWebContext.ExecuteQueryRetry();
+
+                Lists = targetWebContext.Web.Lists.Select(l => System.Text.RegularExpressions.Regex.Replace(l.RootFolder.ServerRelativeUrl, @"\/(?:sites|teams)\/.*?\/", string.Empty)).ToArray();
+
+                WriteVerbose($"Including all custom lists and libraries in the site script... {Lists.Length} found");
+                foreach (var list in Lists)
+                {
+                    WriteVerbose($"- {list}");
+                }
             }
             
             var tenantSiteScriptSerializationInfo = new TenantSiteScriptSerializationInfo


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes issue https://github.com/pnp/powershell/issues/4752

## What is in this Pull Request ? ##
- Fixed `Get-PnPSiteScriptFromWeb` throwing a file not found error when providing a web URL through `-Url` that differed from the connected to URL
- Contains some other fixes to the same cmdlet as well where certain combinations of parameters weren't being accepted