### PR TITLE
Fix for Get-HubSite not returning null if provided site is not a hub site …

### DIFF
--- a/src/Commands/Admin/GetHubSite.cs
+++ b/src/Commands/Admin/GetHubSite.cs
@@ -18,7 +18,13 @@ namespace PnP.PowerShell.Commands.Admin
                 var hubSiteProperties = Identity.GetHubSite(Tenant);
                 AdminContext.Load(hubSiteProperties);
                 AdminContext.ExecuteQueryRetry();
-                WriteObject(hubSiteProperties);
+                if ((bool)hubSiteProperties.ServerObjectIsNull)
+                {
+                    WriteObject(null);
+                }
+                else { 
+                    WriteObject(hubSiteProperties);
+                }
             }
             else
             {


### PR DESCRIPTION

## Type ##
- [x ] Bug Fix


## Related Issues? ##
Fixes #5032 , 

## What is in this Pull Request ? ##
Fix to issue menitioned in #5032  "Get-PnPHubSite currently returns a not-null respons when calling using a valid URL to a site that is not a hub site. I would expect a null value"

