### PR TITLE
Fixes `Set-PnPTerm -Name "New Name" -Lcid 1043` changing the default name of the taxonomy item, ignoring the provided language id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Get-PnPSiteScriptFromWeb` throwing a file not found error when providing a web URL through `-Url` that differed from the connected to URL [#4785](https://github.com/pnp/powershell/pull/4785)
 - Fixed `Set-PnPListItem -Values @{}` passing in a taxonomy field with a guid typed value throwing an error [#4811](https://github.com/pnp/powershell/pull/4811)
 - Fixed `Get-PnPFolder` throwing an exception when a lot of files and folders are present [#4819](https://github.com/pnp/powershell/pull/4819)
+- Fixed `Set-PnPTerm -Name "New Name" -Lcid 1043` changing the default name of the taxonomy item, ignoring the provided language id and changing the name for the default language instead.
 
 ### Removed
 

--- a/src/Commands/Taxonomy/SetTerm.cs
+++ b/src/Commands/Taxonomy/SetTerm.cs
@@ -95,7 +95,14 @@ namespace PnP.PowerShell.Commands.Taxonomy
 
             if (ParameterSpecified(nameof(Name)))
             {
-                term.Name = TaxonomyExtensions.NormalizeName(Name);
+                if (ParameterSpecified(nameof(Lcid)))
+                {
+                    term.CreateLabel(TaxonomyExtensions.NormalizeName(Name), Lcid, true);
+                }
+                else
+                {
+                    term.Name = TaxonomyExtensions.NormalizeName(Name);
+                }
             }
             if (ParameterSpecified(nameof(Description)))
             {


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Partially fixes https://github.com/pnp/powershell/issues/4772

## What is in this Pull Request ? ##
Fixed `Set-PnPTerm -Name "New Name" -Lcid 1043` changing the default name of the taxonomy item, ignoring the provided language id and changing the name for the default language instead. Unfortunately the only way to fix this is by allowing it to set the old name as a synonim of the same taxonomy item for that language. Not perfect, but the only option due to CSOM limitations.
