### PR TITLE
fix for bug #5019: to allow reuse of connection created using certificate in Connect-PnPOnline to create a new connection the cmdelet asks for interactive login

### DIFF
--- a/src/Commands/Base/ConnectOnline.cs
+++ b/src/Commands/Base/ConnectOnline.cs
@@ -648,7 +648,7 @@ namespace PnP.PowerShell.Commands.Base
             }
             else if (ParameterSpecified(nameof(Thumbprint)))
             {
-                _certificate = CertificateHelper.GetCertificateFromStore(Thumbprint);
+                certificate = CertificateHelper.GetCertificateFromStore(Thumbprint);
 
                 if (certificate == null)
                 {


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix

## Related Issues? ##
Fixes #5019 