### PR TITLE
Allow relative URLs for graph requests when using batch

### DIFF
--- a/documentation/Invoke-PnPGraphMethod.md
+++ b/documentation/Invoke-PnPGraphMethod.md
@@ -136,8 +136,8 @@ This example retrieves a Planner task to find the etag value which is required t
 ### EXAMPLE 9
 ```powershell
 $batch = New-PnPBatch -RetainRequests
-Invoke-PnPSPRestMethod -Method Get -Url "users" -Batch $batch
-Invoke-PnPSPRestMethod -Method Get -Url "groups" -Batch $batch
+Invoke-PnPGraphMethod -Method Get -Url "users" -Batch $batch
+Invoke-PnPGraphMethod -Method Get -Url "groups" -Batch $batch
 $response = Invoke-PnPBatch $batch -Details
 $response
 ```

--- a/src/Commands/Graph/InvokeGraphMethod.cs
+++ b/src/Commands/Graph/InvokeGraphMethod.cs
@@ -12,6 +12,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 
 namespace PnP.PowerShell.Commands.Base
 {
@@ -352,22 +353,12 @@ namespace PnP.PowerShell.Commands.Base
             extraHeaders.Add("Content-Type", ContentType);
 
             ApiRequestType apiRequestType = ApiRequestType.Graph;
-            if (requestUrl.IndexOf("/beta/", StringComparison.InvariantCultureIgnoreCase) > -1)
+            if (requestUrl.IndexOf("/beta/", StringComparison.InvariantCultureIgnoreCase) > -1 || requestUrl.StartsWith("beta/", StringComparison.InvariantCultureIgnoreCase))
             {
                 apiRequestType = ApiRequestType.GraphBeta;
             }
 
-            if (requestUrl.StartsWith("https://", StringComparison.InvariantCultureIgnoreCase))
-            {
-                if (requestUrl.IndexOf("/v1.0/", StringComparison.InvariantCultureIgnoreCase) > -1)
-                {
-                    requestUrl = requestUrl.Replace($"https://{Connection.GraphEndPoint}/v1.0/", "", StringComparison.InvariantCultureIgnoreCase);
-                }
-                else if (requestUrl.IndexOf("/beta/", StringComparison.InvariantCultureIgnoreCase) > -1)
-                {
-                    requestUrl = requestUrl.Replace($"https://{Connection.GraphEndPoint}/beta/", "", StringComparison.InvariantCultureIgnoreCase);
-                }
-            }
+            requestUrl = Regex.Replace(requestUrl, $"^(https://{Connection.GraphEndPoint})*/*(v1.0|beta)/", "", RegexOptions.IgnoreCase);
 
             web.WithHeaders(extraHeaders).ExecuteRequestBatch(Batch.Batch, new ApiRequest(method, apiRequestType, requestUrl, contentString));
         }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## What is in this Pull Request ? ##
Updated URL handling in Invoke-PnPGraphMethod command to allow usage of relative URLs in batch scenarios. Previously v1.0/ was added to the URL by default which resulted in illformatted URLs for the graph batch request.

Updated Example 9 in `Invoke-PnPGraphMethod` documentation to use the the proper command Invoke-PnPGraphMethod instead of Invoke-PnPSPRestMethod.