### PR TITLE
Implementation to set "DelayContentSecurityPolicyEnforcement" on Tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support for `-AllowFileArchive` and `-AllowFileArchiveOnNewSitesByDefault` on `Set-PnPTenant`, `-AllowFileArchive` on `Set-PnPTenantSite`, and `ArchivedFileDiskUsed` on `Get-PnPTenantSite` to configure and inspect file-level archiving. [#5283](https://github.com/pnp/powershell/pull/5283)
 - Added `Set-PnPFileArchiveState` cmdlet to archive and reactivate SharePoint files through the Microsoft Graph beta archive APIs. [#5283](https://github.com/pnp/powershell/pull/5283)
 - Added `Set-PnPFolderArchiveState` cmdlet to archive and reactivate SharePoint folders through the Microsoft Graph beta archive APIs. [#5283](https://github.com/pnp/powershell/pull/5283)
+- Added optional parameter `-DelayContentSecurityPolicyEnforcement` to cmdlet `Set-PnPTenant`. [#5288](https://github.com/pnp/powershell/pull/5288)
 
 ### Changed
 - Improved `Get-PnPTerm` cmdlet to show a better error message. [#4933](https://github.com/pnp/powershell/pull/4933)

--- a/documentation/Set-PnPTenant.md
+++ b/documentation/Set-PnPTenant.md
@@ -177,6 +177,7 @@ Set-PnPTenant [-SpecialCharactersStateInFileFolderNames <SpecialCharactersState>
  [-EnableMediaReactions <Boolean>]
  [-ContentSecurityPolicyEnforcement <Boolean>]
  [-DisableSpacesActivation <Boolean>]
+ [-DelayContentSecurityPolicyEnforcement <Boolean>]
  [-Force] [-Connection <PnPConnection>]
 ```
 
@@ -236,6 +237,13 @@ Set-PnPTenant -AllowFileArchive $true -AllowFileArchiveOnNewSitesByDefault $true
 ```
 
 This example enables file-level archiving for the tenant and makes new sites inherit the capability by default.
+
+### EXAMPLE 8
+```powershell
+Set-PnPTenant -DelayContentSecurityPolicyEnforcement $true
+```
+
+This example will delay the Content security policy enforcement by 90 days, until June 1, 2026.
 
 ## PARAMETERS
 
@@ -431,6 +439,20 @@ Optional connection to be used by the cmdlet. Retrieve the value for this parame
 
 ```yaml
 Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DelayContentSecurityPolicyEnforcement
+Delays the Content security policy enforcement by 90 days, until June 1, 2026.
+
+```yaml
+Type: Boolean
 Parameter Sets: (All)
 
 Required: False

--- a/src/Commands/Admin/SetTenant.cs
+++ b/src/Commands/Admin/SetTenant.cs
@@ -547,6 +547,9 @@ namespace PnP.PowerShell.Commands.Admin
         [Parameter(Mandatory = false)]
         public string[] FileTypesForVersionExpiration { set; get; }
 
+        [Parameter(Mandatory = false)]
+        public bool? DelayContentSecurityPolicyEnforcement { set; get; }
+
         protected override void ExecuteCmdlet()
         {
             AdminContext.Load(Tenant);
@@ -1767,6 +1770,11 @@ namespace PnP.PowerShell.Commands.Admin
                         Tenant.GuestSharingGroupAllowListInTenantByPrincipalIdentity = new string[0];
                     }
                 }
+                modified = true;
+            }
+            if (DelayContentSecurityPolicyEnforcement.HasValue)
+            {
+                Tenant.DelayContentSecurityPolicyEnforcement = DelayContentSecurityPolicyEnforcement.Value;
                 modified = true;
             }
             if (BlockDownloadFileTypePolicy.HasValue)


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## What is in this Pull Request ? ##
Added a new property to ```Set-PnPTenant``` commandlet, to set ```DelayContentSecurityPolicyEnforcement``` on the tenant. 

`Note : Delay of the enforcement is upto 90 days, until June 1, 2026`

### Examples ###
```Set-PnPTenant -DelayContentSecurityPolicyEnforcement $true```

Link to the [article](https://learn.microsoft.com/en-us/sharepoint/dev/spfx/content-securty-policy-trusted-script-sources)

Thanks,
Nish