### PR TITLE
Adding new mandatory parameter `-ArchiveStatus` to `Get-PnPContainer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - `Get-PnPTenant` now uses nullable types for the properties that can return null if the property is not set or could not be retrieved. Beware that the property `PublicCdnOrigins` has been renamed to `PublicCdnOriginParsed `. All other property names will remain the same. [#4722](https://github.com/pnp/powershell/pull/4722)
 - Removed `New-PnPMicrosoft365Group` setting the group visibility options twice when providing `-HideFromAddressLists` and/or `-HideFromOutlookClients` and adding logging around trying to set the group visibility [#4791](https://github.com/pnp/powershell/pull/4791)
 - Visual Studio Code launch profiles have been cleaned up and restructured [#4808](https://github.com/pnp/powershell/pull/4804)
-- The cmdlet `Get-PnPContainer` now has a new optional parameter `-ArchiveStatus` which allows filtering SharePoint Online Embedded containers by archival status
+- The cmdlet `Get-PnPContainer` now has a new optional parameter `-ArchiveStatus` which allows filtering SharePoint Online Embedded containers by archival status [#4821](https://github.com/pnp/powershell/pull/4821)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - `Get-PnPTenant` now uses nullable types for the properties that can return null if the property is not set or could not be retrieved. Beware that the property `PublicCdnOrigins` has been renamed to `PublicCdnOriginParsed `. All other property names will remain the same. [#4722](https://github.com/pnp/powershell/pull/4722)
 - Removed `New-PnPMicrosoft365Group` setting the group visibility options twice when providing `-HideFromAddressLists` and/or `-HideFromOutlookClients` and adding logging around trying to set the group visibility [#4791](https://github.com/pnp/powershell/pull/4791)
 - Visual Studio Code launch profiles have been cleaned up and restructured [#4808](https://github.com/pnp/powershell/pull/4804)
+- The cmdlet `Get-PnPContainer` now has a new optional parameter `-ArchiveStatus` which allows filtering SharePoint Online Embedded containers by archival status
 
 ### Fixed
 

--- a/documentation/Get-PnPContainer.md
+++ b/documentation/Get-PnPContainer.md
@@ -20,7 +20,7 @@ Returns one or more Containers in a SharePoint Embedded application.
 ## SYNTAX
 
 ```powershell
-Get-PnPContainer [-Identity <ContainerPipeBind>] [-OwningApplicationId <Guid>] [-Paged <switchparameter>] [-PagingToken <string>][-SortOrder <SortOrder>] [-Connection <PnPConnection>] 
+Get-PnPContainer [-Identity <ContainerPipeBind>] [-OwningApplicationId <Guid>] [-Paged <switchparameter>] [-PagingToken <string>][-SortOrder <SortOrder>] [-ArchiveStatus <SPContainerArchiveStatusFilterProperties>] [-Connection <PnPConnection>] 
 ```
 
 ## DESCRIPTION
@@ -49,6 +49,26 @@ Get-PnPContainer -Identity "bc07d4b8-1c2f-4184-8cc2-a52dfd6fe0c4" -Identity  "ht
 Returns the properties of the specified container by using the container url
 
 ## PARAMETERS
+
+### -ArchiveStatus
+
+The ArchiveStatus parameter is used to display containers in various stages of archiving. The following states are supported:
+- Archived: Displays containers in all archived states.
+- RecentlyArchived: Displays containers in the "Recently archived" state.
+- FullyArchived: Displays containers in the "Fully archived" state.
+- Reactivating: Displays containers in the "Reactivating" state.
+- NotArchived: Displays active containers
+
+```yaml
+Type: SPContainerArchiveStatusFilterProperties
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: NotArchived
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Connection
 

--- a/src/Commands/Admin/GetContainer.cs
+++ b/src/Commands/Admin/GetContainer.cs
@@ -28,11 +28,14 @@ namespace PnP.PowerShell.Commands.Admin
         [Parameter(Mandatory = false)]
         public SortOrder? SortByStorage { get; set; }
 
+        [Parameter(Mandatory = false)]
+        public SPContainerArchiveStatusFilterProperties ArchiveStatus { get; set; } = SPContainerArchiveStatusFilterProperties.NotArchived;
+
         protected override void ExecuteCmdlet()
         {
             if (Identity != null)
             {
-                var containerProperties = Identity.GetContainer(Tenant);            
+                var containerProperties = Identity.GetContainer(Tenant);
                 WriteObject(containerProperties);
             }
             else if (OwningApplicationId != Guid.Empty)
@@ -41,11 +44,11 @@ namespace PnP.PowerShell.Commands.Admin
                 if (SortByStorage.HasValue)
                 {
                     bool ascending = SortByStorage == SortOrder.Ascending;
-                    clientResult = Tenant.GetSortedSPOContainersByApplicationId(OwningApplicationId, ascending, Paged, PagingToken);
+                    clientResult = Tenant.GetSortedSPOContainersByApplicationId(OwningApplicationId, ascending, Paged, PagingToken, ArchiveStatus);
                 }
                 else
                 {
-                    clientResult = Tenant.GetSPOContainersByApplicationId(OwningApplicationId, Paged, PagingToken);
+                    clientResult = Tenant.GetSPOContainersByApplicationId(OwningApplicationId, Paged, PagingToken, ArchiveStatus);
                 }
                 AdminContext.ExecuteQueryRetry();
                 IList<SPContainerProperties> containerCollection = clientResult.Value.ContainerCollection;
@@ -65,8 +68,8 @@ namespace PnP.PowerShell.Commands.Admin
                         {
                             WriteObject("End of containers view.");
                         }
-                    }                    
-                }                
+                    }
+                }
             }
             else
             {


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Adding new mandatory parameter `-ArchiveStatus` to `Get-PnPContainer` as introduced in the last CSOM update