### PR TITLE
Add Get-PnPListVersionPolicy and Set-PnPListVersionPolicy cmdlets for managing SharePoint document library version policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Current nightly]
 
 ### Added
-- Added `Get-PnPListVersionPolicy` and `Set-PnPListVersionPolicy` cmdlets to inspect and manage SharePoint Online document library version policies.
+- Added `Get-PnPListVersionPolicy` and `Set-PnPListVersionPolicy` cmdlets to inspect and manage SharePoint Online document library version policies. [#5299](https://github.com/pnp/powershell/pull/5299)
 - Added `Add-PnPEntraIDServicePrincipalAppRoleAssignment`, `Get-PnPEntraIDServicePrincipalAppRoleAssignment`, and `Remove-PnPEntraIDServicePrincipalAppRoleAssignment` cmdlets to manage Entra ID user and group enterprise application assignments with app roles [#5292](https://github.com/pnp/powershell/pull/5292)
 - Added `Copy-PnPFileMetadata` to copy Metadata fields (Created, Modified, Author, Editor) between items [#5072](https://github.com/pnp/powershell/pull/5072)
 - Added `-NewFileName` parameter to `Convert-PnPFile` cmdlet to choose custom output file name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Current nightly]
 
 ### Added
+- Added `Get-PnPListVersionPolicy` and `Set-PnPListVersionPolicy` cmdlets to inspect and manage SharePoint Online document library version policies.
 - Added `Add-PnPEntraIDServicePrincipalAppRoleAssignment`, `Get-PnPEntraIDServicePrincipalAppRoleAssignment`, and `Remove-PnPEntraIDServicePrincipalAppRoleAssignment` cmdlets to manage Entra ID user and group enterprise application assignments with app roles [#5292](https://github.com/pnp/powershell/pull/5292)
 - Added `Copy-PnPFileMetadata` to copy Metadata fields (Created, Modified, Author, Editor) between items [#5072](https://github.com/pnp/powershell/pull/5072)
 - Added `-NewFileName` parameter to `Convert-PnPFile` cmdlet to choose custom output file name.

--- a/documentation/Get-PnPListVersionPolicy.md
+++ b/documentation/Get-PnPListVersionPolicy.md
@@ -1,0 +1,94 @@
+---
+Module Name: PnP.PowerShell
+title: Get-PnPListVersionPolicy
+schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/Get-PnPListVersionPolicy.html
+---
+
+# Get-PnPListVersionPolicy
+
+## SYNOPSIS
+Gets file version policy settings from a SharePoint Online document library.
+
+## SYNTAX
+
+```powershell
+Get-PnPListVersionPolicy
+ -Identity <ListPipeBind>
+ [-Site <SitePipeBind>]
+ [-Connection <PnPConnection>]
+```
+
+## DESCRIPTION
+Retrieves the effective version policy settings for a document library. When `-Site` is provided, the cmdlet resolves the library from that site and reads the library version policy through the SharePoint Online admin APIs.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-PnPListVersionPolicy -Identity "Documents"
+```
+
+Returns the version policy settings for the `Documents` library in the currently connected site.
+
+### EXAMPLE 2
+```powershell
+Get-PnPListVersionPolicy -Site "https://contoso.sharepoint.com/sites/project-x" -Identity "Documents"
+```
+
+Returns the version policy settings for the `Documents` library in the specified site.
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+The document library to inspect. You can provide the library title, id, url, or a list instance.
+
+```yaml
+Type: ListPipeBind
+Parameter Sets: (All)
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True
+Accept wildcard characters: False
+```
+
+### -Site
+Optional target site containing the document library. When omitted, the cmdlet uses the currently connected SharePoint site.
+
+```yaml
+Type: SitePipeBind
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## OUTPUTS
+
+### PnP.PowerShell.Commands.Model.SharePoint.ListVersionPolicy
+Contains the library version policy settings and any file type override settings.
+
+## RELATED LINKS
+
+[Set-PnPListVersionPolicy](Set-PnPListVersionPolicy.md)

--- a/documentation/Set-PnPListVersionPolicy.md
+++ b/documentation/Set-PnPListVersionPolicy.md
@@ -25,6 +25,7 @@ Set-PnPListVersionPolicy
  [-MajorVersionLimit <Int32>]
  [-MajorWithMinorVersionsLimit <Int32>]
  [-FileTypes <String[]>]
+ [-NoWait]
  [-Connection <PnPConnection>]
 ```
 
@@ -37,6 +38,7 @@ Set-PnPListVersionPolicy
  -Sync
  [-FileTypes <String[]>]
  [-ExcludeDefaultPolicy]
+ [-NoWait]
  [-Connection <PnPConnection>]
 ```
 
@@ -47,11 +49,12 @@ Set-PnPListVersionPolicy
  -Identity <ListPipeBind>
  [-Site <SitePipeBind>]
  -RemoveVersionExpirationFileTypeOverride <String[]>
+ [-NoWait]
  [-Connection <PnPConnection>]
 ```
 
 ## DESCRIPTION
-Configures the versioning policy for a document library in the currently connected site. The cmdlet resolves the library from the active SharePoint connection and uses the SharePoint Online admin APIs to apply the requested library version policy action.
+Configures the versioning policy for a document library in the currently connected site. The cmdlet resolves the library from the active SharePoint connection and uses the SharePoint Online admin APIs to apply the requested library version policy action. By default it waits for the tenant operation to complete. Use `-NoWait` to return immediately after the operation has been queued.
 
 ## EXAMPLES
 
@@ -103,6 +106,13 @@ Set-PnPListVersionPolicy -Site "https://contoso.sharepoint.com/sites/project-x" 
 ```
 
 Enables automatic version expiration for a document library on a specific site.
+
+### EXAMPLE 8
+```powershell
+Set-PnPListVersionPolicy -Identity "Documents" -Sync -NoWait
+```
+
+Queues the library version policy synchronization request and returns immediately without waiting for the tenant operation to complete.
 
 ## PARAMETERS
 
@@ -210,6 +220,20 @@ The maximum number of major versions for which minor versions are retained. Spec
 ```yaml
 Type: Nullable`1[Int32]
 Parameter Sets: Set Policy
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoWait
+Queues the version policy operation and returns immediately instead of waiting for the SharePoint Online tenant operation to complete.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
 
 Required: False
 Position: Named

--- a/documentation/Set-PnPListVersionPolicy.md
+++ b/documentation/Set-PnPListVersionPolicy.md
@@ -1,0 +1,263 @@
+---
+Module Name: PnP.PowerShell
+title: Set-PnPListVersionPolicy
+schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/Set-PnPListVersionPolicy.html
+---
+
+# Set-PnPListVersionPolicy
+
+## SYNOPSIS
+Sets, synchronizes, or removes file version policy settings on a SharePoint Online document library.
+
+## SYNTAX
+
+### Set Policy
+
+```powershell
+Set-PnPListVersionPolicy
+ -Identity <ListPipeBind>
+ -EnableAutoExpirationVersionTrim <Boolean>
+ [-Site <SitePipeBind>]
+ [-ExpireVersionsAfterDays <Int32>]
+ [-MajorVersionLimit <Int32>]
+ [-MajorWithMinorVersionsLimit <Int32>]
+ [-FileTypes <String[]>]
+ [-Connection <PnPConnection>]
+```
+
+### Sync Policy
+
+```powershell
+Set-PnPListVersionPolicy
+ -Identity <ListPipeBind>
+ [-Site <SitePipeBind>]
+ -Sync
+ [-FileTypes <String[]>]
+ [-ExcludeDefaultPolicy]
+ [-Connection <PnPConnection>]
+```
+
+### Remove File Type Overrides
+
+```powershell
+Set-PnPListVersionPolicy
+ -Identity <ListPipeBind>
+ [-Site <SitePipeBind>]
+ -RemoveVersionExpirationFileTypeOverride <String[]>
+ [-Connection <PnPConnection>]
+```
+
+## DESCRIPTION
+Configures the versioning policy for a document library in the currently connected site. The cmdlet resolves the library from the active SharePoint connection and uses the SharePoint Online admin APIs to apply the requested library version policy action.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Set-PnPListVersionPolicy -Identity "Documents" -EnableAutoExpirationVersionTrim $true
+```
+
+Enables automatic version expiration for the specified document library.
+
+### EXAMPLE 2
+```powershell
+Set-PnPListVersionPolicy -Identity "Documents" -EnableAutoExpirationVersionTrim $false -ExpireVersionsAfterDays 180 -MajorVersionLimit 100 -MajorWithMinorVersionsLimit 20
+```
+
+Sets a manual version policy for the specified document library.
+
+### EXAMPLE 3
+```powershell
+Set-PnPListVersionPolicy -Identity "Documents" -EnableAutoExpirationVersionTrim $false -ExpireVersionsAfterDays 180 -MajorVersionLimit 100 -MajorWithMinorVersionsLimit 20 -FileTypes "pdf","docx"
+```
+
+Sets a manual version policy override for the specified file types in the document library.
+
+### EXAMPLE 4
+```powershell
+Set-PnPListVersionPolicy -Identity "Documents" -Sync -FileTypes "pdf","docx"
+```
+
+Synchronizes the version policy for the specified file types in the document library.
+
+### EXAMPLE 5
+```powershell
+Set-PnPListVersionPolicy -Identity "Documents" -Sync -ExcludeDefaultPolicy
+```
+
+Synchronizes the document library version policy while excluding the default policy.
+
+### EXAMPLE 6
+```powershell
+Set-PnPListVersionPolicy -Identity "Documents" -RemoveVersionExpirationFileTypeOverride "pdf","docx"
+```
+
+Removes version policy file type overrides from the specified document library.
+
+### EXAMPLE 7
+```powershell
+Set-PnPListVersionPolicy -Site "https://contoso.sharepoint.com/sites/project-x" -Identity "Documents" -EnableAutoExpirationVersionTrim $true
+```
+
+Enables automatic version expiration for a document library on a specific site.
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableAutoExpirationVersionTrim
+Enables or disables AutoExpiration version trimming on the document library. When set to `$false`, you must also specify `ExpireVersionsAfterDays`, `MajorVersionLimit`, and `MajorWithMinorVersionsLimit`.
+
+```yaml
+Type: Boolean
+Parameter Sets: Set Policy
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExcludeDefaultPolicy
+Excludes the default policy while synchronizing the document library version policy.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Sync Policy
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExpireVersionsAfterDays
+The number of days after which versions expire. Specify `0` for no expiration, or a value from `30` through `36500`.
+
+```yaml
+Type: Nullable`1[Int32]
+Parameter Sets: Set Policy
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FileTypes
+The file types for which the library version policy should be applied or synchronized.
+
+```yaml
+Type: String[]
+Parameter Sets: Set Policy, Sync Policy
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+The document library to update. You can provide the library title, id, url, or a list instance.
+
+```yaml
+Type: ListPipeBind
+Parameter Sets: (All)
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True
+Accept wildcard characters: False
+```
+
+### -MajorVersionLimit
+The maximum number of major versions to keep. Specify a value from `1` through `50000`.
+
+```yaml
+Type: Nullable`1[Int32]
+Parameter Sets: Set Policy
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MajorWithMinorVersionsLimit
+The maximum number of major versions for which minor versions are retained. Specify a value from `0` through `50000`.
+
+```yaml
+Type: Nullable`1[Int32]
+Parameter Sets: Set Policy
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Site
+Optional target site containing the document library. When omitted, the cmdlet uses the currently connected SharePoint site.
+
+```yaml
+Type: SitePipeBind
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RemoveVersionExpirationFileTypeOverride
+Removes version expiration overrides for the specified file types from the document library.
+
+```yaml
+Type: String[]
+Parameter Sets: Remove File Type Overrides
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Sync
+Synchronizes the document library version policy.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Sync Policy
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+## RELATED LINKS
+[Get-PnPListVersionPolicy](Get-PnPListVersionPolicy.md)

--- a/src/Commands/Lists/GetListVersionPolicy.cs
+++ b/src/Commands/Lists/GetListVersionPolicy.cs
@@ -1,0 +1,111 @@
+using Microsoft.Online.SharePoint.TenantAdministration;
+using Microsoft.SharePoint.Client;
+using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Model.SharePoint;
+using System;
+using System.Collections.Generic;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Lists
+{
+	[Cmdlet(VerbsCommon.Get, "PnPListVersionPolicy")]
+	[RequiredApiDelegatedPermissions("sharepoint/AllSites.FullControl")]
+	[RequiredApiApplicationPermissions("sharepoint/Sites.FullControl.All")]
+	[OutputType(typeof(ListVersionPolicy))]
+	public class GetListVersionPolicy : ListVersionPolicyCmdletBase
+	{
+		protected override void ExecuteCmdlet()
+		{
+			var targetSiteUrl = GetTargetSiteUrl();
+			var list = GetListOrWarn(l => l.BaseType);
+			if (list is null)
+			{
+				return;
+			}
+
+			if (list.BaseType != BaseType.DocumentLibrary)
+			{
+				throw new PSArgumentException("The specified list must be a document library.", nameof(Identity));
+			}
+
+			var libraryParameters = new SPOListParameters
+			{
+				Id = list.Id,
+				Title = list.Title
+			};
+
+			var fileVersionPolicyResult = Tenant.GetFileVersionPolicyForLibrary(targetSiteUrl, libraryParameters);
+			AdminContext.ExecuteQueryRetry();
+
+			if (fileVersionPolicyResult?.Value == null)
+			{
+				return;
+			}
+
+			var fileVersionPolicy = fileVersionPolicyResult.Value;
+			var listVersionPolicy = new ListVersionPolicy
+			{
+				VersioningEnabled = fileVersionPolicy.VersioningEnabled,
+				MinorVersionsEnabled = null,
+				EnableAutoExpirationVersionTrim = null,
+				ExpireVersionsAfterDays = null,
+				MajorVersionLimit = null,
+				MajorWithMinorVersionsLimit = null,
+				FileTypesForVersionExpiration = null,
+				VersionPolicyFileTypeOverride = null
+			};
+
+			if (fileVersionPolicy.VersioningEnabled)
+			{
+				listVersionPolicy.MinorVersionsEnabled = fileVersionPolicy.MinorVersionsEnabled;
+				listVersionPolicy.EnableAutoExpirationVersionTrim = fileVersionPolicy.EnableAutoExpirationVersionTrim;
+				listVersionPolicy.FileTypesForVersionExpiration = fileVersionPolicy.FileTypesForVersionExpiration;
+
+				if (fileVersionPolicy.MinorVersionsEnabled)
+				{
+					listVersionPolicy.MajorWithMinorVersionsLimit = fileVersionPolicy.MajorWithMinorVersionsLimit;
+				}
+
+				if (!fileVersionPolicy.EnableAutoExpirationVersionTrim)
+				{
+					listVersionPolicy.ExpireVersionsAfterDays = fileVersionPolicy.ExpireVersionsAfterDays;
+					listVersionPolicy.MajorVersionLimit = fileVersionPolicy.MajorVersionLimit;
+				}
+
+				listVersionPolicy.VersionPolicyFileTypeOverride = CreateFileTypeOverrides(fileVersionPolicy.VersionPolicyFileTypeOverride, fileVersionPolicy.MinorVersionsEnabled);
+			}
+
+			WriteObject(listVersionPolicy);
+		}
+
+		private static Dictionary<string, ListVersionPolicyFileTypeSettings> CreateFileTypeOverrides(SPOFileVersionFileTypePolicySettings[] fileTypeOverrides, bool minorVersionsEnabled)
+		{
+			var overrides = new Dictionary<string, ListVersionPolicyFileTypeSettings>(StringComparer.OrdinalIgnoreCase);
+
+			if (fileTypeOverrides == null)
+			{
+				return overrides;
+			}
+
+			foreach (var fileTypeOverride in fileTypeOverrides)
+			{
+				overrides[fileTypeOverride.Name] = new ListVersionPolicyFileTypeSettings
+				{
+					Name = fileTypeOverride.Name,
+					Extensions = fileTypeOverride.Extensions,
+					EnableAutoExpirationVersionTrim = fileTypeOverride.EnableAutoExpirationVersionTrim,
+					ExpireVersionsAfterDays = fileTypeOverride.EnableAutoExpirationVersionTrim ? null : GetExpireVersionsAfterDays(fileTypeOverride.ExpireVersionsAfter),
+					MajorVersionLimit = fileTypeOverride.EnableAutoExpirationVersionTrim ? null : fileTypeOverride.MajorVersionLimit,
+					MajorWithMinorVersionsLimit = minorVersionsEnabled ? fileTypeOverride.MajorWithMinorVersionsLimit : null
+				};
+			}
+
+			return overrides;
+		}
+
+		private static int? GetExpireVersionsAfterDays(TimeSpan expireVersionsAfter)
+		{
+			return (int)Math.Round(expireVersionsAfter.TotalDays, MidpointRounding.AwayFromZero);
+		}
+	}
+}

--- a/src/Commands/Lists/ListVersionPolicyCmdletBase.cs
+++ b/src/Commands/Lists/ListVersionPolicyCmdletBase.cs
@@ -1,0 +1,100 @@
+using Microsoft.SharePoint.Client;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Base.Completers;
+using PnP.PowerShell.Commands.Base.PipeBinds;
+using System;
+using System.Linq.Expressions;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Lists
+{
+	public abstract class ListVersionPolicyCmdletBase : PnPSharePointOnlineAdminCmdlet
+	{
+		[Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
+		[ValidateNotNull]
+		[ArgumentCompleter(typeof(ListNameCompleter))]
+		public ListPipeBind Identity;
+
+		[Parameter(Mandatory = false)]
+		public SitePipeBind Site;
+
+		protected List GetListOrWarn(params Expression<Func<List, object>>[] retrievals)
+		{
+			var targetWebUrl = GetTargetWebUrl();
+			if (string.Equals(targetWebUrl, Connection.Url.TrimEnd('/'), StringComparison.OrdinalIgnoreCase))
+			{
+				return Identity.GetListOrWarn(this, ClientContext.Web, retrievals);
+			}
+
+			using var targetWebContext = Connection.CloneContext(targetWebUrl);
+			return Identity.GetListOrWarn(this, targetWebContext.Web, retrievals);
+		}
+
+		protected string GetTargetSiteUrl()
+		{
+			if (!ParameterSpecified(nameof(Site)))
+			{
+				return ClientContext.Site.EnsureProperty(s => s.Url).TrimEnd('/');
+			}
+
+			if (Site.Site != null)
+			{
+				Site.Site.EnsureProperty(s => s.Url);
+				return Site.Site.Url.TrimEnd('/');
+			}
+
+			if (!string.IsNullOrEmpty(Site.Url))
+			{
+				using var targetWebContext = Connection.CloneContext(Site.Url.TrimEnd('/'));
+				targetWebContext.Load(targetWebContext.Site, s => s.Url);
+				targetWebContext.ExecuteQueryRetry();
+				return targetWebContext.Site.Url.TrimEnd('/');
+			}
+
+			if (Site.Id != Guid.Empty)
+			{
+				var siteProperties = Tenant.GetSitePropertiesById(Site.Id, false, Connection.TenantAdminUrl);
+				if (siteProperties == null || string.IsNullOrEmpty(siteProperties.Url))
+				{
+					throw new PSArgumentException("The specified site could not be resolved.", nameof(Site));
+				}
+
+				return siteProperties.Url.TrimEnd('/');
+			}
+
+			throw new PSArgumentException("The Site parameter must be a valid site object, site id, or absolute site url.", nameof(Site));
+		}
+
+		private string GetTargetWebUrl()
+		{
+			if (!ParameterSpecified(nameof(Site)))
+			{
+				return Connection.Url.TrimEnd('/');
+			}
+
+			if (Site.Site != null)
+			{
+				Site.Site.EnsureProperty(s => s.Url);
+				return Site.Site.Url.TrimEnd('/');
+			}
+
+			if (!string.IsNullOrEmpty(Site.Url))
+			{
+				return Site.Url.TrimEnd('/');
+			}
+
+			if (Site.Id != Guid.Empty)
+			{
+				var siteProperties = Tenant.GetSitePropertiesById(Site.Id, false, Connection.TenantAdminUrl);
+				if (siteProperties == null || string.IsNullOrEmpty(siteProperties.Url))
+				{
+					throw new PSArgumentException("The specified site could not be resolved.", nameof(Site));
+				}
+
+				return siteProperties.Url.TrimEnd('/');
+			}
+
+			throw new PSArgumentException("The Site parameter must be a valid site object, site id, or absolute site url.", nameof(Site));
+		}
+	}
+}

--- a/src/Commands/Lists/SetListVersionPolicy.cs
+++ b/src/Commands/Lists/SetListVersionPolicy.cs
@@ -1,0 +1,177 @@
+using Microsoft.Online.SharePoint.TenantAdministration;
+using Microsoft.SharePoint.Client;
+using PnP.PowerShell.Commands.Attributes;
+using System;
+using System.Linq;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Lists
+{
+	[Cmdlet(VerbsCommon.Set, "PnPListVersionPolicy", DefaultParameterSetName = SetPolicyParameterSet)]
+	[RequiredApiDelegatedPermissions("sharepoint/AllSites.FullControl")]
+	[RequiredApiApplicationPermissions("sharepoint/Sites.FullControl.All")]
+	[OutputType(typeof(void))]
+	public class SetListVersionPolicy : ListVersionPolicyCmdletBase
+	{
+		private const string SetPolicyParameterSet = "SetPolicy";
+		private const string RemovePolicyParameterSet = "RemovePolicy";
+		private const string SyncPolicyParameterSet = "SyncPolicy";
+
+		[Parameter(Mandatory = true, ParameterSetName = SetPolicyParameterSet)]
+		public bool EnableAutoExpirationVersionTrim;
+
+		[Parameter(Mandatory = false, ParameterSetName = SetPolicyParameterSet)]
+		public int? ExpireVersionsAfterDays;
+
+		[Parameter(Mandatory = false, ParameterSetName = SetPolicyParameterSet)]
+		public int? MajorVersionLimit;
+
+		[Parameter(Mandatory = false, ParameterSetName = SetPolicyParameterSet)]
+		public int? MajorWithMinorVersionsLimit;
+
+		[Parameter(Mandatory = false, ParameterSetName = SetPolicyParameterSet)]
+		[Parameter(Mandatory = false, ParameterSetName = SyncPolicyParameterSet)]
+		public string[] FileTypes;
+
+		[Parameter(Mandatory = true, ParameterSetName = SyncPolicyParameterSet)]
+		public SwitchParameter Sync;
+
+		[Parameter(Mandatory = false, ParameterSetName = SyncPolicyParameterSet)]
+		public SwitchParameter ExcludeDefaultPolicy;
+
+		[Parameter(Mandatory = true, ParameterSetName = RemovePolicyParameterSet)]
+		[ValidateNotNullOrEmpty]
+		public string[] RemoveVersionExpirationFileTypeOverride;
+
+		protected override void ExecuteCmdlet()
+		{
+			var targetSiteUrl = GetTargetSiteUrl();
+			var list = GetListOrWarn(l => l.BaseType);
+			if (list is null)
+			{
+				return;
+			}
+
+			if (list.BaseType != BaseType.DocumentLibrary)
+			{
+				throw new PSArgumentException("The specified list must be a document library.", nameof(Identity));
+			}
+
+			var normalizedFileTypes = NormalizeFileTypes(FileTypes, nameof(FileTypes));
+			var libraryParameters = new SPOListParameters
+			{
+				Id = list.Id,
+				Title = list.Title
+			};
+
+			SpoOperation operation;
+			switch (ParameterSetName)
+			{
+				case SyncPolicyParameterSet:
+				{
+					operation = Tenant.SyncVersionPolicyForLibrary(targetSiteUrl, libraryParameters, normalizedFileTypes, ExcludeDefaultPolicy.IsPresent);
+					break;
+				}
+				case RemovePolicyParameterSet:
+				{
+					var normalizedOverridesToRemove = NormalizeFileTypes(RemoveVersionExpirationFileTypeOverride, nameof(RemoveVersionExpirationFileTypeOverride));
+					operation = Tenant.RemoveFileTypeVersionPolicyForLibrary(targetSiteUrl, libraryParameters, normalizedOverridesToRemove);
+					break;
+				}
+				default:
+				{
+					ValidateSetPolicyParameters();
+
+					var versionPolicySettings = new SPOFileVersionPolicySettings
+					{
+						EnableAutoExpirationVersionTrim = EnableAutoExpirationVersionTrim,
+						ExpireVersionsAfterDays = EnableAutoExpirationVersionTrim ? -1 : ExpireVersionsAfterDays.Value,
+						MajorVersionLimit = EnableAutoExpirationVersionTrim ? -1 : MajorVersionLimit.Value,
+						MajorWithMinorVersionsLimit = EnableAutoExpirationVersionTrim ? -1 : MajorWithMinorVersionsLimit.Value,
+						FileTypesForVersionExpiration = normalizedFileTypes
+					};
+
+					operation = Tenant.SetFileVersionPolicyForLibrary(targetSiteUrl, libraryParameters, versionPolicySettings);
+					break;
+				}
+			}
+
+			AdminContext.Load(operation);
+			AdminContext.ExecuteQueryRetry();
+		}
+
+		private void ValidateSetPolicyParameters()
+		{
+			if (EnableAutoExpirationVersionTrim)
+			{
+				if (ParameterSpecified(nameof(ExpireVersionsAfterDays)))
+				{
+					throw new PSArgumentException($"Don't specify {nameof(ExpireVersionsAfterDays)} when {nameof(EnableAutoExpirationVersionTrim)} is true.", nameof(ExpireVersionsAfterDays));
+				}
+
+				if (ParameterSpecified(nameof(MajorVersionLimit)))
+				{
+					throw new PSArgumentException($"Don't specify {nameof(MajorVersionLimit)} when {nameof(EnableAutoExpirationVersionTrim)} is true.", nameof(MajorVersionLimit));
+				}
+
+				if (ParameterSpecified(nameof(MajorWithMinorVersionsLimit)))
+				{
+					throw new PSArgumentException($"Don't specify {nameof(MajorWithMinorVersionsLimit)} when {nameof(EnableAutoExpirationVersionTrim)} is true.", nameof(MajorWithMinorVersionsLimit));
+				}
+			}
+			else
+			{
+				if (!ExpireVersionsAfterDays.HasValue)
+				{
+					throw new PSArgumentException($"You must specify {nameof(ExpireVersionsAfterDays)} when {nameof(EnableAutoExpirationVersionTrim)} is false.", nameof(ExpireVersionsAfterDays));
+				}
+
+				if (!MajorVersionLimit.HasValue)
+				{
+					throw new PSArgumentException($"You must specify {nameof(MajorVersionLimit)} when {nameof(EnableAutoExpirationVersionTrim)} is false.", nameof(MajorVersionLimit));
+				}
+
+				if (!MajorWithMinorVersionsLimit.HasValue)
+				{
+					throw new PSArgumentException($"You must specify {nameof(MajorWithMinorVersionsLimit)} when {nameof(EnableAutoExpirationVersionTrim)} is false.", nameof(MajorWithMinorVersionsLimit));
+				}
+
+				if (ExpireVersionsAfterDays.Value != 0 && (ExpireVersionsAfterDays.Value < 30 || ExpireVersionsAfterDays.Value > 36500))
+				{
+					throw new PSArgumentException($"{nameof(ExpireVersionsAfterDays)} must be 0 or between 30 and 36500.", nameof(ExpireVersionsAfterDays));
+				}
+
+				if (MajorVersionLimit.Value < 1 || MajorVersionLimit.Value > 50000)
+				{
+					throw new PSArgumentException($"{nameof(MajorVersionLimit)} must be between 1 and 50000.", nameof(MajorVersionLimit));
+				}
+
+				if (MajorWithMinorVersionsLimit.Value < 0 || MajorWithMinorVersionsLimit.Value > 50000)
+				{
+					throw new PSArgumentException($"{nameof(MajorWithMinorVersionsLimit)} must be between 0 and 50000.", nameof(MajorWithMinorVersionsLimit));
+				}
+			}
+		}
+
+		private static string[] NormalizeFileTypes(string[] fileTypes, string parameterName)
+		{
+			if (fileTypes == null)
+			{
+				return null;
+			}
+
+			var normalizedFileTypes = fileTypes
+				.Select(fileType => fileType?.Trim())
+				.ToArray();
+
+			if (normalizedFileTypes.Length == 0 || normalizedFileTypes.Any(string.IsNullOrWhiteSpace))
+			{
+				throw new PSArgumentException($"The parameter {parameterName} must contain one or more non-empty file types.", parameterName);
+			}
+
+			return normalizedFileTypes
+				.Distinct(StringComparer.OrdinalIgnoreCase)
+				.ToArray();
+		}
+	}
+}

--- a/src/Commands/Lists/SetListVersionPolicy.cs
+++ b/src/Commands/Lists/SetListVersionPolicy.cs
@@ -39,6 +39,9 @@ namespace PnP.PowerShell.Commands.Lists
 		[Parameter(Mandatory = false, ParameterSetName = SyncPolicyParameterSet)]
 		public SwitchParameter ExcludeDefaultPolicy;
 
+		[Parameter(Mandatory = false)]
+		public SwitchParameter NoWait;
+
 		[Parameter(Mandatory = true, ParameterSetName = RemovePolicyParameterSet)]
 		[ValidateNotNullOrEmpty]
 		public string[] RemoveVersionExpirationFileTypeOverride;
@@ -98,6 +101,11 @@ namespace PnP.PowerShell.Commands.Lists
 
 			AdminContext.Load(operation);
 			AdminContext.ExecuteQueryRetry();
+
+			if (!NoWait.ToBool())
+			{
+				PollOperation(operation);
+			}
 		}
 
 		private void ValidateSetPolicyParameters()

--- a/src/Commands/Model/SPOSite.cs
+++ b/src/Commands/Model/SPOSite.cs
@@ -108,6 +108,7 @@ namespace PnP.PowerShell.Commands.Model
         public bool AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled { get; set; }
         public bool HidePeoplePreviewingFiles { get; set; }
         public bool HidePeopleWhoHaveListsOpen { get; set; }
+        public SPOFileVersionFileTypePolicySettings[] VersionPolicyFileTypeOverride { get; set; }
 
         #endregion
 
@@ -210,6 +211,7 @@ namespace PnP.PowerShell.Commands.Model
             AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled = props.AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled;
             HidePeoplePreviewingFiles = props.HidePeoplePreviewingFiles;
             HidePeopleWhoHaveListsOpen = props.HidePeopleWhoHaveListsOpen;
+            VersionPolicyFileTypeOverride = props.VersionPolicyFileTypeOverride;
         }
     }
 }

--- a/src/Commands/Model/SharePoint/ListVersionPolicy.cs
+++ b/src/Commands/Model/SharePoint/ListVersionPolicy.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+
+namespace PnP.PowerShell.Commands.Model.SharePoint
+{
+	/// <summary>
+	/// The version policy settings on a document library.
+	/// </summary>
+	public class ListVersionPolicy
+	{
+		/// <summary>
+		/// Indicates whether versioning is enabled on the library.
+		/// </summary>
+		public bool VersioningEnabled { get; set; }
+
+		/// <summary>
+		/// Indicates whether minor versions are enabled on the library.
+		/// </summary>
+		public bool? MinorVersionsEnabled { get; set; }
+
+		/// <summary>
+		/// Indicates whether AutoExpiration version trimming is enabled.
+		/// </summary>
+		public bool? EnableAutoExpirationVersionTrim { get; set; }
+
+		/// <summary>
+		/// The number of days after which versions expire.
+		/// </summary>
+		public int? ExpireVersionsAfterDays { get; set; }
+
+		/// <summary>
+		/// The maximum number of major versions to keep.
+		/// </summary>
+		public int? MajorVersionLimit { get; set; }
+
+		/// <summary>
+		/// The maximum number of major versions for which minor versions are retained.
+		/// </summary>
+		public int? MajorWithMinorVersionsLimit { get; set; }
+
+		/// <summary>
+		/// The file types for which the version expiration policy applies.
+		/// </summary>
+		public string[] FileTypesForVersionExpiration { get; set; }
+
+		/// <summary>
+		/// The version policy overrides per file type.
+		/// </summary>
+		public Dictionary<string, ListVersionPolicyFileTypeSettings> VersionPolicyFileTypeOverride { get; set; }
+	}
+
+	/// <summary>
+	/// The version policy override settings for a file type.
+	/// </summary>
+	public class ListVersionPolicyFileTypeSettings
+	{
+		/// <summary>
+		/// The name of the file type override.
+		/// </summary>
+		public string Name { get; set; }
+
+		/// <summary>
+		/// The file extensions included in the override.
+		/// </summary>
+		public string[] Extensions { get; set; }
+
+		/// <summary>
+		/// Indicates whether AutoExpiration version trimming is enabled for the file type override.
+		/// </summary>
+		public bool EnableAutoExpirationVersionTrim { get; set; }
+
+		/// <summary>
+		/// The number of days after which versions expire for the file type override.
+		/// </summary>
+		public int? ExpireVersionsAfterDays { get; set; }
+
+		/// <summary>
+		/// The maximum number of major versions to keep for the file type override.
+		/// </summary>
+		public int? MajorVersionLimit { get; set; }
+
+		/// <summary>
+		/// The maximum number of major versions for which minor versions are retained for the file type override.
+		/// </summary>
+		public int? MajorWithMinorVersionsLimit { get; set; }
+	}
+}


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Added new cmdlets to handle list version policy

## What is in this Pull Request ? ##
Added new cmdlets to handle list version policies