### PR TITLE
Add example for handling large lists with pagination

### DIFF
--- a/documentation/Get-PnPListItem.md
+++ b/documentation/Get-PnPListItem.md
@@ -127,6 +127,20 @@ Get-PnPListItem -List Tasks -Id 1 -IncludeContentType
 
 Retrieves the list item with ID 1 from the Tasks list along with its content type information.
 
+### EXAMPLE 12
+```powershell
+$Data = @()
+$batchSize = 5000
+do {
+    $batch = Get-PnPListItem -List "LargeList" -Fields "ID","Title" -PageSize $batchSize -ScriptBlock { param($items) $items | Sort-Object -Property ID -Descending }
+    if ($batch) {
+        $Data += $batch
+    }
+} while ($batch.Count -eq $batchSize)
+```
+
+Retrieves all items from a large list avoiding SharePoint's list view threshold limit.
+
 ## PARAMETERS
 
 ### -Connection


### PR DESCRIPTION
Add example for retrieving items from a large list which avoids the list view threshold limit error.


## Type ##
- [X] Sample

## What is in this Pull Request ? ##
Add example 12 to the Get-PnPListItem to demonstrate how to retrieve list items from large lists and avoid the list view threshold error you may encounter. 
