### PR TITLE
Renaming Brand Center Font to FontPackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,8 +65,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added the ability to `Get-PnPPage` to return all site pages in the site by omitting the `-Identity` parameter [#4805](https://github.com/pnp/powershell/pull/4805)
 - Added `Copy-PnPPage`, `Move-PnPPage` and `Get-PnPPageCopyProgress` cmdlets to allow for copying and moving site pages between sites [#4806](https://github.com/pnp/powershell/pull/4806)
 - Added `Get-PnPBrandCenterConfig` to retrieve the configuration of the Brand Center on the tenant [#4830](https://github.com/pnp/powershell/pull/4830)
-- Added `Get-PnPBrandCenterFont` to retrieve the available fonts from the various Brand Centers [#4830](https://github.com/pnp/powershell/pull/4830)
-- Added `Use-PnPBrandCenterFont` to apply the specified font from the Brand Center to the current site [#4830](https://github.com/pnp/powershell/pull/4830)
+- Added `Get-PnPBrandCenterFontPackage` to retrieve the available font packages from the various Brand Centers [#4830](https://github.com/pnp/powershell/pull/4830)
+- Added `Use-PnPBrandCenterFontPackage` to apply the specified font package from the Brand Center to the current site [#4830](https://github.com/pnp/powershell/pull/4830)
 - Added `Add-PnPBrandCenterFont` to upload a font to the tenant Brand Center [#4830](https://github.com/pnp/powershell/pull/4830)
 
 ### Changed

--- a/documentation/Get-PnPBrandCenterFontPackage.md
+++ b/documentation/Get-PnPBrandCenterFontPackage.md
@@ -2,40 +2,60 @@
 Module Name: PnP.PowerShell
 schema: 2.0.0
 applicable: SharePoint Online
-online version: https://pnp.github.io/powershell/cmdlets/Use-PnPBrandCenterFont.html
+online version: https://pnp.github.io/powershell/cmdlets/Get-PnPBrandCenterFontPackage.html
 external help file: PnP.PowerShell.dll-Help.xml
-title: Use-PnPBrandCenterFont
+title: Get-PnPBrandCenterFontPackage
 ---
   
-# Use-PnPBrandCenterFont
+# Get-PnPBrandCenterFontPackage
 
 ## SYNOPSIS
-Applies the specified font from the Brand Center to the current site.
+Returns the available fonts configured throught heBrand Center
 
 ## SYNTAX
 
+### All
 ```powershell
-Use-PnPBrandCenterFont -Identity <BrandCenterFontPipeBind> [-Store <Tenant|OutOfBox|Site|All>] [-Connection <PnPConnection>]
+Get-PnPBrandCenterFontPackage [-Store <Tenant|OutOfBox|Site|All>] [-Connection <PnPConnection>]
+```
+
+### Single
+```powershell
+Get-PnPBrandCenterFontPackage -Identity <BrandCenterFontPipeBind> [-Store <Tenant|OutOfBox|Site|All>] [-Connection <PnPConnection>]
 ```
 
 ## DESCRIPTION
-Applies the specified font from the Brand Center to the current site.
+Allows retrieval of the available fonts from the various Brand Centers.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```powershell
-Use-PnPBrandCenterFont -Identity "2812cbd8-7176-4e45-8911-6a063f89a1f1"
+Get-PnPBrandCenterFontPackage
 ```
 
-Looks up and applies the font with the identity "2812cbd8-7176-4e45-8911-6a063f89a1f1" from any of the Brand Centers to the current site
+Returns all the available fonts
 
 ### EXAMPLE 2
 ```powershell
-Use-PnPBrandCenterFont -Identity "My awesome font" -Store Tenant
+Get-PnPBrandCenterFontPackage -Store Site
 ```
 
-Looks up and applies the font with the title "My awesome font" from the tenant Brand Center
+Returns the available fonts from the site collection Brand Center
+
+### EXAMPLE 3
+```powershell
+Get-PnPBrandCenterFontPackage -Identity "My awesome font"
+```
+
+Looks up and returns the font with the name "My awesome font" from any of the Brand Centers
+
+### EXAMPLE 4
+```powershell
+Get-PnPBrandCenterFontPackage -Identity "2812cbd8-7176-4e45-8911-6a063f89a1f1"
+```
+
+Looks up and returns the font with the Identity "2812cbd8-7176-4e45-8911-6a063f89a1f1" from any of the Brand Centers
 
 ## PARAMETERS
 
@@ -54,11 +74,11 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Unique identifier of the font to be applied. This can be its guid, name or a BrandCenterFont object.
+Unique identifier of the font to be retrieved. This can be its guid, name or a BrandCenterFont object. If not specified, all the available fonts will be returned.
 
 ```yaml
 Type: BrandCenterFontPipeBind
-Parameter Sets: (All)
+Parameter Sets: Single
 
 Required: True
 Position: Named
@@ -68,7 +88,7 @@ Accept wildcard characters: False
 ```
 
 ### -Store
-Indicates the source of the fonts to be looked in to try to locate the font to apply. The following values are available:
+Indicates the source of the fonts to be retrieved. The following values are available:
 - Tenant: The fonts configured in the tenant Brand Center
 - Site: The fonts configured in the site collection Brand Center
 - OutOfBox: The out of box fonts available in the tenant

--- a/documentation/Use-PnPBrandCenterFontPackage.md
+++ b/documentation/Use-PnPBrandCenterFontPackage.md
@@ -2,60 +2,40 @@
 Module Name: PnP.PowerShell
 schema: 2.0.0
 applicable: SharePoint Online
-online version: https://pnp.github.io/powershell/cmdlets/Get-PnPBrandCenterFont.html
+online version: https://pnp.github.io/powershell/cmdlets/Use-PnPBrandCenterFontPackage.html
 external help file: PnP.PowerShell.dll-Help.xml
-title: Get-PnPBrandCenterFont
+title: Use-PnPBrandCenterFontPackage
 ---
   
-# Get-PnPBrandCenterFont
+# Use-PnPBrandCenterFontPackage
 
 ## SYNOPSIS
-Returns the available fonts configured throught heBrand Center
+Applies the specified font from the Brand Center to the current site.
 
 ## SYNTAX
 
-### All
 ```powershell
-Get-PnPBrandCenterFont [-Store <Tenant|OutOfBox|Site|All>] [-Connection <PnPConnection>]
-```
-
-### Single
-```powershell
-Get-PnPBrandCenterFont -Identity <BrandCenterFontPipeBind> [-Store <Tenant|OutOfBox|Site|All>] [-Connection <PnPConnection>]
+Use-PnPBrandCenterFontPackage -Identity <BrandCenterFontPipeBind> [-Store <Tenant|OutOfBox|Site|All>] [-Connection <PnPConnection>]
 ```
 
 ## DESCRIPTION
-Allows retrieval of the available fonts from the various Brand Centers.
+Applies the specified font from the Brand Center to the current site.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```powershell
-Get-PnPBrandCenterFont
+Use-PnPBrandCenterFontPackage -Identity "2812cbd8-7176-4e45-8911-6a063f89a1f1"
 ```
 
-Returns all the available fonts
+Looks up and applies the font with the identity "2812cbd8-7176-4e45-8911-6a063f89a1f1" from any of the Brand Centers to the current site
 
 ### EXAMPLE 2
 ```powershell
-Get-PnPBrandCenterFont -Store Site
+Use-PnPBrandCenterFontPackage -Identity "My awesome font" -Store Tenant
 ```
 
-Returns the available fonts from the site collection Brand Center
-
-### EXAMPLE 3
-```powershell
-Get-PnPBrandCenterFont -Identity "My awesome font"
-```
-
-Looks up and returns the font with the name "My awesome font" from any of the Brand Centers
-
-### EXAMPLE 4
-```powershell
-Get-PnPBrandCenterFont -Identity "2812cbd8-7176-4e45-8911-6a063f89a1f1"
-```
-
-Looks up and returns the font with the Identity "2812cbd8-7176-4e45-8911-6a063f89a1f1" from any of the Brand Centers
+Looks up and applies the font with the title "My awesome font" from the tenant Brand Center
 
 ## PARAMETERS
 
@@ -74,11 +54,11 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Unique identifier of the font to be retrieved. This can be its guid, name or a BrandCenterFont object. If not specified, all the available fonts will be returned.
+Unique identifier of the font to be applied. This can be its guid, name or a BrandCenterFont object.
 
 ```yaml
 Type: BrandCenterFontPipeBind
-Parameter Sets: Single
+Parameter Sets: (All)
 
 Required: True
 Position: Named
@@ -88,7 +68,7 @@ Accept wildcard characters: False
 ```
 
 ### -Store
-Indicates the source of the fonts to be retrieved. The following values are available:
+Indicates the source of the fonts to be looked in to try to locate the font to apply. The following values are available:
 - Tenant: The fonts configured in the tenant Brand Center
 - Site: The fonts configured in the site collection Brand Center
 - OutOfBox: The out of box fonts available in the tenant

--- a/src/Commands/Base/Completers/BrandCenterFontPackageCompleter.cs
+++ b/src/Commands/Base/Completers/BrandCenterFontPackageCompleter.cs
@@ -8,12 +8,12 @@ using PnP.PowerShell.Commands.Utilities;
 
 namespace PnP.PowerShell.Commands.Base.Completers
 {
-    public sealed class BrandCenterFontCompleter : PnPArgumentCompleter
+    public sealed class BrandCenterFontPackageCompleter : PnPArgumentCompleter
     {
         protected override IEnumerable<CompletionResult> GetArguments(string commandName, string parameterName, string wordToComplete, CommandAst commandAst, IDictionary fakeBoundParameters)
         {
             ClientContext.Web.EnsureProperty(w => w.Url);
-            var fonts = BrandCenterUtility.GetFonts(null, ClientContext, ClientContext.Web.Url);
+            var fonts = BrandCenterUtility.GetFontPackages(null, ClientContext, ClientContext.Web.Url);
             return fonts.Select(font => new CompletionResult(font.Title)).OrderBy(ct => ct.CompletionText);
         }
     }

--- a/src/Commands/Base/PipeBinds/BrandCenterFontPipeBind.cs
+++ b/src/Commands/Base/PipeBinds/BrandCenterFontPipeBind.cs
@@ -54,12 +54,12 @@ namespace PnP.PowerShell.Commands.Base.PipeBinds
             }
             else if (_id.HasValue)
             {
-                _font = BrandCenterUtility.GetFontById(cmdlet, clientContext, _id.Value, webUrl, store);
+                _font = BrandCenterUtility.GetFontPackageById(cmdlet, clientContext, _id.Value, webUrl, store);
                 return _font;
             }
             else if (!string.IsNullOrEmpty(_title))
             {
-                _font = BrandCenterUtility.GetFontByTitle(cmdlet, clientContext, _title, webUrl, store);
+                _font = BrandCenterUtility.GetFontPackageByTitle(cmdlet, clientContext, _title, webUrl, store);
                 return _font;
             }            
             return null;

--- a/src/Commands/Branding/GetBrandCenterFontPackage.cs
+++ b/src/Commands/Branding/GetBrandCenterFontPackage.cs
@@ -8,16 +8,16 @@ using PnP.PowerShell.Commands.Utilities;
 
 namespace PnP.PowerShell.Commands.Branding
 {
-    [Cmdlet(VerbsCommon.Get, "PnPBrandCenterFont", DefaultParameterSetName = ParameterSet_ALL)]
+    [Cmdlet(VerbsCommon.Get, "PnPBrandCenterFontPackage", DefaultParameterSetName = ParameterSet_ALL)]
     [OutputType(typeof(Font), ParameterSetName = new[] { ParameterSet_SINGLE })]
     [OutputType(typeof(IEnumerable<Font>), ParameterSetName = new[] { ParameterSet_ALL })]
-    public class GetBrandCenterFont : PnPWebCmdlet
+    public class GetBrandCenterFontPackage : PnPWebCmdlet
     {
         private const string ParameterSet_SINGLE = "Single";
         private const string ParameterSet_ALL = "All";
 
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = ParameterSet_SINGLE)]
-        [ArgumentCompleter(typeof(BrandCenterFontCompleter))]
+        [ArgumentCompleter(typeof(BrandCenterFontPackageCompleter))]
         public BrandCenterFontPipeBind Identity { get; set; }
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_SINGLE)]
@@ -35,7 +35,7 @@ namespace PnP.PowerShell.Commands.Branding
             }
             else
             {
-                WriteObject(BrandCenterUtility.GetFonts(this, ClientContext, CurrentWeb.Url, Store), true);
+                WriteObject(BrandCenterUtility.GetFontPackages(this, ClientContext, CurrentWeb.Url, Store), true);
             }
         }
     }

--- a/src/Commands/Branding/SetBrandCenterFont.cs
+++ b/src/Commands/Branding/SetBrandCenterFont.cs
@@ -12,7 +12,7 @@ namespace PnP.PowerShell.Commands.Files
     public class SetBrandCenterFont : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
-        [ArgumentCompleter(typeof(BrandCenterFontCompleter))]
+        [ArgumentCompleter(typeof(BrandCenterFontPackageCompleter))]
         public BrandCenterFontPipeBind Identity { get; set; }
 
         [Parameter(Mandatory = true)]

--- a/src/Commands/Branding/UseBrandCenterFontPackage.cs
+++ b/src/Commands/Branding/UseBrandCenterFontPackage.cs
@@ -8,12 +8,12 @@ using PnP.PowerShell.Commands.Utilities.REST;
 
 namespace PnP.PowerShell.Commands.Branding
 {
-    [Cmdlet(VerbsOther.Use, "PnPBrandCenterFont")]
+    [Cmdlet(VerbsOther.Use, "PnPBrandCenterFontPackage")]
     [OutputType(typeof(void))]
-    public class UseBrandCenterFont : PnPWebCmdlet
+    public class UseBrandCenterFontPackage : PnPWebCmdlet
     {
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
-        [ArgumentCompleter(typeof(BrandCenterFontCompleter))]
+        [ArgumentCompleter(typeof(BrandCenterFontPackageCompleter))]
         public BrandCenterFontPipeBind Identity { get; set; }
 
         [Parameter(Mandatory = false)]
@@ -31,7 +31,7 @@ namespace PnP.PowerShell.Commands.Branding
                 LogWarning($"The font with identity {font.Id} titled '{font.Title}' is not valid. Will try to apply it anyway.");
             }
 
-            var url = $"{BrandCenterUtility.GetStoreUrlByStoreType(font.Store, CurrentWeb.Url)}/GetById('{font.Id}')/Apply";
+            var url = $"{BrandCenterUtility.GetStoreFontPackageUrlByStoreType(font.Store, CurrentWeb.Url)}/GetById('{font.Id}')/Apply";
             LogDebug($"Applying font by making a POST call to {url}");
             RestHelper.Post(Connection.HttpClient, url, ClientContext);
         }

--- a/src/Commands/Utilities/BrandCenterUtility.cs
+++ b/src/Commands/Utilities/BrandCenterUtility.cs
@@ -15,7 +15,7 @@ namespace PnP.PowerShell.Commands.Utilities
     internal static class BrandCenterUtility
     {
         /// <summary>
-        /// Retrieves a font from the Brand Center based on its name and optionally store type.
+        /// Retrieves a font package from the Brand Center based on its name and optionally store type.
         /// </summary>
         /// <param name="cmdlet">Cmdlet for which this runs, used for logging</param>
         /// <param name="title">Title of the font to retrieve</param>
@@ -23,16 +23,16 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="store">The store to check for the font. When NULL, it will check all stores.</param>
         /// <param name="clientContext">ClientContext to use to communicate with SharePoint Online</param>
         /// <returns>The font with the provided identity or NULL if no font found with the provided identity</returns>
-        public static Font GetFontByTitle(BasePSCmdlet cmdlet, ClientContext clientContext, string title, string webUrl, Store store = Store.All)
+        public static Font GetFontPackageByTitle(BasePSCmdlet cmdlet, ClientContext clientContext, string title, string webUrl, Store store = Store.All)
         {
             if (store == Store.All)
             {
-                return GetFontByTitle(cmdlet, clientContext, title, webUrl, Store.Site) ??
-                       GetFontByTitle(cmdlet, clientContext, title, webUrl, Store.Tenant) ??
-                       GetFontByTitle(cmdlet, clientContext, title, webUrl, Store.OutOfBox);
+                return GetFontPackageByTitle(cmdlet, clientContext, title, webUrl, Store.Site) ??
+                       GetFontPackageByTitle(cmdlet, clientContext, title, webUrl, Store.Tenant) ??
+                       GetFontPackageByTitle(cmdlet, clientContext, title, webUrl, Store.OutOfBox);
             }
 
-            var url = $"{GetStoreUrlByStoreType(store, webUrl)}/GetByTitle('{title}')";
+            var url = $"{GetStoreFontPackageUrlByStoreType(store, webUrl)}/GetByTitle('{title}')";
             cmdlet?.LogDebug($"Making a GET request to {url} to retrieve {store} font with title {title}.");
             try
             {
@@ -52,7 +52,7 @@ namespace PnP.PowerShell.Commands.Utilities
         }
 
         /// <summary>
-        /// Retrieves a font from the Brand Center based on its identity and optionally store type.
+        /// Retrieves a font package from the Brand Center based on its identity and optionally store type.
         /// </summary>
         /// <param name="cmdlet">Cmdlet for which this runs, used for logging</param>
         /// <param name="identity">Id of the font to retrieve</param>
@@ -60,16 +60,16 @@ namespace PnP.PowerShell.Commands.Utilities
         /// <param name="store">The store to check for the font. When NULL, it will check all stores.</param>
         /// <param name="clientContext">ClientContext to use to communicate with SharePoint Online</param>
         /// <returns>The font with the provided identity or NULL if no font found with the provided identity</returns>
-        public static Font GetFontById(BasePSCmdlet cmdlet, ClientContext clientContext, Guid identity, string webUrl, Store store = Store.All)
+        public static Font GetFontPackageById(BasePSCmdlet cmdlet, ClientContext clientContext, Guid identity, string webUrl, Store store = Store.All)
         {
             if (store == Store.All)
             {
-                return GetFontById(cmdlet, clientContext, identity, webUrl, Store.Site) ??
-                       GetFontById(cmdlet, clientContext, identity, webUrl, Store.Tenant) ??
-                       GetFontById(cmdlet, clientContext, identity, webUrl, Store.OutOfBox);
+                return GetFontPackageById(cmdlet, clientContext, identity, webUrl, Store.Site) ??
+                       GetFontPackageById(cmdlet, clientContext, identity, webUrl, Store.Tenant) ??
+                       GetFontPackageById(cmdlet, clientContext, identity, webUrl, Store.OutOfBox);
             }
 
-            var url = $"{GetStoreUrlByStoreType(store, webUrl)}/GetById('{identity}')";
+            var url = $"{GetStoreFontPackageUrlByStoreType(store, webUrl)}/GetById('{identity}')";
             cmdlet?.LogDebug($"Making a GET request to {url} to retrieve {store} font with identity {identity}.");
             try
             {
@@ -89,38 +89,38 @@ namespace PnP.PowerShell.Commands.Utilities
         }
 
         /// <summary>
-        /// Retrieves fonts from the Brand Center optionally based on the store type.
+        /// Retrieves font packages from the Brand Center optionally based on the store type.
         /// </summary>
         /// <param name="cmdlet">Cmdlet for which this runs, used for logging</param>
         /// <param name="webUrl">Url to use to check the site collection Brand Center</param>
         /// <param name="store">The store to check for the font. When NULL, it will check all stores.</param>
         /// <param name="clientContext">ClientContext to use to communicate with SharePoint Online</param>
         /// <returns>The available fonts</returns>
-        public static List<Font> GetFonts(BasePSCmdlet cmdlet, ClientContext clientContext, string webUrl, Store store = Store.All)
+        public static List<Font> GetFontPackages(BasePSCmdlet cmdlet, ClientContext clientContext, string webUrl, Store store = Store.All)
         {
             if (store == Store.All)
             {
                 var allStoresFonts = new List<Font>();
-                allStoresFonts.AddRange(GetFonts(cmdlet, clientContext, webUrl, Store.Site));
-                allStoresFonts.AddRange(GetFonts(cmdlet, clientContext, webUrl, Store.Tenant));
-                allStoresFonts.AddRange(GetFonts(cmdlet, clientContext, webUrl, Store.OutOfBox));
+                allStoresFonts.AddRange(GetFontPackages(cmdlet, clientContext, webUrl, Store.Site));
+                allStoresFonts.AddRange(GetFontPackages(cmdlet, clientContext, webUrl, Store.Tenant));
+                allStoresFonts.AddRange(GetFontPackages(cmdlet, clientContext, webUrl, Store.OutOfBox));
                 return allStoresFonts;
             }
 
-            var url = GetStoreUrlByStoreType(store, webUrl);
+            var url = GetStoreFontPackageUrlByStoreType(store, webUrl);
             cmdlet?.LogDebug($"Making a GET request to {url} to retrieve {store} fonts.");
             var fonts = RestHelper.Get<RestResultCollection<Font>>(Framework.Http.PnPHttpClient.Instance.GetHttpClient(), url, clientContext);
             return fonts.Items.ToList();
         }
 
         /// <summary>
-        /// Returns the URL to the Brand Center based on the store type
+        /// Returns the font package URL to the Brand Center based on the store type
         /// </summary>
         /// <param name="store">Brand Center store to connect to</param>
         /// <param name="webUrl">Base URL to connect to</param>
         /// <returns></returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if an invalid store type has been provided</exception>
-        public static string GetStoreUrlByStoreType(Store store, string webUrl)
+        public static string GetStoreFontPackageUrlByStoreType(Store store, string webUrl)
         {
             return store switch
             {


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample
- [X] Refactor

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Renaming the Brand Center Font cmdlets to FontPackage, as that better suits them and leaves room for additional cmdlets that work directly with individual fonts