### PR TITLE
Fixes `Get-PnPPropertyBag` not returning updated values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Get-PnPSiteScriptFromWeb` throwing a file not found error when providing a web URL through `-Url` that differed from the connected to URL [#4785](https://github.com/pnp/powershell/pull/4785)
 - Fixed `Set-PnPListItem -Values @{}` passing in a taxonomy field with a guid typed value throwing an error [#4811](https://github.com/pnp/powershell/pull/4811)
 - Fixed `Get-PnPFolder` throwing an exception when a lot of files and folders are present [#4819](https://github.com/pnp/powershell/pull/4819)
+- Fixed `Get-PnPPropertyBag` not returning updated values after running it for the first time
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Get-PnPSiteScriptFromWeb` throwing a file not found error when providing a web URL through `-Url` that differed from the connected to URL [#4785](https://github.com/pnp/powershell/pull/4785)
 - Fixed `Set-PnPListItem -Values @{}` passing in a taxonomy field with a guid typed value throwing an error [#4811](https://github.com/pnp/powershell/pull/4811)
 - Fixed `Get-PnPFolder` throwing an exception when a lot of files and folders are present [#4819](https://github.com/pnp/powershell/pull/4819)
-- Fixed `Get-PnPPropertyBag` not returning updated values after running it for the first time
+- Fixed `Get-PnPPropertyBag` not returning updated values after running it for the first time [#4823](https://github.com/pnp/powershell/pull/4823)
 
 ### Removed
 

--- a/src/Commands/Web/GetPropertyBag.cs
+++ b/src/Commands/Web/GetPropertyBag.cs
@@ -32,7 +32,8 @@ namespace PnP.PowerShell.Commands
                 }
                 else
                 {
-                    CurrentWeb.EnsureProperty(w => w.AllProperties);
+                    ClientContext.Load(CurrentWeb.AllProperties);
+                    ClientContext.ExecuteQueryRetry();
 
                     var values = CurrentWeb.AllProperties.FieldValues.Select(x => new PropertyBagValue() { Key = x.Key, Value = x.Value });
                     WriteObject(values, true);
@@ -46,7 +47,8 @@ namespace PnP.PowerShell.Commands
 
                 var folderUrl = UrlUtility.Combine(CurrentWeb.ServerRelativeUrl, Folder);
                 var folder = CurrentWeb.GetFolderByServerRelativePath(ResourcePath.FromDecodedUrl(folderUrl));
-                folder.EnsureProperty(f => f.Properties);
+                ClientContext.Load(folder, f => f.Properties);
+                ClientContext.ExecuteQueryRetry();
 
                 if (!string.IsNullOrEmpty(Key))
                 {
@@ -58,7 +60,6 @@ namespace PnP.PowerShell.Commands
                     var values = folder.Properties.FieldValues.Select(x => new PropertyBagValue() { Key = x.Key, Value = x.Value });
                     WriteObject(values, true);
                 }
-
             }
         }
     }


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes https://github.com/pnp/powershell/issues/4793

## What is in this Pull Request ? ##
Fixed `Get-PnPPropertyBag` not returning updated values after running it for the first time due it using EnsureProperty instead of a Load