### PR TITLE
Added various SharePoint Online Brand Center cmdlets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,10 +64,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `-Transitive` parameter to `Get-PnPAzureADGroupMember` cmdlet to allow members of groups inside groups to be retrieved [#4799](https://github.com/pnp/powershell/pull/4799)
 - Added the ability to `Get-PnPPage` to return all site pages in the site by omitting the `-Identity` parameter [#4805](https://github.com/pnp/powershell/pull/4805)
 - Added `Copy-PnPPage`, `Move-PnPPage` and `Get-PnPPageCopyProgress` cmdlets to allow for copying and moving site pages between sites [#4806](https://github.com/pnp/powershell/pull/4806)
-- Added `Get-PnPBrandCenterConfig` to retrieve the configuration of the Brand Center on the tenant
-- Added `Get-PnPBrandCenterFont` to retrieve the available fonts from the various Brand Centers
-- Added `Set-PnPBrandCenterFont` to apply the specified font from the Brand Center to the current site
-- Added `Add-PnPBrandCenterFont` to upload a font to the tenant Brand Center
+- Added `Get-PnPBrandCenterConfig` to retrieve the configuration of the Brand Center on the tenant [#4830](https://github.com/pnp/powershell/pull/4830)
+- Added `Get-PnPBrandCenterFont` to retrieve the available fonts from the various Brand Centers [#4830](https://github.com/pnp/powershell/pull/4830)
+- Added `Set-PnPBrandCenterFont` to apply the specified font from the Brand Center to the current site [#4830](https://github.com/pnp/powershell/pull/4830)
+- Added `Add-PnPBrandCenterFont` to upload a font to the tenant Brand Center [#4830](https://github.com/pnp/powershell/pull/4830)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `-Transitive` parameter to `Get-PnPAzureADGroupMember` cmdlet to allow members of groups inside groups to be retrieved [#4799](https://github.com/pnp/powershell/pull/4799)
 - Added the ability to `Get-PnPPage` to return all site pages in the site by omitting the `-Identity` parameter [#4805](https://github.com/pnp/powershell/pull/4805)
 - Added `Copy-PnPPage`, `Move-PnPPage` and `Get-PnPPageCopyProgress` cmdlets to allow for copying and moving site pages between sites [#4806](https://github.com/pnp/powershell/pull/4806)
+- Added `Get-PnPBrandCenterConfig` to retrieve the configuration of the Brand Center on the tenant
+- Added `Get-PnPBrandCenterFont` to retrieve the available fonts from the various Brand Centers
+- Added `Set-PnPBrandCenterFont` to apply the specified font from the Brand Center to the current site
+- Added `Add-PnPBrandCenterFont` to upload a font to the tenant Brand Center
 
 ### Changed
 

--- a/documentation/Add-PnPBrandCenterFont.md
+++ b/documentation/Add-PnPBrandCenterFont.md
@@ -1,0 +1,86 @@
+---
+Module Name: PnP.PowerShell
+schema: 2.0.0
+applicable: SharePoint Online
+online version: https://pnp.github.io/powershell/cmdlets/Add-PnPBrandCenterFont.html
+external help file: PnP.PowerShell.dll-Help.xml
+title: Add-PnPBrandCenterFont
+---
+  
+# Add-PnPBrandCenterFont
+
+## SYNOPSIS
+Allows a font to be uploaded to the tenant Brand Center
+
+## SYNTAX
+
+```powershell
+Add-PnPBrandCenterFont -Path <String> [-Visible <Boolean>] [-Connection <PnPConnection>] [-Verbose]
+```
+
+## DESCRIPTION
+This cmdlet allows a font to be uploaded to the tenant Brand Center. The font will be available for use in the tenant and site collection Brand Center.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Add-PnPBrandCenterFont -Path c:\temp\MyAwesomeFont.ttf
+```
+
+This will upload the font MyAwesomeFont.ttf to the tenant Brand Center and will make it visible
+
+### EXAMPLE 2
+```powershell
+Add-PnPBrandCenterFont -Path c:\temp\MyAwesomeFont.ttf -Visible:$false
+```
+
+This will upload the font MyAwesomeFont.ttf to the tenant Brand Center and will hide it from being used
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing [Get-PnPConnection](Get-PnPConnection.md).
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+The local file path to where the font is stored that needs to be uploaded
+
+```yaml
+Type: String
+Parameter Sets: (All)
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Visible
+Indicates if the font should be visible in the Brand Center. The default is true.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: True
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/documentation/Get-PnPBrandCenterConfig.md
+++ b/documentation/Get-PnPBrandCenterConfig.md
@@ -1,0 +1,51 @@
+---
+Module Name: PnP.PowerShell
+schema: 2.0.0
+applicable: SharePoint Online
+online version: https://pnp.github.io/powershell/cmdlets/Get-PnPBrandCenterConfig.html
+external help file: PnP.PowerShell.dll-Help.xml
+title: Get-PnPBrandCenterConfig
+---
+  
+# Get-PnPBrandCenterConfig
+
+## SYNOPSIS
+Returns the Brand Center configuration for the current tenant
+
+## SYNTAX
+
+```powershell
+Get-PnPBrandCenterConfig
+```
+
+## DESCRIPTION
+Allows retrieval of the Brand Center configuration for the current tenant. The Brand Center is a centralized location for managing and sharing branding assets, such as logos, colors, and fonts, across Microsoft 365 applications.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-PnPBrandCenterConfig
+```
+
+Returns the configuration of the Brand Center for the current tenant.
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing [Get-PnPConnection](Get-PnPConnection.md).
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/documentation/Get-PnPBrandCenterFont.md
+++ b/documentation/Get-PnPBrandCenterFont.md
@@ -1,0 +1,110 @@
+---
+Module Name: PnP.PowerShell
+schema: 2.0.0
+applicable: SharePoint Online
+online version: https://pnp.github.io/powershell/cmdlets/Get-PnPBrandCenterFont.html
+external help file: PnP.PowerShell.dll-Help.xml
+title: Get-PnPBrandCenterFont
+---
+  
+# Get-PnPBrandCenterFont
+
+## SYNOPSIS
+Returns the available fonts configured throught heBrand Center
+
+## SYNTAX
+
+### All
+```powershell
+Get-PnPBrandCenterFont [-Store <Tenant|OutOfBox|Site|All>] [-Connection <PnPConnection>]
+```
+
+### Single
+```powershell
+Get-PnPBrandCenterFont -Identity <BrandCenterFontPipeBind> [-Store <Tenant|OutOfBox|Site|All>] [-Connection <PnPConnection>]
+```
+
+## DESCRIPTION
+Allows retrieval of the available fonts from the various Brand Centers.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-PnPBrandCenterFont
+```
+
+Returns all the available fonts
+
+### EXAMPLE 2
+```powershell
+Get-PnPBrandCenterFont -Store Site
+```
+
+Returns the available fonts from the site collection Brand Center
+
+### EXAMPLE 3
+```powershell
+Get-PnPBrandCenterFont -Identity "My awesome font"
+```
+
+Looks up and returns the font with the name "My awesome font" from any of the Brand Centers
+
+### EXAMPLE 4
+```powershell
+Get-PnPBrandCenterFont -Identity "2812cbd8-7176-4e45-8911-6a063f89a1f1"
+```
+
+Looks up and returns the font with the Identity "2812cbd8-7176-4e45-8911-6a063f89a1f1" from any of the Brand Centers
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing [Get-PnPConnection](Get-PnPConnection.md).
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+Unique identifier of the font to be retrieved. This can be its guid, name or a BrandCenterFont object. If not specified, all the available fonts will be returned.
+
+```yaml
+Type: BrandCenterFontPipeBind
+Parameter Sets: Single
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True
+Accept wildcard characters: False
+```
+
+### -Store
+Indicates the source of the fonts to be retrieved. The following values are available:
+- Tenant: The fonts configured in the tenant Brand Center
+- Site: The fonts configured in the site collection Brand Center
+- OutOfBox: The out of box fonts available in the tenant
+- All: All the fonts available in the tenant, including the ones configured in the tenant and site collection Brand Center and the out of box fonts.
+
+```yaml
+Type: Store
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: All
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/documentation/Set-PnPBrandCenterFont.md
+++ b/documentation/Set-PnPBrandCenterFont.md
@@ -1,0 +1,90 @@
+---
+Module Name: PnP.PowerShell
+schema: 2.0.0
+applicable: SharePoint Online
+online version: https://pnp.github.io/powershell/cmdlets/Set-PnPBrandCenterFont.html
+external help file: PnP.PowerShell.dll-Help.xml
+title: Set-PnPBrandCenterFont
+---
+  
+# Set-PnPBrandCenterFont
+
+## SYNOPSIS
+Applies the specified font from the Brand Center to the current site.
+
+## SYNTAX
+
+```powershell
+Set-PnPBrandCenterFont -Identity <BrandCenterFontPipeBind> [-Store <Tenant|OutOfBox|Site|All>] [-Connection <PnPConnection>]
+```
+
+## DESCRIPTION
+Applies the specified font from the Brand Center to the current site.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Set-PnPBrandCenterFont -Identity "2812cbd8-7176-4e45-8911-6a063f89a1f1"
+```
+
+Looks up and applies the font with the identity "2812cbd8-7176-4e45-8911-6a063f89a1f1" from any of the Brand Centers to the current site
+
+### EXAMPLE 2
+```powershell
+Set-PnPBrandCenterFont -Identity "My awesome font" -Store Tenant
+```
+
+Looks up and applies the font with the title "My awesome font" from the tenant Brand Center
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing [Get-PnPConnection](Get-PnPConnection.md).
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+Unique identifier of the font to be applied. This can be its guid, name or a BrandCenterFont object.
+
+```yaml
+Type: BrandCenterFontPipeBind
+Parameter Sets: (All)
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True
+Accept wildcard characters: False
+```
+
+### -Store
+Indicates the source of the fonts to be looked in to try to locate the font to apply. The following values are available:
+- Tenant: The fonts configured in the tenant Brand Center
+- Site: The fonts configured in the site collection Brand Center
+- OutOfBox: The out of box fonts available in the tenant
+- All: All the fonts available in the tenant, including the ones configured in the tenant and site collection Brand Center and the out of box fonts.
+
+```yaml
+Type: Store
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: All
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/resources/PnP.PowerShell.Format.ps1xml
+++ b/resources/PnP.PowerShell.Format.ps1xml
@@ -3201,6 +3201,57 @@
           </TableRowEntry>
         </TableRowEntries>
       </TableControl>
-    </View>         
+    </View>
+    <View>
+      <Name>Font</Name>
+      <ViewSelectedBy>
+        <TypeName>PnP.PowerShell.Commands.Model.SharePoint.BrandCenter.Font</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>Id</Label>
+            <Alignment>left</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Title</Label>
+            <Alignment>left</Alignment>
+          </TableColumnHeader>          
+          <TableColumnHeader>
+            <Label>Store</Label>
+            <Alignment>left</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>IsValid</Label>
+            <Alignment>left</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>IsHidden</Label>
+            <Alignment>left</Alignment>
+          </TableColumnHeader>                    
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>Id</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Title</PropertyName>
+              </TableColumnItem>              
+              <TableColumnItem>
+                <PropertyName>Store</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>IsValid</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>IsHidden</PropertyName>
+              </TableColumnItem>                            
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>          
   </ViewDefinitions>
 </Configuration>

--- a/src/Commands/Base/PipeBinds/ApplyConfigurationPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/ApplyConfigurationPipeBind.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using Microsoft.SharePoint.Client;
-using PnP.Framework.Provisioning.Model.Configuration;
+﻿using PnP.Framework.Provisioning.Model.Configuration;
 
 namespace PnP.PowerShell.Commands.Base.PipeBinds
 {

--- a/src/Commands/Base/PipeBinds/BrandCenterFontPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/BrandCenterFontPipeBind.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.SharePoint.Client;
+using PnP.PowerShell.Commands.Model.SharePoint.BrandCenter;
+using PnP.PowerShell.Commands.Utilities;
+
+namespace PnP.PowerShell.Commands.Base.PipeBinds
+{
+    public sealed class BrandCenterFontPipeBind
+    {
+        public readonly Guid? _id;
+        public readonly string _title;
+        private Font _font;
+
+        public BrandCenterFontPipeBind()
+        {
+        }
+
+        public BrandCenterFontPipeBind(Guid id)
+        {
+            _id = id;
+        }
+
+        public BrandCenterFontPipeBind(string idOrTitle)
+        {
+            if(Guid.TryParse(idOrTitle, out Guid guidId))
+            {
+                _id = guidId;
+            }
+            else
+            {
+                _title = idOrTitle;
+            }
+        }
+
+        public BrandCenterFontPipeBind(Font font)
+        {
+            _font = font;
+        }
+
+        /// <summary>
+        /// Gets the Font represented in this pipebind
+        /// </summary>
+        /// <param name="cmdlet">The cmdlet instance to use to retrieve the Font in this pipe bind</param>
+        /// <param name="clientContext">ClientContext to use to communicate with SharePoint Online</param>
+        /// <param name="connection">Connection to use to communicate with SharePoint Online</param>
+        /// <param name="webUrl">Url to use to check the site collection Brand Center</param>
+        /// <param name="store">The store to check for the font. When NULL, it will check all stores.</param>
+        /// <exception cref="Exception">Thrown when the ContainerProperties cannot be retrieved</exception>
+        /// <returns>Font</returns>
+        public Font GetFont(BasePSCmdlet cmdlet, ClientContext clientContext, PnPConnection connection, string webUrl, Store store = Store.All)
+        {
+            if (_font != null)
+            {
+                return _font;
+            }
+            else if (_id.HasValue)
+            {
+                _font = BrandCenterUtility.GetFontById(cmdlet, clientContext, connection, _id.Value, webUrl, store);
+                return _font;
+            }
+            else if (!string.IsNullOrEmpty(_title))
+            {
+                _font = BrandCenterUtility.GetFontByTitle(cmdlet, clientContext, connection, _title, webUrl, store);
+                return _font;
+            }            
+            return null;
+        }
+    }
+}

--- a/src/Commands/Base/PipeBinds/ContainerPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/ContainerPipeBind.cs
@@ -11,26 +11,30 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
         /// Id of the container
         /// </summary>
         private readonly string _id;
+
         /// <summary>
         /// Url of the container
         /// </summary>
         private readonly string _url;
+
         /// <summary>
         /// ContainerProperties of the container
         /// </summary>
         private SPContainerProperties _ContainerProperties;
+
         /// <summary>
         /// Creates a new ContainerPipeBind based on the Url of a container or the Id of a container
         /// </summary>
         /// <param name="identity">Url or Id of a container</param>
         public string Id => _id;
+        
         public ContainerPipeBind(string idOrUrl)
         {
             if (string.IsNullOrEmpty(idOrUrl))
                 throw new ArgumentException("Url or ID null or empty.", nameof(idOrUrl));
 
             Uri uriResult;
-            if( Uri.TryCreate(idOrUrl, UriKind.Absolute,out uriResult))
+            if (Uri.TryCreate(idOrUrl, UriKind.Absolute, out uriResult))
             {
                 _url = idOrUrl;
             }

--- a/src/Commands/Base/PipeBinds/ThemePipeBind.cs
+++ b/src/Commands/Base/PipeBinds/ThemePipeBind.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.SharePoint.Client;
-using PnP.PowerShell.Commands.Model;
-using System;
+﻿using PnP.PowerShell.Commands.Model;
 
 namespace PnP.PowerShell.Commands.Base.PipeBinds
 {

--- a/src/Commands/Branding/AddBrandCenterFont.cs
+++ b/src/Commands/Branding/AddBrandCenterFont.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections;
+using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using PnP.PowerShell.Commands.Utilities;
+
+namespace PnP.PowerShell.Commands.Files
+{
+    [Cmdlet(VerbsCommon.Add, "PnPBrandCenterFont")]
+    [OutputType(typeof(File))]
+    public class AddBrandCenterFont : PnPWebCmdlet
+    {
+        [ValidateNotNullOrEmpty]
+        [Parameter(Mandatory = true)]
+        public string Path = string.Empty;
+
+        [Parameter(Mandatory = false)]
+        public bool? Visible = true;
+
+        protected override void ExecuteCmdlet()
+        {
+            if (!System.IO.Path.IsPathRooted(Path))
+            {
+                Path = System.IO.Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, Path);
+            }
+
+            var brandCenterConfig = BrandCenterUtility.GetBrandCenterConfiguration(this, ClientContext);
+            if (brandCenterConfig == null || !brandCenterConfig.IsBrandCenterSiteFeatureEnabled || string.IsNullOrEmpty(brandCenterConfig.SiteUrl))
+            {
+                throw new PSArgumentException("Brand Center is not enabled for this tenant");
+            }
+
+            LogDebug($"Connecting to the Brand Center site at {brandCenterConfig.SiteUrl}");
+            using var brandCenterContext = Connection.CloneContext(brandCenterConfig.SiteUrl);
+
+            LogDebug($"Retrieving the Brand Center font library with ID {brandCenterConfig.BrandFontLibraryId}");
+            var brandCenterFontLibrary = brandCenterContext.Web.GetListById(brandCenterConfig.BrandFontLibraryId);
+            brandCenterContext.Load(brandCenterFontLibrary, l => l.RootFolder);
+            brandCenterContext.ExecuteQueryRetry();
+
+            LogDebug($"Uploading the font to the Brand Center font library root folder at {brandCenterFontLibrary.RootFolder.ServerRelativeUrl}");
+            var file = brandCenterFontLibrary.RootFolder.UploadFile(System.IO.Path.GetFileName(Path), Path, true);
+
+            if (ParameterSpecified(nameof(Visible)) && Visible.HasValue)
+            {
+                LogDebug($"Setting the font visibility to {Visible.Value}");
+                ListItemHelper.SetFieldValues(file.ListItemAllFields, new Hashtable { { "_SPFontVisible", Visible.Value ? "True" : "False" } }, this);
+                file.ListItemAllFields.UpdateOverwriteVersion();
+            }
+
+            brandCenterContext.Load(file);
+            brandCenterContext.ExecuteQueryRetry();
+
+            LogDebug("Font uploaded successfully");
+            WriteObject(file);
+        }
+    }
+}

--- a/src/Commands/Branding/GetBrandCenterConfig.cs
+++ b/src/Commands/Branding/GetBrandCenterConfig.cs
@@ -1,0 +1,16 @@
+﻿using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using PnP.PowerShell.Commands.Utilities;
+
+namespace PnP.PowerShell.Commands.Branding
+{
+    [Cmdlet(VerbsCommon.Get, "PnPBrandCenterConfig")]
+    [OutputType(typeof(BrandCenterConfiguration))]
+    public class GetBrandCenterConfig : PnPSharePointCmdlet
+    {
+        protected override void ExecuteCmdlet()
+        {
+            WriteObject(BrandCenterUtility.GetBrandCenterConfiguration(this, ClientContext), false);
+        }
+    }
+}

--- a/src/Commands/Branding/GetBrandCenterFont.cs
+++ b/src/Commands/Branding/GetBrandCenterFont.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using PnP.PowerShell.Commands.Base.PipeBinds;
+using PnP.PowerShell.Commands.Model.SharePoint.BrandCenter;
+using PnP.PowerShell.Commands.Utilities;
+
+namespace PnP.PowerShell.Commands.Branding
+{
+    [Cmdlet(VerbsCommon.Get, "PnPBrandCenterFont", DefaultParameterSetName = ParameterSet_ALL)]
+    [OutputType(typeof(Font), ParameterSetName = new[] { ParameterSet_SINGLE })]
+    [OutputType(typeof(IEnumerable<Font>), ParameterSetName = new[] { ParameterSet_ALL })]
+    public class GetBrandCenterFont : PnPWebCmdlet
+    {
+        private const string ParameterSet_SINGLE = "Single";
+        private const string ParameterSet_ALL = "All";
+
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = ParameterSet_SINGLE)]
+        public BrandCenterFontPipeBind Identity { get; set; }
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_SINGLE)]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_ALL)]
+        public Store Store { get; set; } = Store.All;
+
+        protected override void ExecuteCmdlet()
+        {
+            CurrentWeb.EnsureProperty(w => w.Url);
+
+            if (ParameterSpecified(nameof(Identity)))
+            {
+                var font = Identity.GetFont(this, ClientContext, Connection, CurrentWeb.Url, Store);
+                WriteObject(font, false);
+            }
+            else
+            {
+                WriteObject(BrandCenterUtility.GetFonts(this, ClientContext, Connection, CurrentWeb.Url, Store), true);
+            }
+        }
+    }
+}

--- a/src/Commands/Branding/SetBrandCenterFont.cs
+++ b/src/Commands/Branding/SetBrandCenterFont.cs
@@ -1,0 +1,37 @@
+﻿using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using PnP.PowerShell.Commands.Base.PipeBinds;
+using PnP.PowerShell.Commands.Model.SharePoint.BrandCenter;
+using PnP.PowerShell.Commands.Utilities;
+using PnP.PowerShell.Commands.Utilities.REST;
+
+namespace PnP.PowerShell.Commands.Branding
+{
+    [Cmdlet(VerbsCommon.Set, "PnPBrandCenterFont")]
+    [OutputType(typeof(void))]
+    public class SetBrandCenterFont : PnPWebCmdlet
+    {
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+        public BrandCenterFontPipeBind Identity { get; set; }
+
+        [Parameter(Mandatory = false)]
+        public Store Store { get; set; } = Store.All;
+
+        protected override void ExecuteCmdlet()
+        {
+            CurrentWeb.EnsureProperty(w => w.Url);
+
+            LogDebug("Trying to retrieve the font with the provided identity from the Brand Center");
+            var font = Identity.GetFont(this, ClientContext, Connection, CurrentWeb.Url, Store) ?? throw new PSArgumentException($"The font with the provided identity was not found in the Brand Center. Please check the identity and try again.", nameof(Identity));
+
+            if (font.IsValid.HasValue && font.IsValid.Value == false)
+            {
+                LogWarning($"The font with identity {font.Id} titled '{font.Title}' is not valid. Will try to apply it anyway.");
+            }
+
+            var url = $"{BrandCenterUtility.GetStoreUrlByStoreType(font.Store, CurrentWeb.Url)}/GetById('{font.Id}')/Apply";
+            LogDebug($"Applying font by making a POST call to {url}");
+            RestHelper.Post(Connection.HttpClient, url, ClientContext);
+        }
+    }
+}

--- a/src/Commands/Model/SharePoint/BrandCenter/Font.cs
+++ b/src/Commands/Model/SharePoint/BrandCenter/Font.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace PnP.PowerShell.Commands.Model.SharePoint.BrandCenter
+{
+    /// <summary>
+    /// Represents a font in the Brand Center
+    /// </summary>
+    public class Font
+    {
+        /// <summary>
+        /// Unique identifier of the font
+        /// </summary>
+        [JsonPropertyName("ID")]
+        public Guid? Id { get; set; }
+        /// <summary>
+        /// Name of the font
+        /// </summary>
+        [JsonPropertyName("Title")]
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Defines where the font is stored
+        /// </summary>
+        [JsonPropertyName("Store")]
+        public Store Store { get; set; }
+
+        /// <summary>
+        /// The JSON definition of the font choices
+        /// </summary>
+        [JsonPropertyName("PackageJson")]
+        public string PackageJson { get; set; }
+
+        /// <summary>
+        /// Indication if the font package is valid
+        /// </summary>
+        [JsonPropertyName("IsValid")]
+        public bool? IsValid { get; set; }
+
+        /// <summary>
+        /// Indication if the font package is hidden
+        /// </summary>
+        [JsonPropertyName("IsHidden")]
+        public bool? IsHidden { get; set; }
+    }
+}

--- a/src/Commands/Model/SharePoint/BrandCenter/Store.cs
+++ b/src/Commands/Model/SharePoint/BrandCenter/Store.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace PnP.PowerShell.Commands.Model.SharePoint.BrandCenter
+{
+    /// <summary>
+    /// Contains the types of stores where fonts can reside in the Brand Center
+    /// </summary>
+    public enum Store
+    {
+        /// <summary>
+        /// Tenant Brand Center
+        /// </summary>
+        Tenant = 0,
+
+        /// <summary>
+        /// Provided by Microsoft
+        /// </summary>
+        OutOfBox = 1,
+
+        /// <summary>
+        /// Site collection Brand Center
+        /// </summary>
+        Site = 2,
+
+        /// <summary>
+        /// Indicates that any font should be retrieved, regardless of the store
+        /// </summary>
+        All = 99
+    }
+}

--- a/src/Commands/Utilities/BrandCenterUtility.cs
+++ b/src/Commands/Utilities/BrandCenterUtility.cs
@@ -1,0 +1,154 @@
+using Microsoft.SharePoint.Client;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Model.SharePoint.BrandCenter;
+using PnP.PowerShell.Commands.Utilities.REST;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+
+namespace PnP.PowerShell.Commands.Utilities
+{
+    /// <summary>
+    /// Utilities for working with the Brand Center
+    /// </summary>
+    internal static class BrandCenterUtility
+    {
+        /// <summary>
+        /// Retrieves a font from the Brand Center based on its name and optionally store type.
+        /// </summary>
+        /// <param name="cmdlet">Cmdlet for which this runs, used for logging</param>
+        /// <param name="title">Title of the font to retrieve</param>
+        /// <param name="webUrl">Url to use to check the site collection Brand Center</param>
+        /// <param name="store">The store to check for the font. When NULL, it will check all stores.</param>
+        /// <param name="clientContext">ClientContext to use to communicate with SharePoint Online</param>
+        /// <param name="connection">Connection to use to communicate with SharePoint Online</param>
+        /// <returns>The font with the provided identity or NULL if no font found with the provided identity</returns>
+        public static Font GetFontByTitle(BasePSCmdlet cmdlet, ClientContext clientContext, PnPConnection connection, string title, string webUrl, Store store = Store.All)
+        {
+            if (store == Store.All)
+            {
+                return GetFontByTitle(cmdlet, clientContext, connection, title, webUrl, Store.Site) ??
+                       GetFontByTitle(cmdlet, clientContext, connection, title, webUrl, Store.Tenant) ??
+                       GetFontByTitle(cmdlet, clientContext, connection, title, webUrl, Store.OutOfBox);
+            }
+
+            var url = $"{GetStoreUrlByStoreType(store, webUrl)}/GetByTitle('{title}')";
+            cmdlet?.LogDebug($"Making a GET request to {url} to retrieve {store} font with title {title}.");
+            try
+            {
+                var font = RestHelper.Get<Font>(connection.HttpClient, url, clientContext);
+
+                if (font != null)
+                {
+                    return font;
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                cmdlet?.LogDebug($"Font with title {title} not found in the {store} Brand Center: {ex.Message}");
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Retrieves a font from the Brand Center based on its identity and optionally store type.
+        /// </summary>
+        /// <param name="cmdlet">Cmdlet for which this runs, used for logging</param>
+        /// <param name="identity">Id of the font to retrieve</param>
+        /// <param name="webUrl">Url to use to check the site collection Brand Center</param>
+        /// <param name="store">The store to check for the font. When NULL, it will check all stores.</param>
+        /// <param name="clientContext">ClientContext to use to communicate with SharePoint Online</param>
+        /// <param name="connection">Connection to use to communicate with SharePoint Online</param>
+        /// <returns>The font with the provided identity or NULL if no font found with the provided identity</returns>
+        public static Font GetFontById(BasePSCmdlet cmdlet, ClientContext clientContext, PnPConnection connection, Guid identity, string webUrl, Store store = Store.All)
+        {
+            if (store == Store.All)
+            {
+                return GetFontById(cmdlet, clientContext, connection, identity, webUrl, Store.Site) ??
+                       GetFontById(cmdlet, clientContext, connection, identity, webUrl, Store.Tenant) ??
+                       GetFontById(cmdlet, clientContext, connection, identity, webUrl, Store.OutOfBox);
+            }
+
+            var url = $"{GetStoreUrlByStoreType(store, webUrl)}/GetById('{identity}')";
+            cmdlet?.LogDebug($"Making a GET request to {url} to retrieve {store} font with identity {identity}.");
+            try
+            {
+                var font = RestHelper.Get<Font>(connection.HttpClient, url, clientContext);
+
+                if (font != null)
+                {
+                    return font;
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                cmdlet?.LogDebug($"Font with {identity} not found in the {store} Brand Center: {ex.Message}");
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Retrieves fonts from the Brand Center optionally based on the store type.
+        /// </summary>
+        /// <param name="cmdlet">Cmdlet for which this runs, used for logging</param>
+        /// <param name="webUrl">Url to use to check the site collection Brand Center</param>
+        /// <param name="store">The store to check for the font. When NULL, it will check all stores.</param>
+        /// <param name="clientContext">ClientContext to use to communicate with SharePoint Online</param>
+        /// <param name="connection">Connection to use to communicate with SharePoint Online</param>
+        /// <returns>The available fonts</returns>
+        public static List<Font> GetFonts(BasePSCmdlet cmdlet, ClientContext clientContext, PnPConnection connection, string webUrl, Store store = Store.All)
+        {
+
+            if (store == Store.All)
+            {
+                var allStoresFonts = new List<Font>();
+                allStoresFonts.AddRange(GetFonts(cmdlet, clientContext, connection, webUrl, Store.Site));
+                allStoresFonts.AddRange(GetFonts(cmdlet, clientContext, connection, webUrl, Store.Tenant));
+                allStoresFonts.AddRange(GetFonts(cmdlet, clientContext, connection, webUrl, Store.OutOfBox));
+                return allStoresFonts;
+            }
+
+            var url = GetStoreUrlByStoreType(store, webUrl);
+            cmdlet?.LogDebug($"Making a GET request to {url} to retrieve {store} fonts.");
+            var fonts = RestHelper.Get<RestResultCollection<Font>>(connection.HttpClient, url, clientContext);
+            return fonts.Items.ToList();
+        }
+
+        /// <summary>
+        /// Returns the URL to the Brand Center based on the store type
+        /// </summary>
+        /// <param name="store">Brand Center store to connect to</param>
+        /// <param name="webUrl">Base URL to connect to</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if an invalid store type has been provided</exception>
+        public static string GetStoreUrlByStoreType(Store store, string webUrl)
+        {
+            return store switch
+            {
+                Store.Tenant => $"{webUrl}/_api/FontPackages",
+                Store.Site => $"{webUrl}/_api/SiteFontPackages",
+                Store.OutOfBox => $"{webUrl}/_api/outofboxfontpackages",
+                _ => throw new ArgumentOutOfRangeException(nameof(store), store, null)
+            };
+        }
+
+        /// <summary>
+        /// Retrieves the Brand Center configuration for the tenant
+        /// </summary>
+        /// <param name="cmdlet">Cmdlet for which this runs, used for logging</param>
+        /// <param name="clientContext">ClientContext to use to communicate with SharePoint Online</param>
+        /// <returns>BrandCenterConfiguration instance</returns>
+        public static BrandCenterConfiguration GetBrandCenterConfiguration(BasePSCmdlet cmdlet, ClientContext clientContext)
+        {
+            cmdlet?.LogDebug("Retrieving the Brand Center configuration");
+            var brandCenter = new BrandCenter(clientContext);
+            var config = brandCenter.CurrentBrandingConfiguration();
+            clientContext.ExecuteQueryRetry();
+
+            return config.Value;
+        }
+    }
+}

--- a/src/Commands/Utilities/REST/RestHelper.cs
+++ b/src/Commands/Utilities/REST/RestHelper.cs
@@ -1,4 +1,5 @@
 using Microsoft.SharePoint.Client;
+using PnP.Framework.Diagnostics;
 using System;
 using System.Collections.Generic;
 using System.Linq;


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
- Added `Get-PnPBrandCenterConfig` to retrieve the configuration of the Brand Center on the tenant
- Added `Get-PnPBrandCenterFont` to retrieve the available fonts from the various Brand Centers
- Added `Set-PnPBrandCenterFont` to apply the specified font from the Brand Center to the current site
- Added `Add-PnPBrandCenterFont` to upload a font to the tenant Brand Center