### PR TITLE
Bugfix due to incorrect rewrite to RequestHelper class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fix `Connect-PnPOnline` not working correctly with `-DeviceLogin` in Azure Cloud Shell.
 - Fix `Connect-PnPOnline` not working correctly with `-DeviceLogin` in desktop-less environments, such as on a Raspberry Pi [#5058](https://github.com/pnp/powershell/pull/5058)
 - Fix `Get-PnPTenantRestrictedSearchMode` throwing an error in some cases [#5042](https://github.com/pnp/powershell/pull/5042)
+- Fixed issues with `Get-PnPTenantInfo`, `Set-PnPList`, `Remove-PnPSiteSensitivityLabel`, `Set-PnPSiteSensitivityLabel`, `Send-PnPMail` and `Set-PnPWebHeader` cmdlets returning an error
 
 ### Removed
 

--- a/src/Commands/Admin/GetTenantInfo.cs
+++ b/src/Commands/Admin/GetTenantInfo.cs
@@ -36,7 +36,7 @@ namespace PnP.PowerShell.Commands.Admin
             var requestUrl = BuildRequestUrl();
 
             LogDebug($"Making call to {requestUrl} to request tenant information");
-            var results = this.RequestHelper.Get<Model.TenantInfo>(requestUrl);
+            var results = GraphRequestHelper.Get<Model.TenantInfo>(requestUrl);
             WriteObject(results, true);
         }
 

--- a/src/Commands/Base/PnPSharePointCmdlet.cs
+++ b/src/Commands/Base/PnPSharePointCmdlet.cs
@@ -32,8 +32,16 @@ namespace PnP.PowerShell.Commands
         /// </summary>
         public HttpClient HttpClient => Framework.Http.PnPHttpClient.Instance.GetHttpClient(ClientContext);
 
+        /// <summary>
+        /// An instance of the <see cref="ApiRequestHelper"/> class to help with making requests to the SharePoint Online services
+        /// </summary>
+        public ApiRequestHelper SharePointRequestHelper { get; set; }
 
-        public ApiRequestHelper RequestHelper { get; set; }
+        /// <summary>
+        /// An instance of the <see cref="ApiRequestHelper"/> class to help with making requests to the Microsoft Graph services
+        /// </summary>
+        public ApiRequestHelper GraphRequestHelper { get; private set; }        
+
         /// <summary>
         /// The current Bearer access token for SharePoint Online
         /// </summary>
@@ -122,7 +130,8 @@ namespace PnP.PowerShell.Commands
             }
             var resourceUri = new Uri(Connection.Url);
             var defaultResource = $"{resourceUri.Scheme}://{resourceUri.Authority}/.default";
-            RequestHelper = new ApiRequestHelper(GetType(), Connection, defaultResource);
+            SharePointRequestHelper = new ApiRequestHelper(GetType(), Connection, defaultResource);
+            GraphRequestHelper = new ApiRequestHelper(GetType(), Connection, $"https://{Connection.GraphEndPoint}/.default");
         }
 
         protected override void ProcessRecord()

