### PR TITLE
Retrieve GuestSharingGroupAllowListInTenantByPrincipalIdentity with correct parse.Closes #5244.

### DIFF
--- a/src/Commands/Model/SPOTenant.cs
+++ b/src/Commands/Model/SPOTenant.cs
@@ -567,7 +567,17 @@ namespace PnP.PowerShell.Commands.Model
                 failedProperties++;
                 cmdlet.LogDebug($"Property DefaultOneDriveInformationBarrierMode not loaded due to error '{e.Message}'");
             }
-
+            // GuestSharingGroupAllowListInTenantByPrincipalIdentity requires manual handling as it cannot be parsed directly from the Tenant object value
+            try
+            {
+                GuestSharingGroupAllowListInTenantByPrincipalIdentity = tenant.GuestSharingGroupAllowListInTenantByPrincipalIdentity.ToArray();
+            }
+            catch (Exception e)
+            {
+                failedProperties++;
+                cmdlet.LogDebug($"Property GuestSharingGroupAllowListInTenantByPrincipalIdentity not loaded due to error '{e.Message}'");
+            }
+            
             // If one or more properties failed to load, show a warning
             if (failedProperties > 0)
             {


### PR DESCRIPTION
Fix for #5244, allows to retrieve GuestSharingGroupAllowListInTenantByPrincipalIdentity

## Type ##
- [ ] Bug Fix


## What is in this Pull Request ? ##
Parse of property GuestSharingGroupAllowListInTenantByPrincipalIdentity with the SPOTenant.cs  file

Testing: 
<img width="957" height="101" alt="image" src="https://github.com/user-attachments/assets/3bbec95d-878e-4499-91e3-1a79bffab6a3" />
