### PR TITLE
Fix Set-PnPView -Aggregations parameter not showing aggregations in SPO

### DIFF
--- a/src/Commands/Lists/SetView.cs
+++ b/src/Commands/Lists/SetView.cs
@@ -110,6 +110,14 @@ namespace PnP.PowerShell.Commands.Fields
             if(ParameterSpecified(nameof(Aggregations)))
             {
                 view.Aggregations = Aggregations;
+                if (!string.IsNullOrEmpty(Aggregations))
+                {
+                    view.AggregationsStatus = "On";
+                }
+                else
+                {
+                    view.AggregationsStatus = "Off";
+                }
                 view.Update();
                 ClientContext.Load(view);
                 ClientContext.ExecuteQueryRetry();


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #4706

## What is in this Pull Request ? ##
Fix Set-PnPView -Aggregations parameter not showing aggregations in SPO.

Use the script below to test the PR:
```powershell
Set-PnPView -List "Test simple list" -Identity "All Items" -Aggregations "<FieldRef Name='LinkTitle' Type='COUNT'/>"
```

Before the PR, the aggregation bar is visible but without any value:
![Screenshot 2025-04-20 164100](https://github.com/user-attachments/assets/0a69d906-8aed-4c36-a57d-a77dda5d4ca5)

After the PR, "Count: 4" is visible:
![Screenshot 2025-04-20 160435](https://github.com/user-attachments/assets/2efc3555-62e3-4494-8e9d-181c0a602159)

Passing an empty string as -Aggregation removes the aggregation bar:
![image](https://github.com/user-attachments/assets/ecf56e7b-76d7-48d4-88de-e66a8ea24ae6)


