### PR TITLE
Fix opening browser on Linux by treating URL as 1 argument instead of many

### DIFF
--- a/src/Commands/Utilities/BrowserHelper.cs
+++ b/src/Commands/Utilities/BrowserHelper.cs
@@ -249,7 +249,7 @@ namespace PnP.PowerShell.Commands.Utilities
 
         internal static void OpenLinuxBrowser(string openToolPath, string url)
         {
-            ProcessStartInfo psi = new ProcessStartInfo(openToolPath, url)
+            ProcessStartInfo psi = new ProcessStartInfo(openToolPath, [url])
             {
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## What is in this Pull Request ? ##
On Linux, PnP can fail to open a browser for authentication when running `Register-PnPEntraIDAppForInteractiveLogin` and other similar commands. It tries a series of commands like `xdg-open` with a single argument for the URL in order to open a browser. However, that URL may contain spaces. `OpenLinuxBrowser` is using [`ProcessStartInfo`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.-ctor?view=net-10.0#system-diagnostics-processstartinfo-ctor(system-string-system-collections-generic-ienumerable((system-string)))) with the constructor that treats the string as all the arguments, meaning that any URLs with spaces get split apart and not opened by the tool. This PR fixes the issue by using the `ProcessStartInfo` constructor with a list of arguments, forcing it to treat any URL with spaces as only 1 argument.
