### PR TITLE
Fix Get-PnPHubSiteChild to work with vanity domains

### DIFF
--- a/src/Commands/Admin/GetHubSiteChild.cs
+++ b/src/Commands/Admin/GetHubSiteChild.cs
@@ -48,7 +48,7 @@ namespace PnP.PowerShell.Commands.Admin
             // Get the ID of the hubsite for which we need to find child sites
             var hubSiteId = hubSiteProperties.ID;
 
-            WriteObject(Tenant.GetHubSiteChildUrls(hubSiteId), true);
+            WriteObject(Tenant.GetHubSiteChildUrls(hubSiteId, Connection.TenantAdminUrl), true);
         }
     }
 }


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
https://github.com/pnp/pnpframework/pull/1095

## What is in this Pull Request ? ##
Adds **Connection.TenantAdminUrl** parameter to **GetHubSiteChildUrls**, so **Get-PnPHubSiteChild** cmdlet works with vanity domains.