--- a/src/Commands/Lists/SetList.cs
+++ b/src/Commands/Lists/SetList.cs
@@ -406,7 +406,7 @@ namespace PnP.PowerShell.Commands.Lists
                         if (!string.IsNullOrEmpty(DefaultSensitivityLabelForLibrary.LabelName))
                         {
                             LogDebug($"Looking up sensitivity label id by label name '{DefaultSensitivityLabelForLibrary.LabelName}'");
-                            var label = DefaultSensitivityLabelForLibrary.GetLabelByNameThroughGraph(Connection,RequestHelper);
+                            var label = DefaultSensitivityLabelForLibrary.GetLabelByNameThroughGraph(Connection, GraphRequestHelper);
 
                             if (label == null || !label.Id.HasValue)
                             {

--- a/src/Commands/Purview/RemoveSiteSensitivityLabel.cs
+++ b/src/Commands/Purview/RemoveSiteSensitivityLabel.cs
@@ -28,7 +28,7 @@ namespace PnP.PowerShell.Commands.Purview
                 LogDebug($"Trying to remove the Microsoft Purview sensitivity label from the Microsoft 365 Group with Id {ClientContext.Site.GroupId} behind the current site {Connection.Url}");
                 var stringContent = new StringContent(JsonSerializer.Serialize(new { assignedLabels = new [] { new { labelId = "" }}}));
                 stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-                RequestHelper.Patch(stringContent, $"beta/groups/{ClientContext.Site.GroupId}");
+                GraphRequestHelper.Patch(stringContent, $"beta/groups/{ClientContext.Site.GroupId}");
             }
             else
             {

--- a/src/Commands/Purview/SetSiteSensitivityLabel.cs
+++ b/src/Commands/Purview/SetSiteSensitivityLabel.cs
@@ -22,7 +22,7 @@ namespace PnP.PowerShell.Commands.Purview
                 // Look up the sensitivity label Guid with the provided name
                 LogDebug($"Passed in label '{Identity}' is a name, going to try to lookup its Id");
 
-                var label = RequestHelper.GetResultCollection<Model.Graph.Purview.InformationProtectionLabel>($"/beta/{(Connection.ConnectionMethod == Model.ConnectionMethod.AzureADAppOnly ? "" : "me/")}informationProtection/policy/labels?$filter=name eq '{Identity}'");
+                var label = GraphRequestHelper.GetResultCollection<Model.Graph.Purview.InformationProtectionLabel>($"/beta/{(Connection.ConnectionMethod == Model.ConnectionMethod.AzureADAppOnly ? "" : "me/")}informationProtection/policy/labels?$filter=name eq '{Identity}'");
                 if (label == null || label.Count() == 0)
                 {
                     throw new PSArgumentException($"No Microsoft Purview sensitivity label with the provided name '{Identity}' could be found", nameof(Identity));
@@ -54,7 +54,7 @@ namespace PnP.PowerShell.Commands.Purview
                 LogDebug($"Trying to set the Microsoft 365 Group with Id {ClientContext.Site.GroupId} behind the current site {Connection.Url} to Microsoft Purview sensitivity label with Id {sensitivityLabelId}");
                 var stringContent = new StringContent(JsonSerializer.Serialize(new { assignedLabels = new[] { new { labelId = sensitivityLabelId } } }));
                 stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-                RequestHelper.Patch(stringContent, $"beta/groups/{ClientContext.Site.GroupId}");
+                GraphRequestHelper.Patch(stringContent, $"beta/groups/{ClientContext.Site.GroupId}");
             }
             else
             {

--- a/src/Commands/SiteDesigns/InvokeSiteScript.cs
+++ b/src/Commands/SiteDesigns/InvokeSiteScript.cs
@@ -55,7 +55,7 @@ namespace PnP.PowerShell.Commands
                     else
                     {
                         LogDebug($"Executing provided script");
-                        result = Utilities.SiteTemplates.InvokeSiteScript(RequestHelper, Script, hostUrl).Items;
+                        result = Utilities.SiteTemplates.InvokeSiteScript(SharePointRequestHelper, Script, hostUrl).Items;
                     }
                     break;
 
@@ -81,7 +81,7 @@ namespace PnP.PowerShell.Commands
                         else
                         {
                             LogDebug($"Executing site script '{script.Title}' ({script.Id})");
-                            result =Utilities.SiteTemplates.InvokeSiteScript(RequestHelper, script, hostUrl).Items;
+                            result =Utilities.SiteTemplates.InvokeSiteScript(SharePointRequestHelper, script, hostUrl).Items;
                         }
                     }
                     break;

--- a/src/Commands/Utilities/SendMail.cs
+++ b/src/Commands/Utilities/SendMail.cs
@@ -1,4 +1,5 @@
-﻿using PnP.PowerShell.Commands.Base.PipeBinds;
+﻿using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Base.PipeBinds;
 using PnP.PowerShell.Commands.Enums;
 using PnP.PowerShell.Commands.Model.Mail;
 using System.Collections.Generic;
@@ -86,7 +87,7 @@ namespace PnP.PowerShell.Commands.Utilities
                     messageAttachmentOptions = MailUtility.GetListOfFiles(Files, Connection.PnPContext);
                 }
 
-                MailUtility.SendGraphMail(RequestHelper, new Message
+                MailUtility.SendGraphMail(GraphRequestHelper, new Message
                 {
                     Subject = Subject,
                     MessageBody = new Body

--- a/src/Commands/Web/SetWebHeader.cs
+++ b/src/Commands/Web/SetWebHeader.cs
@@ -109,7 +109,7 @@ namespace PnP.PowerShell.Commands
                     var stringContent = new StringContent("{" + string.Join(",", setSiteBackgroundImageInstructions) + ",\"type\":2,\"aspect\":0}");
                     stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
                     CurrentWeb.EnsureProperties(p => p.Url);
-                    var result = RequestHelper.PostHttpContent($"{CurrentWeb.Url.TrimEnd('/')}/_api/siteiconmanager/setsitelogo", stringContent);
+                    var result = SharePointRequestHelper.PostHttpContent($"{CurrentWeb.Url.TrimEnd('/')}/_api/siteiconmanager/setsitelogo", stringContent);
                     LogDebug($"Response from setsitelogo request: {result.StatusCode}");
                 }
             }
@@ -128,7 +128,7 @@ namespace PnP.PowerShell.Commands
             var stringContent = new StringContent($"{{\"relativeLogoUrl\":\"{imageUrl}\",\"type\":0,\"aspect\":{aspect}}}");
             stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
             CurrentWeb.EnsureProperties(p => p.Url);
-            var result = RequestHelper.PostHttpContent($"{CurrentWeb.Url.TrimEnd('/')}/_api/siteiconmanager/setsitelogo", stringContent);
+            var result = SharePointRequestHelper.PostHttpContent($"{CurrentWeb.Url.TrimEnd('/')}/_api/siteiconmanager/setsitelogo", stringContent);
             LogDebug($"Response from {imageType} request: {result.StatusCode}");
         }
     }


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes https://github.com/pnp/powershell/issues/5044

## What is in this Pull Request ? ##
The introduction of the RequestHelper in version 3 caused Graph cmdlets to be executed with a SharePoint Online token causing them to fail executing. This broke these cmdlets:

- `Get-PnPTenantInfo`
- `Set-PnPList`
- `Remove-PnPSiteSensitivityLabel`
- `Set-PnPSiteSensitivityLabel`
- `Send-PnPMail`
- `Set-PnPWebHeader`

These should all work again with this fix.