### PR TITLE
Include original exception information when throwing in `PnPConnectedCmdlet.ProcessRecord`

### DIFF
--- a/src/Commands/Base/PnPConnectedCmdlet.cs
+++ b/src/Commands/Base/PnPConnectedCmdlet.cs
@@ -101,7 +101,7 @@ namespace PnP.PowerShell.Commands.Base
                 // If the ErrorAction is not set to Stop, Ignore or SilentlyContinue throw an exception, otherwise just continue
                 if (!(new[] { "stop", "ignore", "silentlycontinue" }.Contains(ErrorActionSetting.ToLowerInvariant())))
                 {
-                    throw new PSInvalidOperationException(errorMessage);
+                    throw new PSInvalidOperationException(errorMessage, ex);
                 }
 
                 if (Connection.Context.Url != Connection.Url)


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##

## What is in this Pull Request ? ##
When any cmdlet descending from `PnPConnectedCmdlet` encounters an exception while processing records (presumably, I'm not very familiar with all of this) that doesn't match its list of more specific exceptions, it throws a `PSInvalidOperationException`. [This behavior has previously been described as "error shallowing"](https://github.com/pnp/powershell/issues/3365#issuecomment-1709864014:~:text=Which%20correspond%20to%20this%20error%20shallowing%20code:) because it erases the more specific cause of the error, especially in errors with indistinctive messages like "Object reference not set to an instance of an object.".

This PR includes the original exception as an [inner exception](https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.psinvalidoperationexception.-ctor?view=powershellsdk-7.4.0#system-management-automation-psinvalidoperationexception-ctor(system-string-system-exception)), which preserves that information when running `(Get-PnPException).Exception` and such.

If someone reviews this request- do you think it would be a good idea to add an inner exception element to `Get-PnPException`/`Get-PnPDiagnostics`? I'd be happy to make a PR for them too or add all that to this one 🙂
