### PR TITLE
Removed `New-PnPMicrosoft365Group` setting the group visibility twice and adding logging around trying to set the group visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - `Get-PnPCustomAction` now supports a completer for `-Identity` and uses the PnP Core SDK to return custom actions.
 - `Set-PnPPropertyBagValue` and `Remove-PnPPropertyBagValue` now toggle the NoScript status of the site to allow setting/removing property bag values, but only if the tenant wide `AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled` is not enabled [#4680](https://github.com/pnp/powershell/pull/4680)
 - `Get-PnPTenant` now uses nullable types for the properties that can return null if the property is not set or could not be retrieved. Beware that the property `PublicCdnOrigins` has been renamed to `PublicCdnOriginParsed `. All other property names will remain the same. [#4722](https://github.com/pnp/powershell/pull/4722)
-- Removed `New-PnPMicrosoft365Group` setting the group visibility options twice when providing `-HideFromAddressLists` and/or `-HideFromOutlookClients` and adding logging around trying to set the group visibility
+- Removed `New-PnPMicrosoft365Group` setting the group visibility options twice when providing `-HideFromAddressLists` and/or `-HideFromOutlookClients` and adding logging around trying to set the group visibility [#4791](https://github.com/pnp/powershell/pull/4791)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - `Get-PnPCustomAction` now supports a completer for `-Identity` and uses the PnP Core SDK to return custom actions.
 - `Set-PnPPropertyBagValue` and `Remove-PnPPropertyBagValue` now toggle the NoScript status of the site to allow setting/removing property bag values, but only if the tenant wide `AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled` is not enabled [#4680](https://github.com/pnp/powershell/pull/4680)
 - `Get-PnPTenant` now uses nullable types for the properties that can return null if the property is not set or could not be retrieved. Beware that the property `PublicCdnOrigins` has been renamed to `PublicCdnOriginParsed `. All other property names will remain the same. [#4722](https://github.com/pnp/powershell/pull/4722)
+- Removed `New-PnPMicrosoft365Group` setting the group visibility options twice when providing `-HideFromAddressLists` and/or `-HideFromOutlookClients` and adding logging around trying to set the group visibility
 
 ### Fixed
 

--- a/src/Commands/Microsoft365Groups/NewMicrosoft365Group.cs
+++ b/src/Commands/Microsoft365Groups/NewMicrosoft365Group.cs
@@ -175,11 +175,6 @@ namespace PnP.PowerShell.Commands.Microsoft365Groups
 
                 var group = Microsoft365GroupsUtility.Create(GraphRequestHelper, newGroup, CreateTeam, LogoPath, Owners, Members, HideFromAddressLists, HideFromOutlookClients, Labels);
 
-                if (ParameterSpecified(nameof(HideFromAddressLists)) || ParameterSpecified(nameof(HideFromOutlookClients)))
-                {
-                    Microsoft365GroupsUtility.SetVisibility(GraphRequestHelper, group.Id.Value, HideFromAddressLists, HideFromOutlookClients);
-                }
-
                 var updatedGroup = Microsoft365GroupsUtility.GetGroup(GraphRequestHelper, group.Id.Value, true, false, false, true);
 
                 WriteObject(updatedGroup);

--- a/src/Commands/Utilities/Microsoft365GroupsUtility.cs
+++ b/src/Commands/Utilities/Microsoft365GroupsUtility.cs
@@ -1,3 +1,4 @@
+using PnP.Framework.Diagnostics;
 using PnP.PowerShell.Commands.Model;
 using PnP.PowerShell.Commands.Utilities.REST;
 using System;
@@ -699,33 +700,42 @@ namespace PnP.PowerShell.Commands.Utilities
             return requestHelper.Patch($"v1.0/groups/{group.Id}", group);
         }
 
+        /// <summary>
+        /// Allows to set the visibility of a group to hideFromAddressLists and hideFromOutlookClients.
+        /// </summary>
         internal static void SetVisibility(ApiRequestHelper requestHelper, Guid groupId, bool? hideFromAddressLists, bool? hideFromOutlookClients)
         {
-            var patchData = new
-            {
-                hideFromAddressLists = hideFromAddressLists,
-                hideFromOutlookClients = hideFromOutlookClients
-            };
+            var attempt = 1;
+            var maxRetries = 10;
+            var retryAfterSeconds = 5;
 
-            var retry = true;
-            var iteration = 0;
-            while (retry)
+            while (true)
             {
                 try
                 {
-                    requestHelper.Patch<dynamic>($"v1.0/groups/{groupId}", patchData);
-                    retry = false;
-                }
+                    requestHelper.Patch<dynamic>($"v1.0/groups/{groupId}", new
+                    {
+                        hideFromAddressLists,
+                        hideFromOutlookClients
+                    });
 
-                catch (Exception)
-                {
-                    Thread.Sleep(5000);
-                    iteration++;
+                    // Request successful, exit the loop
+                    break;
                 }
-
-                if (iteration > 10) // don't try more than 10 times
+                catch (Exception e)
                 {
-                    retry = false;
+                    if (attempt == maxRetries)
+                    {
+                        Log.Warning("Microsoft365GroupsUtility.SetVisibility", $"Failed to set the visibility of the group {groupId} to hideFromAddressLists: {hideFromAddressLists} and hideFromOutlookClients: {hideFromOutlookClients}. Exception: {e.Message}. Giving up after {maxRetries} attempts.");
+                        break;
+                    }
+                    else
+                    {
+                        Log.Debug("Microsoft365GroupsUtility.SetVisibility", $"Failed to set the visibility of the group {groupId} to hideFromAddressLists: {hideFromAddressLists} and hideFromOutlookClients: {hideFromOutlookClients}. Exception: {e.Message}. Retrying in {retryAfterSeconds} seconds. Attempt {attempt} out of {maxRetries}.");
+                    }
+
+                    Thread.Sleep(TimeSpan.FromSeconds(retryAfterSeconds));
+                    attempt++;
                 }
             }
         }


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Removed `New-PnPMicrosoft365Group` setting the group visibility options twice when providing `-HideFromAddressLists` and/or `-HideFromOutlookClients` and adding logging around trying to set the group visibility