### PR TITLE
Allow to pass Id parameter to cmdlet Register-PnPHubSite similar to cmdlet Unregister-PnPHubSite

### DIFF
--- a/src/Commands/Admin/UnregisterHubSite.cs
+++ b/src/Commands/Admin/UnregisterHubSite.cs
@@ -26,7 +26,7 @@ namespace PnP.PowerShell.Commands.Admin
             }
             else
             {
-                props = hubSitesProperties.Single(h => h.SiteUrl.Equals(Site.Url, StringComparison.OrdinalIgnoreCase));
+                props = hubSitesProperties.Single(h => !string.IsNullOrEmpty(h.SiteUrl) && h.SiteUrl.Equals(Site.Url, StringComparison.OrdinalIgnoreCase));
             }
             Tenant.UnregisterHubSiteById(props.ID);
             AdminContext.ExecuteQueryRetry();


### PR DESCRIPTION
## Type ##
- [ ] New Feature

## What is in this Pull Request ? ##
Unregister-PnPHubSite allows to pass site Id to Site parameter
```
Unregister-PnPHubSite -Site $site.SiteId.Guid
```

This change will allow to pass siteId.Guid to the cmdlet  Register-PnPHubSite , for example

```
$site = Get-PnPTenantsite -identity https://reshmeeauckloo.sharepoint.com/sites/TestHR_Hub
Register-PnPHubSite -Site $site.siteId.Guid
```