### PR TITLE
Fixing local Core SDK Build not being debuggable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Get-PnPFolder` throwing an exception when a lot of files and folders are present [#4819](https://github.com/pnp/powershell/pull/4819)
 - Fixed `Set-PnPTerm -Name "New Name" -Lcid 1043` changing the default name of the taxonomy item, ignoring the provided language id and changing the name for the default language instead. [#4824](https://github.com/pnp/powershell/pull/4824)
 - Fixed `Get-PnPPropertyBag` not returning updated values after running it for the first time [#4823](https://github.com/pnp/powershell/pull/4823)
+- Fixed local build of PnP PowerShell using a local Core SDK build not being debuggable and optimized PnP PowerShell debug profiles for Visual Studio Code
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,7 +130,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Get-PnPFolder` throwing an exception when a lot of files and folders are present [#4819](https://github.com/pnp/powershell/pull/4819)
 - Fixed `Set-PnPTerm -Name "New Name" -Lcid 1043` changing the default name of the taxonomy item, ignoring the provided language id and changing the name for the default language instead. [#4824](https://github.com/pnp/powershell/pull/4824)
 - Fixed `Get-PnPPropertyBag` not returning updated values after running it for the first time [#4823](https://github.com/pnp/powershell/pull/4823)
-- Fixed local build of PnP PowerShell using a local Core SDK build not being debuggable and optimized PnP PowerShell debug profiles for Visual Studio Code
+- Fixed local build of PnP PowerShell using a local Core SDK build not being debuggable and optimized PnP PowerShell debug profiles for Visual Studio Code [#4838](https://github.com/pnp/powershell/pull/4838)
 
 ### Removed
 

--- a/build/Build-Debug.ps1
+++ b/build/Build-Debug.ps1
@@ -53,7 +53,7 @@ $version = "$($versionObject.Major).$($versionObject.Minor).$buildVersion"
 
 Write-Host "Building PnP.PowerShell version $version-debug" -ForegroundColor Yellow
 
-$buildCmd = "dotnet build `"$PSScriptRoot/../src/Commands/PnP.PowerShell.csproj`"" + "--nologo --configuration Debug -p:VersionPrefix=$version -p:VersionSuffix=debug";
+$buildCmd = "dotnet build `"$PSScriptRoot/../src/Commands/PnP.PowerShell.csproj`" --nologo --configuration Debug -p:VersionPrefix=$version -p:VersionSuffix=debug";
 if ($NoIncremental) {
 	$buildCmd += " --no-incremental";
 }
@@ -62,25 +62,28 @@ if ($Force) {
 }
 if ($LocalPnPFramework) {
 	# Check if available
-	$pnpFrameworkAssembly = Join-Path $PSScriptRoot -ChildPath "..\..\pnpframework\src\lib\PnP.Framework\bin\Debug\netstandard2.0\PnP.Framework.dll"
+	$pnpFrameworkAssembly = Join-Path $PSScriptRoot -ChildPath "..\..\pnpframework\src\lib\PnP.Framework\bin\Debug\$configuration\PnP.Framework.dll"
 	$pnpFrameworkAssembly = [System.IO.Path]::GetFullPath($pnpFrameworkAssembly)
 	if (Test-Path $pnpFrameworkAssembly -PathType Leaf) {
+		$pnpFrameworkAssemblyItem = Get-ChildItem -Path $pnpFrameworkAssembly
+		Write-Host "  Using local PnP Framework build located at $($pnpFrameworkAssemblyItem.FullName) compiled at $($pnpFrameworkAssemblyItem.LastWritetime)" -ForegroundColor Yellow
 		$buildCmd += " -p:PnPFrameworkPath=`"..\..\..\pnpframework\src\lib\`""
 	}
- else {
+ 	else {
 		$localFolder = Join-Path $PSScriptRoot -ChildPath "..\..\pnpframework"
 		$localFolder = [System.IO.Path]::GetFullPath($localFolder)
 		Write-Error -Message "Please make sure you have a local copy of the PnP.Framework repository installed at $localFolder"
 	}
 }
 if ($LocalPnPCore) {
-	# Check if available
-	$pnpCoreAssembly = Join-Path $PSScriptRoot -ChildPath "..\..\pnpcore\src\sdk\PnP.Core\bin\Debug\netstandard2.0\PnP.Core.dll"
+	$pnpCoreAssembly = Join-Path $PSScriptRoot -ChildPath "..\..\pnpcore\src\sdk\PnP.Core\bin\Debug\$configuration\PnP.Core.dll"
 	$pnpCoreAssembly = [System.IO.Path]::GetFullPath($pnpCoreAssembly)
 	if (Test-Path $pnpCoreAssembly -PathType Leaf) {
+		$pnpCoreAssemblyItem = Get-ChildItem -Path $pnpCoreAssembly
+		Write-Host "  Using local PnP.Core SDK build located at $($pnpCoreAssemblyItem.FullName) compiled at $($pnpCoreAssemblyItem.LastWritetime)" -ForegroundColor Yellow
 		$buildCmd += " -p:PnPCoreSdkPath=`"..\..\..\pnpcore\src\sdk\`""
 	}
- else {
+ 	else {
 		$localFolder = Join-Path $PSScriptRoot -ChildPath "..\..\pnpcore"
 		$localFolder = [System.IO.Path]::GetFullPath($localFolder)
 		Write-Error -Message "Please make sure you have a local copy of the PnP.Core repository installed at $localFolder"
@@ -127,6 +130,12 @@ if ($LASTEXITCODE -eq 0) {
 		Copy-Item -Path "$PSScriptRoot/../resources/*.ps1xml" -Destination "$destinationFolder"
 		Get-ChildItem -Path "$PSScriptRoot/../src/ALC/bin/Debug/net8.0" | Where-Object { $_.Extension -in '.dll', '.pdb' } | Foreach-Object { if (!$assemblyExceptions.Contains($_.Name)) { [void]$commonFiles.Add($_.Name) }; Copy-Item -LiteralPath $_.FullName -Destination $commonPath }
 		Get-ChildItem -Path "$PSScriptRoot/../src/Commands/bin/Debug/$configuration" | Where-Object { $_.Extension -in '.dll', '.pdb' -and -not $commonFiles.Contains($_.Name) } | Foreach-Object { Copy-Item -LiteralPath $_.FullName -Destination $corePath }
+
+		if ($LocalPnPCore) {
+			# Ensure the local PnP.Core SDK is copied to the module folder or else debugging will not work. This assembly otherwises comes in through PnP Framework and will still use the NuGet version instead of the local build.
+			Write-Host "  Copying local PnP.Core SDK assembly" -ForegroundColor Yellow
+			Copy-Item -Path $pnpCoreAssembly -Destination "$destinationFolder\Core" -Force
+		}
 	}
 	Catch {
 		Write-Error "Cannot copy files to $destinationFolder. Maybe a PowerShell session is still using the module or PS modules are hosted in a OneDrive synced location. In the latter case, manually delete $destinationFolder and try again."
@@ -150,7 +159,7 @@ if ($LASTEXITCODE -eq 0) {
 			}
 			Write-Host "Importing dotnet core version of assembly"
 			Import-Module -Name "$destinationFolder/Core/PnP.PowerShell.dll" -DisableNameChecking
-			$cmdlets = get-command -Module PnP.PowerShell | ForEach-Object { "`"$_`"" }
+			$cmdlets = Get-Command -Module PnP.PowerShell | ForEach-Object { "`"$_`"" }
 			$cmdlets -Join ","
 		}
 		$cmdletsString = Start-ThreadJob -ScriptBlock $scriptBlock | Receive-Job -Wait


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
When building PnP PowerShell locally using Visual Studio Code and choosing the option to use a locally compiled PnP Core SDK, the resulting module would not allow you to attach a debugger to PnP Core SDK. This turns out to be as PnP Framework brings in PnP.Core.dll already and uses its nightly build, thereby overriding your locally built PnP.Core.dll causing an execution not to be able to attach a debugger to the code. This extra step guarantees that your custom build will be used instead so you can nicely debug through the code of PnP Core SDK as well.