### PR TITLE
Fixing issue with `Get-PnPChangelog -Nightly`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fix `Connect-PnPOnline` not working correctly with `-DeviceLogin` in desktop-less environments, such as on a Raspberry Pi [#5058](https://github.com/pnp/powershell/pull/5058)
 - Fix `Get-PnPTenantRestrictedSearchMode` throwing an error in some cases [#5042](https://github.com/pnp/powershell/pull/5042)
 - Fixed issues with `Get-PnPTenantInfo`, `Set-PnPList`, `Remove-PnPSiteSensitivityLabel`, `Set-PnPSiteSensitivityLabel`, `Send-PnPMail` and `Set-PnPWebHeader` cmdlets returning an error [#5059](https://github.com/pnp/powershell/pull/5059)
+- Fixed issue with `Get-PnPChangelog -Nightly` throwing an error
 
 ### Removed
 

--- a/src/Commands/Base/GetChangeLog.cs
+++ b/src/Commands/Base/GetChangeLog.cs
@@ -105,7 +105,7 @@ namespace PnP.PowerShell.Commands
 
             LogDebug($"Looking for release information on the {version} release");
 
-            var match = Regex.Match(content, @$"(?<changelog>## \[{version}]\n.*?)\n## \[\d+?\.\d+?\.\d+?\]", RegexOptions.Singleline);
+            var match = Regex.Match(content, @$"(?<changelog>## \[{version}]\n.*?)\n## \[\d+?\.\d+?\.\d+?\]", RegexOptions.Singleline | RegexOptions.IgnoreCase);
 
             if (!match.Success)
             {


### PR DESCRIPTION
## Type ##
- [X] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
`Get-PnPChangelog -Nightly` was expecting [Current nightly] in exactly this capitalization, which wasn't matching. Added the case insensitive flag to the RegEx to make it more resilient and fix it.