### PR TITLE
Added autocompleter to Brand Center Font cmdlets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `Copy-PnPPage`, `Move-PnPPage` and `Get-PnPPageCopyProgress` cmdlets to allow for copying and moving site pages between sites [#4806](https://github.com/pnp/powershell/pull/4806)
 - Added `Get-PnPBrandCenterConfig` to retrieve the configuration of the Brand Center on the tenant [#4830](https://github.com/pnp/powershell/pull/4830)
 - Added `Get-PnPBrandCenterFont` to retrieve the available fonts from the various Brand Centers [#4830](https://github.com/pnp/powershell/pull/4830)
-- Added `Set-PnPBrandCenterFont` to apply the specified font from the Brand Center to the current site [#4830](https://github.com/pnp/powershell/pull/4830)
+- Added `Use-PnPBrandCenterFont` to apply the specified font from the Brand Center to the current site [#4830](https://github.com/pnp/powershell/pull/4830)
 - Added `Add-PnPBrandCenterFont` to upload a font to the tenant Brand Center [#4830](https://github.com/pnp/powershell/pull/4830)
 
 ### Changed

--- a/documentation/Add-PnPBrandCenterFont.md
+++ b/documentation/Add-PnPBrandCenterFont.md
@@ -21,6 +21,9 @@ Add-PnPBrandCenterFont -Path <String> [-Visible <Boolean>] [-Connection <PnPConn
 ## DESCRIPTION
 This cmdlet allows a font to be uploaded to the tenant Brand Center. The font will be available for use in the tenant and site collection Brand Center.
 
+Use [Use-PnPBrandCenterFont](Use-PnPBrandCenterFont.md) to apply the font to the current site.
+Use [Get-PnPBrandCenterFont](Get-PnPBrandCenterFont.md) to retrieve the available fonts.
+
 ## EXAMPLES
 
 ### EXAMPLE 1

--- a/documentation/Use-PnPBrandCenterFont.md
+++ b/documentation/Use-PnPBrandCenterFont.md
@@ -2,12 +2,12 @@
 Module Name: PnP.PowerShell
 schema: 2.0.0
 applicable: SharePoint Online
-online version: https://pnp.github.io/powershell/cmdlets/Set-PnPBrandCenterFont.html
+online version: https://pnp.github.io/powershell/cmdlets/Use-PnPBrandCenterFont.html
 external help file: PnP.PowerShell.dll-Help.xml
-title: Set-PnPBrandCenterFont
+title: Use-PnPBrandCenterFont
 ---
   
-# Set-PnPBrandCenterFont
+# Use-PnPBrandCenterFont
 
 ## SYNOPSIS
 Applies the specified font from the Brand Center to the current site.
@@ -15,7 +15,7 @@ Applies the specified font from the Brand Center to the current site.
 ## SYNTAX
 
 ```powershell
-Set-PnPBrandCenterFont -Identity <BrandCenterFontPipeBind> [-Store <Tenant|OutOfBox|Site|All>] [-Connection <PnPConnection>]
+Use-PnPBrandCenterFont -Identity <BrandCenterFontPipeBind> [-Store <Tenant|OutOfBox|Site|All>] [-Connection <PnPConnection>]
 ```
 
 ## DESCRIPTION
@@ -25,14 +25,14 @@ Applies the specified font from the Brand Center to the current site.
 
 ### EXAMPLE 1
 ```powershell
-Set-PnPBrandCenterFont -Identity "2812cbd8-7176-4e45-8911-6a063f89a1f1"
+Use-PnPBrandCenterFont -Identity "2812cbd8-7176-4e45-8911-6a063f89a1f1"
 ```
 
 Looks up and applies the font with the identity "2812cbd8-7176-4e45-8911-6a063f89a1f1" from any of the Brand Centers to the current site
 
 ### EXAMPLE 2
 ```powershell
-Set-PnPBrandCenterFont -Identity "My awesome font" -Store Tenant
+Use-PnPBrandCenterFont -Identity "My awesome font" -Store Tenant
 ```
 
 Looks up and applies the font with the title "My awesome font" from the tenant Brand Center

--- a/src/Commands/Base/Completers/BrandCenterFontCompleter.cs
+++ b/src/Commands/Base/Completers/BrandCenterFontCompleter.cs
@@ -1,0 +1,20 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+using Microsoft.SharePoint.Client;
+using PnP.PowerShell.Commands.Utilities;
+
+namespace PnP.PowerShell.Commands.Base.Completers
+{
+    public sealed class BrandCenterFontCompleter : PnPArgumentCompleter
+    {
+        protected override IEnumerable<CompletionResult> GetArguments(string commandName, string parameterName, string wordToComplete, CommandAst commandAst, IDictionary fakeBoundParameters)
+        {
+            ClientContext.Web.EnsureProperty(w => w.Url);
+            var fonts = BrandCenterUtility.GetFonts(null, ClientContext, ClientContext.Web.Url);
+            return fonts.Select(font => new CompletionResult(font.Title)).OrderBy(ct => ct.CompletionText);
+        }
+    }
+}

--- a/src/Commands/Base/Completers/PnPArgumentCompleter.cs
+++ b/src/Commands/Base/Completers/PnPArgumentCompleter.cs
@@ -1,44 +1,43 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Management.Automation;
 using System.Management.Automation.Language;
 using System.Threading.Tasks;
-using Microsoft.SharePoint.Client;
-using PnP.Core.Services;
 using PnP.PowerShell.Commands.Base;
 using PnP.PowerShell.Commands.Extensions;
 
 public abstract class PnPArgumentCompleter : IArgumentCompleter
 {
-    public Microsoft.SharePoint.Client.ClientContext ClientContext => PnPConnection.Current.Context;
+    public static Microsoft.SharePoint.Client.ClientContext ClientContext => PnPConnection.Current.Context;
 
-    public PnP.Core.Services.PnPContext PnPContext => PnPConnection.Current.PnPContext;
+    public static PnP.Core.Services.PnPContext PnPContext => PnPConnection.Current.PnPContext;
 
     private const int Timeout = 2000;
+    
     public IEnumerable<CompletionResult> CompleteArgument(string commandName, string parameterName, string wordToComplete, CommandAst commandAst, IDictionary fakeBoundParameters)
     {
         var quoteChar = '"';
-        if(wordToComplete.StartsWith('\''))
+        if (wordToComplete.StartsWith('\''))
         {
             quoteChar = '\'';
         }
         wordToComplete = wordToComplete.Trim(['"', '\'']);
         var task = Task.Run(() => GetArguments(commandName, parameterName, wordToComplete, commandAst, fakeBoundParameters));
-        
+
         var results = task.TimeoutAfter(TimeSpan.FromMilliseconds(GetTimeOut())).GetAwaiter().GetResult();
-        foreach(var result in results)
+        foreach (var result in results)
         {
             var completionText = result.CompletionText;
-            if(quoteChar == '"')
+            if (quoteChar == '"')
             {
-                  completionText = completionText.Replace("\"","`\"");
-            } else if(quoteChar == '\'')
-            {
-                completionText = completionText.Replace("'","`'");
+                completionText = completionText.Replace("\"", "`\"");
             }
-            yield return new CompletionResult($"{quoteChar}{completionText}{quoteChar}",result.ListItemText,result.ResultType,result.ToolTip);
+            else if (quoteChar == '\'')
+            {
+                completionText = completionText.Replace("'", "`'");
+            }
+            yield return new CompletionResult($"{quoteChar}{completionText}{quoteChar}", result.ListItemText, result.ResultType, result.ToolTip);
         }
     }
 

--- a/src/Commands/Base/PipeBinds/BrandCenterFontPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/BrandCenterFontPipeBind.cs
@@ -42,12 +42,11 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
         /// </summary>
         /// <param name="cmdlet">The cmdlet instance to use to retrieve the Font in this pipe bind</param>
         /// <param name="clientContext">ClientContext to use to communicate with SharePoint Online</param>
-        /// <param name="connection">Connection to use to communicate with SharePoint Online</param>
         /// <param name="webUrl">Url to use to check the site collection Brand Center</param>
         /// <param name="store">The store to check for the font. When NULL, it will check all stores.</param>
         /// <exception cref="Exception">Thrown when the ContainerProperties cannot be retrieved</exception>
         /// <returns>Font</returns>
-        public Font GetFont(BasePSCmdlet cmdlet, ClientContext clientContext, PnPConnection connection, string webUrl, Store store = Store.All)
+        public Font GetFont(BasePSCmdlet cmdlet, ClientContext clientContext, string webUrl, Store store = Store.All)
         {
             if (_font != null)
             {
@@ -55,12 +54,12 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             }
             else if (_id.HasValue)
             {
-                _font = BrandCenterUtility.GetFontById(cmdlet, clientContext, connection, _id.Value, webUrl, store);
+                _font = BrandCenterUtility.GetFontById(cmdlet, clientContext, _id.Value, webUrl, store);
                 return _font;
             }
             else if (!string.IsNullOrEmpty(_title))
             {
-                _font = BrandCenterUtility.GetFontByTitle(cmdlet, clientContext, connection, _title, webUrl, store);
+                _font = BrandCenterUtility.GetFontByTitle(cmdlet, clientContext, _title, webUrl, store);
                 return _font;
             }            
             return null;

--- a/src/Commands/Branding/GetBrandCenterFont.cs
+++ b/src/Commands/Branding/GetBrandCenterFont.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Management.Automation;
 using Microsoft.SharePoint.Client;
+using PnP.PowerShell.Commands.Base.Completers;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 using PnP.PowerShell.Commands.Model.SharePoint.BrandCenter;
 using PnP.PowerShell.Commands.Utilities;
@@ -16,6 +17,7 @@ namespace PnP.PowerShell.Commands.Branding
         private const string ParameterSet_ALL = "All";
 
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = ParameterSet_SINGLE)]
+        [ArgumentCompleter(typeof(BrandCenterFontCompleter))]
         public BrandCenterFontPipeBind Identity { get; set; }
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_SINGLE)]
@@ -28,12 +30,12 @@ namespace PnP.PowerShell.Commands.Branding
 
             if (ParameterSpecified(nameof(Identity)))
             {
-                var font = Identity.GetFont(this, ClientContext, Connection, CurrentWeb.Url, Store);
+                var font = Identity.GetFont(this, ClientContext, CurrentWeb.Url, Store);
                 WriteObject(font, false);
             }
             else
             {
-                WriteObject(BrandCenterUtility.GetFonts(this, ClientContext, Connection, CurrentWeb.Url, Store), true);
+                WriteObject(BrandCenterUtility.GetFonts(this, ClientContext, CurrentWeb.Url, Store), true);
             }
         }
     }

--- a/src/Commands/Branding/SetBrandCenterFont.cs
+++ b/src/Commands/Branding/SetBrandCenterFont.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections;
+using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using PnP.PowerShell.Commands.Base.Completers;
+using PnP.PowerShell.Commands.Base.PipeBinds;
+using PnP.PowerShell.Commands.Utilities;
+
+namespace PnP.PowerShell.Commands.Files
+{
+    [Cmdlet(VerbsCommon.Set, "PnPBrandCenterFont")]
+    [OutputType(typeof(void))]
+    public class SetBrandCenterFont : PnPWebCmdlet
+    {
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+        [ArgumentCompleter(typeof(BrandCenterFontCompleter))]
+        public BrandCenterFontPipeBind Identity { get; set; }
+
+        [Parameter(Mandatory = true)]
+        public bool Visible;
+
+        protected override void ExecuteCmdlet()
+        {
+            var webUrl = CurrentWeb.EnsureProperty(w => w.Url);
+
+            var brandCenterConfig = BrandCenterUtility.GetBrandCenterConfiguration(this, ClientContext);
+            if (brandCenterConfig == null || !brandCenterConfig.IsBrandCenterSiteFeatureEnabled || string.IsNullOrEmpty(brandCenterConfig.SiteUrl))
+            {
+                throw new PSArgumentException("Brand Center is not enabled for this tenant");
+            }
+
+            LogDebug($"Connecting to the Brand Center site at {brandCenterConfig.SiteUrl}");
+            using var brandCenterContext = Connection.CloneContext(brandCenterConfig.SiteUrl);
+            var font = Identity.GetFont(this, ClientContext, webUrl);
+            
+            LogDebug($"Retrieving the Brand Center font library with ID {brandCenterConfig.BrandFontLibraryId}");
+            var brandCenterFontLibrary = brandCenterContext.Web.GetListById(brandCenterConfig.BrandFontLibraryId);
+            brandCenterContext.Load(brandCenterFontLibrary, l => l.RootFolder);
+            brandCenterContext.ExecuteQueryRetry();
+
+            LogDebug($"Uploading the font to the Brand Center font library root folder at {brandCenterFontLibrary.RootFolder.ServerRelativeUrl}");
+            var file = brandCenterFontLibrary.RootFolder.UploadFile(System.IO.Path.GetFileName(Path), Path, true);
+
+            if (ParameterSpecified(nameof(Visible)) && Visible.HasValue)
+            {
+                LogDebug($"Setting the font visibility to {Visible.Value}");
+                ListItemHelper.SetFieldValues(file.ListItemAllFields, new Hashtable { { "_SPFontVisible", Visible.Value ? "True" : "False" } }, this);
+                file.ListItemAllFields.UpdateOverwriteVersion();
+            }
+
+            brandCenterContext.Load(file);
+            brandCenterContext.ExecuteQueryRetry();
+
+            LogDebug("Font uploaded successfully");
+            WriteObject(file);
+        }
+    }
+}

--- a/src/Commands/Branding/SetBrandCenterFont.cs
+++ b/src/Commands/Branding/SetBrandCenterFont.cs
@@ -1,5 +1,6 @@
 ﻿using System.Management.Automation;
 using Microsoft.SharePoint.Client;
+using PnP.PowerShell.Commands.Base.Completers;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 using PnP.PowerShell.Commands.Model.SharePoint.BrandCenter;
 using PnP.PowerShell.Commands.Utilities;
@@ -12,6 +13,7 @@ namespace PnP.PowerShell.Commands.Branding
     public class SetBrandCenterFont : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+        [ArgumentCompleter(typeof(BrandCenterFontCompleter))]
         public BrandCenterFontPipeBind Identity { get; set; }
 
         [Parameter(Mandatory = false)]
@@ -22,7 +24,7 @@ namespace PnP.PowerShell.Commands.Branding
             CurrentWeb.EnsureProperty(w => w.Url);
 
             LogDebug("Trying to retrieve the font with the provided identity from the Brand Center");
-            var font = Identity.GetFont(this, ClientContext, Connection, CurrentWeb.Url, Store) ?? throw new PSArgumentException($"The font with the provided identity was not found in the Brand Center. Please check the identity and try again.", nameof(Identity));
+            var font = Identity.GetFont(this, ClientContext, CurrentWeb.Url, Store) ?? throw new PSArgumentException($"The font with the provided identity was not found in the Brand Center. Please check the identity and try again.", nameof(Identity));
 
             if (font.IsValid.HasValue && font.IsValid.Value == false)
             {

--- a/src/Commands/Branding/UseBrandCenterFont.cs
+++ b/src/Commands/Branding/UseBrandCenterFont.cs
@@ -8,9 +8,9 @@ using PnP.PowerShell.Commands.Utilities.REST;
 
 namespace PnP.PowerShell.Commands.Branding
 {
-    [Cmdlet(VerbsCommon.Set, "PnPBrandCenterFont")]
+    [Cmdlet(VerbsOther.Use, "PnPBrandCenterFont")]
     [OutputType(typeof(void))]
-    public class SetBrandCenterFont : PnPWebCmdlet
+    public class UseBrandCenterFont : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
         [ArgumentCompleter(typeof(BrandCenterFontCompleter))]

--- a/src/Commands/Utilities/BrandCenterUtility.cs
+++ b/src/Commands/Utilities/BrandCenterUtility.cs
@@ -22,22 +22,21 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="webUrl">Url to use to check the site collection Brand Center</param>
         /// <param name="store">The store to check for the font. When NULL, it will check all stores.</param>
         /// <param name="clientContext">ClientContext to use to communicate with SharePoint Online</param>
-        /// <param name="connection">Connection to use to communicate with SharePoint Online</param>
         /// <returns>The font with the provided identity or NULL if no font found with the provided identity</returns>
-        public static Font GetFontByTitle(BasePSCmdlet cmdlet, ClientContext clientContext, PnPConnection connection, string title, string webUrl, Store store = Store.All)
+        public static Font GetFontByTitle(BasePSCmdlet cmdlet, ClientContext clientContext, string title, string webUrl, Store store = Store.All)
         {
             if (store == Store.All)
             {
-                return GetFontByTitle(cmdlet, clientContext, connection, title, webUrl, Store.Site) ??
-                       GetFontByTitle(cmdlet, clientContext, connection, title, webUrl, Store.Tenant) ??
-                       GetFontByTitle(cmdlet, clientContext, connection, title, webUrl, Store.OutOfBox);
+                return GetFontByTitle(cmdlet, clientContext, title, webUrl, Store.Site) ??
+                       GetFontByTitle(cmdlet, clientContext, title, webUrl, Store.Tenant) ??
+                       GetFontByTitle(cmdlet, clientContext, title, webUrl, Store.OutOfBox);
             }
 
             var url = $"{GetStoreUrlByStoreType(store, webUrl)}/GetByTitle('{title}')";
             cmdlet?.LogDebug($"Making a GET request to {url} to retrieve {store} font with title {title}.");
             try
             {
-                var font = RestHelper.Get<Font>(connection.HttpClient, url, clientContext);
+                var font = RestHelper.Get<Font>(Framework.Http.PnPHttpClient.Instance.GetHttpClient(), url, clientContext);
 
                 if (font != null)
                 {
@@ -60,22 +59,21 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="webUrl">Url to use to check the site collection Brand Center</param>
         /// <param name="store">The store to check for the font. When NULL, it will check all stores.</param>
         /// <param name="clientContext">ClientContext to use to communicate with SharePoint Online</param>
-        /// <param name="connection">Connection to use to communicate with SharePoint Online</param>
         /// <returns>The font with the provided identity or NULL if no font found with the provided identity</returns>
-        public static Font GetFontById(BasePSCmdlet cmdlet, ClientContext clientContext, PnPConnection connection, Guid identity, string webUrl, Store store = Store.All)
+        public static Font GetFontById(BasePSCmdlet cmdlet, ClientContext clientContext, Guid identity, string webUrl, Store store = Store.All)
         {
             if (store == Store.All)
             {
-                return GetFontById(cmdlet, clientContext, connection, identity, webUrl, Store.Site) ??
-                       GetFontById(cmdlet, clientContext, connection, identity, webUrl, Store.Tenant) ??
-                       GetFontById(cmdlet, clientContext, connection, identity, webUrl, Store.OutOfBox);
+                return GetFontById(cmdlet, clientContext, identity, webUrl, Store.Site) ??
+                       GetFontById(cmdlet, clientContext, identity, webUrl, Store.Tenant) ??
+                       GetFontById(cmdlet, clientContext, identity, webUrl, Store.OutOfBox);
             }
 
             var url = $"{GetStoreUrlByStoreType(store, webUrl)}/GetById('{identity}')";
             cmdlet?.LogDebug($"Making a GET request to {url} to retrieve {store} font with identity {identity}.");
             try
             {
-                var font = RestHelper.Get<Font>(connection.HttpClient, url, clientContext);
+                var font = RestHelper.Get<Font>(Framework.Http.PnPHttpClient.Instance.GetHttpClient(), url, clientContext);
 
                 if (font != null)
                 {
@@ -97,23 +95,21 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="webUrl">Url to use to check the site collection Brand Center</param>
         /// <param name="store">The store to check for the font. When NULL, it will check all stores.</param>
         /// <param name="clientContext">ClientContext to use to communicate with SharePoint Online</param>
-        /// <param name="connection">Connection to use to communicate with SharePoint Online</param>
         /// <returns>The available fonts</returns>
-        public static List<Font> GetFonts(BasePSCmdlet cmdlet, ClientContext clientContext, PnPConnection connection, string webUrl, Store store = Store.All)
+        public static List<Font> GetFonts(BasePSCmdlet cmdlet, ClientContext clientContext, string webUrl, Store store = Store.All)
         {
-
             if (store == Store.All)
             {
                 var allStoresFonts = new List<Font>();
-                allStoresFonts.AddRange(GetFonts(cmdlet, clientContext, connection, webUrl, Store.Site));
-                allStoresFonts.AddRange(GetFonts(cmdlet, clientContext, connection, webUrl, Store.Tenant));
-                allStoresFonts.AddRange(GetFonts(cmdlet, clientContext, connection, webUrl, Store.OutOfBox));
+                allStoresFonts.AddRange(GetFonts(cmdlet, clientContext, webUrl, Store.Site));
+                allStoresFonts.AddRange(GetFonts(cmdlet, clientContext, webUrl, Store.Tenant));
+                allStoresFonts.AddRange(GetFonts(cmdlet, clientContext, webUrl, Store.OutOfBox));
                 return allStoresFonts;
             }
 
             var url = GetStoreUrlByStoreType(store, webUrl);
             cmdlet?.LogDebug($"Making a GET request to {url} to retrieve {store} fonts.");
-            var fonts = RestHelper.Get<RestResultCollection<Font>>(connection.HttpClient, url, clientContext);
+            var fonts = RestHelper.Get<RestResultCollection<Font>>(Framework.Http.PnPHttpClient.Instance.GetHttpClient(), url, clientContext);
             return fonts.Items.ToList();
         }
 


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Added autocompleter to Brand Center Font cmdlets
Renamed Set-PnPBrandCenterFont to Use-PnPBrandCenterFont to allow for a potential future cmdlet that allows updating an existing Brand Center Font