### PR TITLE
Fix syntax for -IsDefault parameter in docs

### DIFF
--- a/documentation/Get-PnPPowerPlatformEnvironment.md
+++ b/documentation/Get-PnPPowerPlatformEnvironment.md
@@ -75,7 +75,7 @@ Accept wildcard characters: False
 ```
 
 ### -IsDefault
-Allows retrieval of the default Power Platform environment by passing in `-IsDefault:$true`. When passing in `-IsDefault :$false` you will get all non default environments. If not provided at all, all available environments, both default and non-default, will be returned.
+Allows retrieval of the default Power Platform environment by passing in `-IsDefault:$true`. When passing in `-IsDefault:$false` you will get all non default environments. If not provided at all, all available environments, both default and non-default, will be returned.
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
Fix #5155: Updated syntax for -IsDefault parameter in documentation.

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #5155

## What is in this Pull Request ? ##
Updated docs