### PR TITLE
Fix -CreateDrive parameter in Connect-PnPOnline

### DIFF
--- a/src/Commands/Provider/SPOProvider.cs
+++ b/src/Commands/Provider/SPOProvider.cs
@@ -38,7 +38,7 @@ namespace PnP.PowerShell.Commands.Provider
 
         protected override PSDriveInfo NewDrive(PSDriveInfo drive)
         {
-            Log.Debug("SPOProvider","NewDrive (Drive.Name = ’{drive.Name}’, Drive.Root = ’{drive.Root}’)");
+            Log.Debug("SPOProvider", $"NewDrive (Drive.Name = ’{drive.Name}’, Drive.Root = ’{drive.Root}’)");
 
             var spoParameters = DynamicParameters as SPODriveParameters;
             Web web = null;
@@ -108,7 +108,7 @@ namespace PnP.PowerShell.Commands.Provider
 
         protected override PSDriveInfo RemoveDrive(PSDriveInfo drive)
         {
-            Log.Debug("SPOProvider","RemoveDrive (Drive.Name = ’{drive.Name}’)");
+            Log.Debug("SPOProvider", $"RemoveDrive (Drive.Name = ’{drive.Name}’)");
 
             var spoDrive = drive as SPODriveInfo;
             if (spoDrive == null) return null;


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #4717

## What is in this Pull Request ? ##
Fix -CreateDrive parameter in Connect-PnPOnline showing an error "Input string was not in a correct format" caused by a missing $ character before a C# string in a recent refactor.