### PR TITLE
Add site version policy management features to Set-PnPTenantSite and related commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Added `Get-PnPListVersionPolicy` and `Set-PnPListVersionPolicy` cmdlets to inspect and manage SharePoint Online document library version policies. [#5299](https://github.com/pnp/powershell/pull/5299)
+- Added `New-PnPSiteManageVersionPolicyJob` cmdlet to queue site-level list version policy trim and sync jobs. [#5299](https://github.com/pnp/powershell/pull/5299)
+- Added site version policy parameters to `Set-PnPSite` and `Set-PnPTenantSite`, including support for inheriting tenant defaults, targeting new or existing document libraries, managing file type overrides, and bypassing confirmation with `-Force`. [#5299](https://github.com/pnp/powershell/pull/5299)
+- Added `DisableClassicPageBaselineSecurityMode`, `DisableSiteBranding`, `AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled`, `IsAuthoritative`, and `RestrictedContentDiscoveryforCopilotAndAgents` parameters to `Set-PnPSite` and `Set-PnPTenantSite`. [#5299](https://github.com/pnp/powershell/pull/5299)
 - Added `Add-PnPEntraIDServicePrincipalAppRoleAssignment`, `Get-PnPEntraIDServicePrincipalAppRoleAssignment`, and `Remove-PnPEntraIDServicePrincipalAppRoleAssignment` cmdlets to manage Entra ID user and group enterprise application assignments with app roles [#5292](https://github.com/pnp/powershell/pull/5292)
 - Added `Copy-PnPFileMetadata` to copy Metadata fields (Created, Modified, Author, Editor) between items [#5072](https://github.com/pnp/powershell/pull/5072)
 - Added `-NewFileName` parameter to `Convert-PnPFile` cmdlet to choose custom output file name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Current nightly]
 
 ### Added
-- Added `Get-PnPListVersionPolicy` and `Set-PnPListVersionPolicy` cmdlets to inspect and manage SharePoint Online document library version policies. [#5299](https://github.com/pnp/powershell/pull/5299)
-- Added `New-PnPSiteManageVersionPolicyJob` cmdlet to queue site-level list version policy trim and sync jobs. [#5299](https://github.com/pnp/powershell/pull/5299)
-- Added site version policy parameters to `Set-PnPSite` and `Set-PnPTenantSite`, including support for inheriting tenant defaults, targeting new or existing document libraries, managing file type overrides, and bypassing confirmation with `-Force`. [#5299](https://github.com/pnp/powershell/pull/5299)
-- Added `DisableClassicPageBaselineSecurityMode`, `DisableSiteBranding`, `AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled`, `IsAuthoritative`, and `RestrictedContentDiscoveryforCopilotAndAgents` parameters to `Set-PnPSite` and `Set-PnPTenantSite`. [#5299](https://github.com/pnp/powershell/pull/5299)
+- Added `Get-PnPListVersionPolicy` and `Set-PnPListVersionPolicy` cmdlets to inspect and manage SharePoint Online document library version policies. [#5300](https://github.com/pnp/powershell/pull/5300)
+- Added `New-PnPSiteManageVersionPolicyJob` cmdlet to queue site-level list version policy trim and sync jobs. [#5300](https://github.com/pnp/powershell/pull/5300)
+- Added site version policy parameters to `Set-PnPSite` and `Set-PnPTenantSite`, including support for inheriting tenant defaults, targeting new or existing document libraries, managing file type overrides, and bypassing confirmation with `-Force`. [#5300](https://github.com/pnp/powershell/pull/5300)
+- Added `DisableClassicPageBaselineSecurityMode`, `DisableSiteBranding`, `AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled`, `IsAuthoritative`, and `RestrictedContentDiscoveryForCopilotAndAgents` parameters to `Set-PnPSite` and `Set-PnPTenantSite`. [#5300](https://github.com/pnp/powershell/pull/5300)
 - Added `Add-PnPEntraIDServicePrincipalAppRoleAssignment`, `Get-PnPEntraIDServicePrincipalAppRoleAssignment`, and `Remove-PnPEntraIDServicePrincipalAppRoleAssignment` cmdlets to manage Entra ID user and group enterprise application assignments with app roles [#5292](https://github.com/pnp/powershell/pull/5292)
 - Added `Copy-PnPFileMetadata` to copy Metadata fields (Created, Modified, Author, Editor) between items [#5072](https://github.com/pnp/powershell/pull/5072)
 - Added `-NewFileName` parameter to `Convert-PnPFile` cmdlet to choose custom output file name.

--- a/documentation/New-PnPSiteManageVersionPolicyJob.md
+++ b/documentation/New-PnPSiteManageVersionPolicyJob.md
@@ -1,0 +1,173 @@
+---
+Module Name: PnP.PowerShell
+schema: 2.0.0
+applicable: SharePoint Online
+online version: https://pnp.github.io/powershell/cmdlets/New-PnPSiteManageVersionPolicyJob.html
+external help file: PnP.PowerShell.dll-Help.xml
+title: New-PnPSiteManageVersionPolicyJob
+---
+
+# New-PnPSiteManageVersionPolicyJob
+
+## SYNOPSIS
+
+Starts a site-level version policy management job for a SharePoint Online site collection.
+
+## SYNTAX
+
+### TrimUseListPolicy
+
+```powershell
+New-PnPSiteManageVersionPolicyJob -Identity <SitePipeBind> -TrimUseListPolicy [-SyncListPolicy] [-FileTypes <String[]>] [-ExcludeDefaultPolicy] [-NoWait] [-Force] [-Connection <PnPConnection>]
+```
+
+### SyncListPolicy
+
+```powershell
+New-PnPSiteManageVersionPolicyJob -Identity <SitePipeBind> -SyncListPolicy [-FileTypes <String[]>] [-ExcludeDefaultPolicy] [-NoWait] [-Force] [-Connection <PnPConnection>]
+```
+
+## DESCRIPTION
+
+Starts a site-level job that can trim versions using existing list version policies, synchronize list version policies across libraries, or do both in a single operation. By default, the cmdlet waits for the tenant operation to complete. Use `-NoWait` to return immediately after the job has been queued.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+New-PnPSiteManageVersionPolicyJob -Identity "https://contoso.sharepoint.com/sites/project-x" -SyncListPolicy
+```
+
+Queues a site-level job that synchronizes list version policies across the target site collection.
+
+### EXAMPLE 2
+```powershell
+New-PnPSiteManageVersionPolicyJob -Identity "https://contoso.sharepoint.com/sites/project-x" -TrimUseListPolicy -SyncListPolicy -Force
+```
+
+Queues a site-level job that trims versions using each library's list version policy and then synchronizes list version policies across the site collection, without prompting for confirmation.
+
+### EXAMPLE 3
+```powershell
+New-PnPSiteManageVersionPolicyJob -Identity "https://contoso.sharepoint.com/sites/project-x" -TrimUseListPolicy -FileTypes "pdf","docx" -ExcludeDefaultPolicy -NoWait
+```
+
+Queues a site-level job that trims versions only for the specified file types, excludes the default policy, and returns immediately without waiting for the tenant operation to complete.
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by either specifying -ReturnConnection on Connect-PnPOnline or by executing Get-PnPConnection.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExcludeDefaultPolicy
+Excludes the default version policy from the site management job. This can be combined with `-FileTypes` to target only specific file types.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FileTypes
+The file types to include in the version policy management job. When omitted, all file types are included.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+When provided together with `-TrimUseListPolicy`, no confirmation prompt will be shown before creating the job.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+The site collection on which to run the version policy management job.
+
+```yaml
+Type: SitePipeBind
+Parameter Sets: (All)
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True
+Accept wildcard characters: False
+```
+
+### -NoWait
+Queues the version policy management job and returns immediately instead of waiting for the SharePoint Online tenant operation to complete.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SyncListPolicy
+Synchronizes the list version policies across document libraries in the site collection.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: TrimUseListPolicy, SyncListPolicy
+
+Required: True (SyncListPolicy), False (TrimUseListPolicy)
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TrimUseListPolicy
+Trims file versions using the existing version policy configured on each document library in the site collection.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: TrimUseListPolicy
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## RELATED LINKS
+
+[Get-PnPSiteFileVersionBatchDeleteJobStatus](Get-PnPSiteFileVersionBatchDeleteJobStatus.md)

--- a/documentation/Set-PnPSite.md
+++ b/documentation/Set-PnPSite.md
@@ -25,6 +25,8 @@ Set-PnPSite
  [-StorageMaximumLevel <Int64>]
  [-StorageWarningLevel <Int64>]
  [-AllowSelfServiceUpgrade]
+ [-DisableClassicPageBaselineSecurityMode <Boolean>]
+ [-DisableSiteBranding <Boolean>]
  [-NoScriptSite]
  [-Owners <System.Collections.Generic.List<[System.String]>]
  [-CommentsOnSitePagesDisabled]
@@ -40,6 +42,9 @@ Set-PnPSite
  [-SocialBarOnSitePagesDisabled]
  [-AnonymousLinkExpirationInDays <Int32>]
  [-RequestFilesLinkExpirationInDays <Int32>]
+ [-AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled <Boolean>]
+ [-IsAuthoritative <Boolean>]
+ [-RestrictedContentDiscoveryforCopilotAndAgents <Boolean>]
  [-OverrideTenantAnonymousLinkExpirationPolicy]
  [-MediaTranscription <MediaTranscriptionPolicyType>]
  [-SensitivityLabel <Guid>]
@@ -53,6 +58,16 @@ Set-PnPSite
  [-RestrictContentOrgWideSearch <Boolean>]
  [-CanSyncHubSitePermissions <SwitchParameter>]
  [-ClearGroupId]
+ [-InheritVersionPolicyFromTenant]
+ [-EnableAutoExpirationVersionTrim <Boolean>]
+ [-ExpireVersionsAfterDays <Int32>]
+ [-MajorVersionLimit <Int32>]
+ [-MajorWithMinorVersionsLimit <Int32>]
+ [-FileTypesForVersionExpiration <String[]>]
+ [-RemoveVersionExpirationFileTypeOverride <String[]>]
+ [-ApplyToNewDocumentLibraries]
+ [-ApplyToExistingDocumentLibraries]
+ [-Force]
  [-HidePeoplePreviewingFiles <Boolean>]
  [-HidePeopleWhoHaveListsOpen <Boolean>]
  [-RestrictedAccessControl <Boolean>]
@@ -112,6 +127,34 @@ Set-PnPSite -NoScriptSite $false
 
 Allows custom script on a specific site. See [Allow or prevent custom script](https://learn.microsoft.com/sharepoint/allow-or-prevent-custom-script) for more information.
 
+### EXAMPLE 7
+```powershell
+Set-PnPSite -EnableAutoExpirationVersionTrim $false -ExpireVersionsAfterDays 180 -MajorVersionLimit 100 -MajorWithMinorVersionsLimit 10
+```
+
+Sets the site version policy for both new and existing document libraries to keep 100 major versions, 10 minor versions, and expire versions after 180 days.
+
+### EXAMPLE 8
+```powershell
+Set-PnPSite -EnableAutoExpirationVersionTrim $true -ApplyToNewDocumentLibraries -FileTypesForVersionExpiration "pdf","docx"
+```
+
+Sets an automatic version trim policy for new document libraries only and limits the override to the specified file types.
+
+### EXAMPLE 9
+```powershell
+Set-PnPSite -ApplyToNewDocumentLibraries -RemoveVersionExpirationFileTypeOverride "pdf","docx"
+```
+
+Removes the specified file type version expiration overrides from the site policy for new document libraries.
+
+### EXAMPLE 10
+```powershell
+Set-PnPSite -InheritVersionPolicyFromTenant
+```
+
+Resets the site version policy so new document libraries inherit the tenant-level defaults.
+
 ## PARAMETERS
 
 ### -AllowSelfServiceUpgrade
@@ -119,6 +162,34 @@ Specifies if the site administrator can upgrade the site collection.
 
 ```yaml
 Type: SwitchParameter
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisableClassicPageBaselineSecurityMode
+Enables or disables classic page baseline security mode for the site collection.
+
+```yaml
+Type: Boolean
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisableSiteBranding
+Enables or disables site branding for the site collection.
+
+```yaml
+Type: Boolean
 Parameter Sets: Set Properties
 
 Required: False
@@ -144,6 +215,34 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ApplyToExistingDocumentLibraries
+Applies the configured site version policy to existing document libraries. If neither this parameter nor `-ApplyToNewDocumentLibraries` is provided, the cmdlet targets both new and existing document libraries.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ApplyToNewDocumentLibraries
+Applies the configured site version policy to new document libraries. If neither this parameter nor `-ApplyToExistingDocumentLibraries` is provided, the cmdlet targets both new and existing document libraries.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -RequestFilesLinkExpirationInDays
 Specifies the number of days before a Request Files link expires for the site.
 
@@ -151,6 +250,48 @@ The value can be from 0 to 730 days.
 
 ```yaml
 Type: Int32
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled
+Enables or disables adding and updating web property bag values when DenyAddAndCustomizePages is enabled.
+
+```yaml
+Type: Boolean
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsAuthoritative
+Marks the site collection as authoritative or not authoritative.
+
+```yaml
+Type: Boolean
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RestrictedContentDiscoveryforCopilotAndAgents
+Restricts content discovery for Copilot and agents on the site collection.
+
+```yaml
+Type: Boolean
 Parameter Sets: Set Properties
 
 Required: False
@@ -318,6 +459,62 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -EnableAutoExpirationVersionTrim
+Enables or disables automatic version trim for the site version policy. Set this to `$true` to use automatic trimming. Set it to `$false` to provide explicit values for `-ExpireVersionsAfterDays` and `-MajorVersionLimit`, and also `-MajorWithMinorVersionsLimit` when existing document libraries are included.
+
+```yaml
+Type: Boolean
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExpireVersionsAfterDays
+Sets the number of days after which versions expire when `-EnableAutoExpirationVersionTrim` is `$false`. Use `0` to keep versions indefinitely. Allowed values are `0` or from `30` through `36500`.
+
+```yaml
+Type: Int32
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FileTypesForVersionExpiration
+Limits the site version policy override to the specified file types. This parameter can only be used when `-EnableAutoExpirationVersionTrim` is also provided and cannot be combined with `-ApplyToExistingDocumentLibraries`.
+
+```yaml
+Type: String[]
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+Bypasses the confirmation prompt when applying site version policy changes that target new document libraries, existing document libraries, or both.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -HidePeoplePreviewingFiles
 Allows hiding of the presence indicators of users simultaneously editing files.
 
@@ -355,6 +552,20 @@ The url of the site collection.
 Type: String
 Parameter Sets: (All)
 Aliases: Url
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InheritVersionPolicyFromTenant
+Resets the site version policy so new document libraries inherit the tenant-level version policy settings.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Set Properties
 
 Required: False
 Position: Named
@@ -401,6 +612,34 @@ If the modern site has a Microsoft 365 Group behind it, use [Set-PnPWebHeader -S
 
 ```yaml
 Type: String
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MajorVersionLimit
+Sets the maximum number of major versions to retain when `-EnableAutoExpirationVersionTrim` is `$false`. Allowed values are from `1` through `50000`.
+
+```yaml
+Type: Int32
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MajorWithMinorVersionsLimit
+Sets the maximum number of major and minor versions to retain when `-EnableAutoExpirationVersionTrim` is `$false` and the policy applies to existing document libraries. Allowed values are from `0` through `50000`.
+
+```yaml
+Type: Int32
 Parameter Sets: Set Properties
 
 Required: False
@@ -546,6 +785,20 @@ Allows configuring whether users will be able to create anonymous requests for p
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RemoveVersionExpirationFileTypeOverride
+Removes one or more file type version expiration overrides from the site policy for new document libraries. This parameter must be combined with `-ApplyToNewDocumentLibraries` and cannot be combined with the other version policy setting parameters.
+
+```yaml
+Type: String[]
+Parameter Sets: Set Properties
 
 Required: False
 Position: Named

--- a/documentation/Set-PnPSite.md
+++ b/documentation/Set-PnPSite.md
@@ -44,7 +44,7 @@ Set-PnPSite
  [-RequestFilesLinkExpirationInDays <Int32>]
  [-AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled <Boolean>]
  [-IsAuthoritative <Boolean>]
- [-RestrictedContentDiscoveryforCopilotAndAgents <Boolean>]
+ [-RestrictedContentDiscoveryForCopilotAndAgents <Boolean>]
  [-OverrideTenantAnonymousLinkExpirationPolicy]
  [-MediaTranscription <MediaTranscriptionPolicyType>]
  [-SensitivityLabel <Guid>]
@@ -287,7 +287,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -RestrictedContentDiscoveryforCopilotAndAgents
+### -RestrictedContentDiscoveryForCopilotAndAgents
 Restricts content discovery for Copilot and agents on the site collection.
 
 ```yaml

--- a/documentation/Set-PnPTenantSite.md
+++ b/documentation/Set-PnPTenantSite.md
@@ -50,7 +50,7 @@ Set-PnPTenantSite [-Identity] <String> [-Title <String>] [-LocaleId <UInt32>] [-
  [-EnableAutoExpirationVersionTrim <Boolean>] [-ExpireVersionsAfterDays <Int32>] [-MajorVersionLimit <Int32>]
  [-MajorWithMinorVersionsLimit <Int32>] [-FileTypesForVersionExpiration <String[]>]
  [-RemoveVersionExpirationFileTypeOverride <String[]>] [-ApplyToNewDocumentLibraries] [-ApplyToExistingDocumentLibraries] [-Force]
- [-AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled <Boolean>] [-IsAuthoritative <Boolean>] [-RestrictedContentDiscoveryforCopilotAndAgents <Boolean>]
+ [-AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled <Boolean>] [-IsAuthoritative <Boolean>] [-RestrictedContentDiscoveryForCopilotAndAgents <Boolean>]
  [-ClearGroupId]
  [-Wait] 
  [-Connection <PnPConnection>] 
@@ -1143,7 +1143,7 @@ Accept wildcard characters: False
 ```
 
 ### -InheritVersionPolicyFromTenant
-Clears the file version setting at site level.
+Resets the site version policy to inherit the default version policy from the tenant.
 
 ```yaml
 Type: SwitchParameter
@@ -1270,7 +1270,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -RestrictedContentDiscoveryforCopilotAndAgents
+### -RestrictedContentDiscoveryForCopilotAndAgents
 Restricts content discovery for Copilot and agents on the site collection.
 
 ```yaml

--- a/documentation/Set-PnPTenantSite.md
+++ b/documentation/Set-PnPTenantSite.md
@@ -22,6 +22,7 @@ Updates settings of a site collection
 ### Set Properties
 ```powershell
 Set-PnPTenantSite [-Identity] <String> [-Title <String>] [-LocaleId <UInt32>] [-AllowSelfServiceUpgrade]
+ [-DisableClassicPageBaselineSecurityMode <Boolean>] [-DisableSiteBranding <Boolean>]
  [-PrimarySiteCollectionAdmin <String>]
  [-Owners <String[]>] [-DenyAddAndCustomizePages]
  [-SharingCapability <SharingCapabilities>] [-StorageQuota <Int64>] [-StorageQuotaWarningLevel <Int64>] [-StorageQuotaReset] [-BlockDownloadLinksFileType <BlockDownloadLinksFileTypes>]
@@ -45,8 +46,11 @@ Set-PnPTenantSite [-Identity] <String> [-Title <String>] [-LocaleId <UInt32>] [-
  [-LoopDefaultSharingLinkScope <SharingScope>] [-RestrictContentOrgWideSearch <Boolean>] [-ReadOnlyForUnmanagedDevices <Boolean>]
  [-RequestFilesLinkExpirationInDays <Int32>] [-RequestFilesLinkEnabled <Boolean>] [-OverrideSharingCapability <Boolean>]
  [-RestrictedAccessControl <Boolean>] [-ClearRestrictedAccessControl <SwitchParameter>] [-RestrictedAccessControlGroups <Guid[]>]
- [-AddRestrictedAccessControlGroups <Guid[]>] [-RemoveRestrictedAccessControlGroups <Guid[]>][-InheritVersionPolicyFromTenant <SwitchParameter>]
- [-AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled <Boolean>]
+ [-AddRestrictedAccessControlGroups <Guid[]>] [-RemoveRestrictedAccessControlGroups <Guid[]>] [-InheritVersionPolicyFromTenant]
+ [-EnableAutoExpirationVersionTrim <Boolean>] [-ExpireVersionsAfterDays <Int32>] [-MajorVersionLimit <Int32>]
+ [-MajorWithMinorVersionsLimit <Int32>] [-FileTypesForVersionExpiration <String[]>]
+ [-RemoveVersionExpirationFileTypeOverride <String[]>] [-ApplyToNewDocumentLibraries] [-ApplyToExistingDocumentLibraries] [-Force]
+ [-AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled <Boolean>] [-IsAuthoritative <Boolean>] [-RestrictedContentDiscoveryforCopilotAndAgents <Boolean>]
  [-ClearGroupId]
  [-Wait] 
  [-Connection <PnPConnection>] 
@@ -105,6 +109,34 @@ Set-PnPTenantSite -Identity "https://contoso.sharepoint.com/sites/marketing" -Al
 
 This will enable file-level archiving on the specified site. The tenant-level `Set-PnPTenant -AllowFileArchive $true` setting must also be enabled or the site setting will not take effect.
 
+### EXAMPLE 7
+```powershell
+Set-PnPTenantSite -Identity "https://contoso.sharepoint.com/sites/marketing" -EnableAutoExpirationVersionTrim $false -ExpireVersionsAfterDays 180 -MajorVersionLimit 100 -MajorWithMinorVersionsLimit 10
+```
+
+This will set the site version policy for both new and existing document libraries to keep 100 major versions, 10 minor versions, and expire versions after 180 days.
+
+### EXAMPLE 8
+```powershell
+Set-PnPTenantSite -Identity "https://contoso.sharepoint.com/sites/marketing" -EnableAutoExpirationVersionTrim $true -ApplyToNewDocumentLibraries -FileTypesForVersionExpiration "pdf","docx"
+```
+
+This will set an automatic version trim policy for new document libraries only and limit the override to the specified file types.
+
+### EXAMPLE 9
+```powershell
+Set-PnPTenantSite -Identity "https://contoso.sharepoint.com/sites/marketing" -ApplyToNewDocumentLibraries -RemoveVersionExpirationFileTypeOverride "pdf","docx"
+```
+
+This will remove the specified file type version expiration overrides from the site policy for new document libraries.
+
+### EXAMPLE 10
+```powershell
+Set-PnPTenantSite -Identity "https://contoso.sharepoint.com/sites/marketing" -InheritVersionPolicyFromTenant
+```
+
+This will reset the site version policy so new document libraries inherit the tenant-level defaults.
+
 ## PARAMETERS
 
 ### -AddInformationSegment
@@ -126,6 +158,34 @@ Specifies if the site administrator can upgrade the site collection.
 
 ```yaml
 Type: SwitchParameter
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisableClassicPageBaselineSecurityMode
+Enables or disables classic page baseline security mode for the site collection.
+
+```yaml
+Type: Boolean
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisableSiteBranding
+Enables or disables site branding for the site collection.
+
+```yaml
+Type: Boolean
 Parameter Sets: Set Properties
 
 Required: False
@@ -172,6 +232,34 @@ To remove the expiration requirement, set the value to zero (0).
 
 ```yaml
 Type: Int32
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ApplyToExistingDocumentLibraries
+Applies the configured site version policy to existing document libraries. If neither this parameter nor `-ApplyToNewDocumentLibraries` is provided, the cmdlet targets both new and existing document libraries.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ApplyToNewDocumentLibraries
+Applies the configured site version policy to new document libraries. If neither this parameter nor `-ApplyToExistingDocumentLibraries` is provided, the cmdlet targets both new and existing document libraries.
+
+```yaml
+Type: SwitchParameter
 Parameter Sets: Set Properties
 
 Required: False
@@ -310,6 +398,62 @@ Determines whether the App Views feature is disabled in the site collection.
 Type: AppViewsPolicy
 Parameter Sets: Set Properties
 Accepted values: Unknown, Disabled, NotDisabled
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableAutoExpirationVersionTrim
+Enables or disables automatic version trim for the site version policy. Set this to `$true` to use automatic trimming. Set it to `$false` to provide explicit values for `-ExpireVersionsAfterDays` and `-MajorVersionLimit`, and also `-MajorWithMinorVersionsLimit` when existing document libraries are included.
+
+```yaml
+Type: Boolean
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExpireVersionsAfterDays
+Sets the number of days after which versions expire when `-EnableAutoExpirationVersionTrim` is `$false`. Use `0` to keep versions indefinitely. Allowed values are `0` or from `30` through `36500`.
+
+```yaml
+Type: Int32
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FileTypesForVersionExpiration
+Limits the site version policy override to the specified file types. This parameter can only be used when `-EnableAutoExpirationVersionTrim` is also provided and cannot be combined with `-ApplyToExistingDocumentLibraries`.
+
+```yaml
+Type: String[]
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+Bypasses the confirmation prompt when applying site version policy changes that target new document libraries, existing document libraries, or both.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Set Properties
 
 Required: False
 Position: Named
@@ -1002,7 +1146,35 @@ Accept wildcard characters: False
 Clears the file version setting at site level.
 
 ```yaml
-Type: Boolean
+Type: SwitchParameter
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MajorVersionLimit
+Sets the maximum number of major versions to retain when `-EnableAutoExpirationVersionTrim` is `$false`. Allowed values are from `1` through `50000`.
+
+```yaml
+Type: Int32
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MajorWithMinorVersionsLimit
+Sets the maximum number of major and minor versions to retain when `-EnableAutoExpirationVersionTrim` is `$false` and the policy applies to existing document libraries. Allowed values are from `0` through `50000`.
+
+```yaml
+Type: Int32
 Parameter Sets: Set Properties
 
 Required: False
@@ -1056,8 +1228,50 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -RemoveVersionExpirationFileTypeOverride
+Removes one or more file type version expiration overrides from the site policy for new document libraries. This parameter must be combined with `-ApplyToNewDocumentLibraries` and cannot be combined with the other version policy setting parameters.
+
+```yaml
+Type: String[]
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled
 Enables or disables adding and updating web property bag values when the DenyAddAndCustomizePages is enabled.
+
+```yaml
+Type: Boolean
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsAuthoritative
+Marks the site collection as authoritative or not authoritative.
+
+```yaml
+Type: Boolean
+Parameter Sets: Set Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RestrictedContentDiscoveryforCopilotAndAgents
+Restricts content discovery for Copilot and agents on the site collection.
 
 ```yaml
 Type: Boolean

--- a/src/Commands/Admin/SetTenantSite.cs
+++ b/src/Commands/Admin/SetTenantSite.cs
@@ -268,7 +268,8 @@ namespace PnP.PowerShell.Commands
         public bool? IsAuthoritative;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
-        public bool? RestrictedContentDiscoveryforCopilotAndAgents;
+        [Alias("RestrictedContentDiscoveryforCopilotAndAgents")]
+        public bool? RestrictedContentDiscoveryForCopilotAndAgents;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
         public string[] ExcludeBlockDownloadSharePointGroups;
@@ -751,9 +752,9 @@ namespace PnP.PowerShell.Commands
                 updateRequired = true;
             }
 
-            if (ParameterSpecified(nameof(RestrictedContentDiscoveryforCopilotAndAgents)) && RestrictedContentDiscoveryforCopilotAndAgents.HasValue)
+            if (ParameterSpecified(nameof(RestrictedContentDiscoveryForCopilotAndAgents)) && RestrictedContentDiscoveryForCopilotAndAgents.HasValue)
             {
-                props.RestrictedContentDiscoveryforCopilotAndAgents = RestrictedContentDiscoveryforCopilotAndAgents.Value;
+                props.RestrictedContentDiscoveryforCopilotAndAgents = RestrictedContentDiscoveryForCopilotAndAgents.Value;
                 updateRequired = true;
             }
 

--- a/src/Commands/Admin/SetTenantSite.cs
+++ b/src/Commands/Admin/SetTenantSite.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 using PnP.PowerShell.Commands.Enums;
 using Microsoft.SharePoint.Client.Sharing;
+using PnP.PowerShell.Commands.Utilities;
 
 namespace PnP.PowerShell.Commands
 {
@@ -33,6 +34,12 @@ namespace PnP.PowerShell.Commands
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
         public SwitchParameter AllowSelfServiceUpgrade;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public bool? DisableClassicPageBaselineSecurityMode;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public bool? DisableSiteBranding;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
         public UserPipeBind PrimarySiteCollectionAdmin;
@@ -215,6 +222,34 @@ namespace PnP.PowerShell.Commands
         public SwitchParameter InheritVersionPolicyFromTenant;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public bool? EnableAutoExpirationVersionTrim;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public int? ExpireVersionsAfterDays;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public int? MajorVersionLimit;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public int? MajorWithMinorVersionsLimit;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public string[] FileTypesForVersionExpiration;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        [ValidateNotNullOrEmpty]
+        public string[] RemoveVersionExpirationFileTypeOverride;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public SwitchParameter ApplyToNewDocumentLibraries;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public SwitchParameter ApplyToExistingDocumentLibraries;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public SwitchParameter Force;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
         public bool OverrideSharingCapability;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
@@ -227,7 +262,13 @@ namespace PnP.PowerShell.Commands
         public bool AllowFileArchive;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
-        public bool AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled;
+        public bool? AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public bool? IsAuthoritative;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public bool? RestrictedContentDiscoveryforCopilotAndAgents;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
         public string[] ExcludeBlockDownloadSharePointGroups;
@@ -287,6 +328,18 @@ namespace PnP.PowerShell.Commands
             if (ParameterSpecified(nameof(AllowSelfServiceUpgrade)))
             {
                 props.AllowSelfServiceUpgrade = AllowSelfServiceUpgrade;
+                updateRequired = true;
+            }
+
+            if (ParameterSpecified(nameof(DisableClassicPageBaselineSecurityMode)) && DisableClassicPageBaselineSecurityMode.HasValue)
+            {
+                props.DisableClassicPageBaselineSecurityMode = DisableClassicPageBaselineSecurityMode.Value;
+                updateRequired = true;
+            }
+
+            if (ParameterSpecified(nameof(DisableSiteBranding)) && DisableSiteBranding.HasValue)
+            {
+                props.DisableSiteBranding = DisableSiteBranding.Value;
                 updateRequired = true;
             }
 
@@ -653,12 +706,6 @@ namespace PnP.PowerShell.Commands
                 updateRequired = true;
             }
 
-            if (ParameterSpecified(nameof(InheritVersionPolicyFromTenant)))
-            {
-                props.InheritVersionPolicyFromTenant = InheritVersionPolicyFromTenant;
-                updateRequired = true;
-            }
-
             if (ParameterSpecified(nameof(ReadOnlyForUnmanagedDevices)))
             {
                 props.ReadOnlyForUnmanagedDevices = ReadOnlyForUnmanagedDevices;
@@ -691,7 +738,22 @@ namespace PnP.PowerShell.Commands
 
             if (ParameterSpecified(nameof(AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled)))
             {
-                props.AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled = AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled;
+                if (AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled.HasValue)
+                {
+                    props.AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled = AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled.Value;
+                    updateRequired = true;
+                }
+            }
+
+            if (ParameterSpecified(nameof(IsAuthoritative)) && IsAuthoritative.HasValue)
+            {
+                props.IsAuthoritative = IsAuthoritative.Value;
+                updateRequired = true;
+            }
+
+            if (ParameterSpecified(nameof(RestrictedContentDiscoveryforCopilotAndAgents)) && RestrictedContentDiscoveryforCopilotAndAgents.HasValue)
+            {
+                props.RestrictedContentDiscoveryforCopilotAndAgents = RestrictedContentDiscoveryforCopilotAndAgents.Value;
                 updateRequired = true;
             }
 
@@ -710,6 +772,11 @@ namespace PnP.PowerShell.Commands
             if (ParameterSpecified(nameof(ClearGroupId)))
             {
                 props.ClearGroupId = ClearGroupId;
+                updateRequired = true;
+            }
+
+            if (SiteVersionPolicyUtilities.ApplyToSiteProperties(props, GetSiteVersionPolicyOptions(), Identity.Url, prompt => Force || ShouldContinue(prompt, string.Empty)))
+            {
                 updateRequired = true;
             }
 
@@ -801,6 +868,19 @@ namespace PnP.PowerShell.Commands
         {
             return Tenant.GetSitePropertiesByUrl(url, true);
         }
+
+        private SiteVersionPolicyOptions GetSiteVersionPolicyOptions() => new SiteVersionPolicyOptions
+        {
+            InheritVersionPolicyFromTenant = InheritVersionPolicyFromTenant.IsPresent,
+            EnableAutoExpirationVersionTrim = EnableAutoExpirationVersionTrim,
+            ExpireVersionsAfterDays = ExpireVersionsAfterDays,
+            MajorVersionLimit = MajorVersionLimit,
+            MajorWithMinorVersionsLimit = MajorWithMinorVersionsLimit,
+            FileTypesForVersionExpiration = FileTypesForVersionExpiration,
+            RemoveVersionExpirationFileTypeOverride = RemoveVersionExpirationFileTypeOverride,
+            ApplyToNewDocumentLibraries = ApplyToNewDocumentLibraries.IsPresent,
+            ApplyToExistingDocumentLibraries = ApplyToExistingDocumentLibraries.IsPresent
+        };
 
         private bool TimeoutFunction(TenantOperationMessage message)
         {

--- a/src/Commands/Site/NewSiteManageVersionPolicyJob.cs
+++ b/src/Commands/Site/NewSiteManageVersionPolicyJob.cs
@@ -1,0 +1,136 @@
+using Microsoft.Online.SharePoint.TenantAdministration;
+using Microsoft.SharePoint.Client;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Base.PipeBinds;
+using System;
+using System.Linq;
+using System.Management.Automation;
+using Resources = PnP.PowerShell.Commands.Properties.Resources;
+
+namespace PnP.PowerShell.Commands.Sites
+{
+    [Cmdlet(VerbsCommon.New, "PnPSiteManageVersionPolicyJob")]
+    public class NewSiteManageVersionPolicyJob : PnPSharePointOnlineAdminCmdlet
+    {
+        private const string ParameterSet_TrimUseListPolicy = "TrimUseListPolicy";
+        private const string ParameterSet_SyncListPolicy = "SyncListPolicy";
+
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = ParameterSet_TrimUseListPolicy)]
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = ParameterSet_SyncListPolicy)]
+        [ValidateNotNull]
+        public SitePipeBind Identity;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_TrimUseListPolicy)]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_SyncListPolicy)]
+        public string[] FileTypes;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_TrimUseListPolicy)]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_SyncListPolicy)]
+        public SwitchParameter ExcludeDefaultPolicy;
+
+        [Parameter(Mandatory = true, ParameterSetName = ParameterSet_TrimUseListPolicy)]
+        public SwitchParameter TrimUseListPolicy;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_TrimUseListPolicy)]
+        [Parameter(Mandatory = true, ParameterSetName = ParameterSet_SyncListPolicy)]
+        public SwitchParameter SyncListPolicy;
+
+        [Parameter(Mandatory = false)]
+        public SwitchParameter NoWait;
+
+        [Parameter(Mandatory = false)]
+        public SwitchParameter Force;
+
+        protected override void ExecuteCmdlet()
+        {
+            var siteUrl = ResolveSiteUrl();
+            var normalizedFileTypes = NormalizeFileTypes(FileTypes, nameof(FileTypes));
+
+            if (ExcludeDefaultPolicy.ToBool() && normalizedFileTypes != null && normalizedFileTypes.Length == 0)
+            {
+                throw new PSArgumentException($"The parameter {nameof(FileTypes)} must contain one or more non-empty file types when {nameof(ExcludeDefaultPolicy)} is specified.", nameof(FileTypes));
+            }
+
+            if (TrimUseListPolicy && !(Force || ShouldContinue($"By executing this command, versions that are expired by the list version policies on {siteUrl} will be permanently deleted. These versions cannot be restored from the recycle bin. Are you sure you want to continue?", Resources.Confirm)))
+            {
+                WriteObject("Cancelled. No site manage version policy job was created.");
+                return;
+            }
+
+            var fileVersionBatchDeleteParameters = new FileVersionBatchDeleteParameters
+            {
+                BatchDeleteMode = TrimUseListPolicy.IsPresent ? FileVersionBatchDeleteMode.ByListPolicy : FileVersionBatchDeleteMode.None,
+                SyncListPolicy = SyncListPolicy.ToBool(),
+                FileTypeSelections = new VersionPolicySelectionParameters
+                {
+                    SelectDefault = !ExcludeDefaultPolicy.ToBool(),
+                    SelectAllFileTypes = normalizedFileTypes == null,
+                    FileTypesSelected = normalizedFileTypes
+                },
+                DeleteOlderThanDays = -1,
+                MajorVersionLimit = -1,
+                MajorWithMinorVersionsLimit = -1
+            };
+
+            var operation = Tenant.NewFileVersionBatchDeleteJob(siteUrl, fileVersionBatchDeleteParameters);
+            AdminContext.Load(operation);
+            AdminContext.ExecuteQueryRetry();
+
+            if (!NoWait.ToBool())
+            {
+                PollOperation(operation);
+            }
+        }
+
+        private string ResolveSiteUrl()
+        {
+            if (Identity.Site != null)
+            {
+                Identity.Site.EnsureProperty(s => s.Url);
+                return Identity.Site.Url.TrimEnd('/');
+            }
+
+            if (!string.IsNullOrEmpty(Identity.Url))
+            {
+                using var targetWebContext = Connection.CloneContext(Identity.Url.TrimEnd('/'));
+                targetWebContext.Load(targetWebContext.Site, s => s.Url);
+                targetWebContext.ExecuteQueryRetry();
+                return targetWebContext.Site.Url.TrimEnd('/');
+            }
+
+            if (Identity.Id != Guid.Empty)
+            {
+                var siteProperties = Tenant.GetSitePropertiesById(Identity.Id, false, Connection.TenantAdminUrl);
+                if (siteProperties == null || string.IsNullOrEmpty(siteProperties.Url))
+                {
+                    throw new PSArgumentException("The specified site could not be resolved.", nameof(Identity));
+                }
+
+                return siteProperties.Url.TrimEnd('/');
+            }
+
+            throw new PSArgumentException("The Identity parameter must be a valid site object, site id, or absolute site url.", nameof(Identity));
+        }
+
+        private static string[] NormalizeFileTypes(string[] fileTypes, string parameterName)
+        {
+            if (fileTypes == null)
+            {
+                return null;
+            }
+
+            var normalizedFileTypes = fileTypes
+                .Select(fileType => fileType?.Trim())
+                .ToArray();
+
+            if (normalizedFileTypes.Length == 0 || normalizedFileTypes.Any(string.IsNullOrWhiteSpace))
+            {
+                throw new PSArgumentException($"The parameter {parameterName} must contain one or more non-empty file types.", parameterName);
+            }
+
+            return normalizedFileTypes
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+    }
+}

--- a/src/Commands/Site/NewSiteManageVersionPolicyJob.cs
+++ b/src/Commands/Site/NewSiteManageVersionPolicyJob.cs
@@ -46,11 +46,6 @@ namespace PnP.PowerShell.Commands.Sites
             var siteUrl = ResolveSiteUrl();
             var normalizedFileTypes = NormalizeFileTypes(FileTypes, nameof(FileTypes));
 
-            if (ExcludeDefaultPolicy.ToBool() && normalizedFileTypes != null && normalizedFileTypes.Length == 0)
-            {
-                throw new PSArgumentException($"The parameter {nameof(FileTypes)} must contain one or more non-empty file types when {nameof(ExcludeDefaultPolicy)} is specified.", nameof(FileTypes));
-            }
-
             if (TrimUseListPolicy && !(Force || ShouldContinue($"By executing this command, versions that are expired by the list version policies on {siteUrl} will be permanently deleted. These versions cannot be restored from the recycle bin. Are you sure you want to continue?", Resources.Confirm)))
             {
                 WriteObject("Cancelled. No site manage version policy job was created.");

--- a/src/Commands/Site/SetSite.cs
+++ b/src/Commands/Site/SetSite.cs
@@ -47,6 +47,12 @@ namespace PnP.PowerShell.Commands.Site
         public SwitchParameter? AllowSelfServiceUpgrade = null;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public bool? DisableClassicPageBaselineSecurityMode;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public bool? DisableSiteBranding;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
         [Alias("DenyAndAddCustomizePages", "DenyAddAndCustomizePages")]
         public SwitchParameter? NoScriptSite;
 
@@ -105,6 +111,15 @@ namespace PnP.PowerShell.Commands.Site
         public int? RequestFilesLinkExpirationInDays;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public bool? AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public bool? IsAuthoritative;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public bool? RestrictedContentDiscoveryforCopilotAndAgents;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
         public string ScriptSafeDomainName;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
@@ -142,6 +157,37 @@ namespace PnP.PowerShell.Commands.Site
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
         public SwitchParameter ClearGroupId;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public SwitchParameter InheritVersionPolicyFromTenant;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public bool? EnableAutoExpirationVersionTrim;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public int? ExpireVersionsAfterDays;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public int? MajorVersionLimit;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public int? MajorWithMinorVersionsLimit;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public string[] FileTypesForVersionExpiration;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        [ValidateNotNullOrEmpty]
+        public string[] RemoveVersionExpirationFileTypeOverride;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public SwitchParameter ApplyToNewDocumentLibraries;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public SwitchParameter ApplyToExistingDocumentLibraries;
+
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
+        public SwitchParameter Force;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_LOCKSTATE)]
         public SwitchParameter Wait;
@@ -317,6 +363,16 @@ namespace PnP.PowerShell.Commands.Site
                     siteProperties.AllowSelfServiceUpgrade = AllowSelfServiceUpgrade.Value;
                     executeQueryRequired = true;
                 }
+                if (ParameterSpecified(nameof(DisableClassicPageBaselineSecurityMode)) && DisableClassicPageBaselineSecurityMode.HasValue)
+                {
+                    siteProperties.DisableClassicPageBaselineSecurityMode = DisableClassicPageBaselineSecurityMode.Value;
+                    executeQueryRequired = true;
+                }
+                if (ParameterSpecified(nameof(DisableSiteBranding)) && DisableSiteBranding.HasValue)
+                {
+                    siteProperties.DisableSiteBranding = DisableSiteBranding.Value;
+                    executeQueryRequired = true;
+                }
                 if (NoScriptSite.HasValue)
                 {
                     siteProperties.DenyAddAndCustomizePages = NoScriptSite == true ? DenyAddAndCustomizePagesStatus.Enabled : DenyAddAndCustomizePagesStatus.Disabled;
@@ -401,6 +457,24 @@ namespace PnP.PowerShell.Commands.Site
                     executeQueryRequired = true;
                 }
 
+                if (ParameterSpecified(nameof(AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled)) && AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled.HasValue)
+                {
+                    siteProperties.AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled = AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled.Value;
+                    executeQueryRequired = true;
+                }
+
+                if (ParameterSpecified(nameof(IsAuthoritative)) && IsAuthoritative.HasValue)
+                {
+                    siteProperties.IsAuthoritative = IsAuthoritative.Value;
+                    executeQueryRequired = true;
+                }
+
+                if (ParameterSpecified(nameof(RestrictedContentDiscoveryforCopilotAndAgents)) && RestrictedContentDiscoveryforCopilotAndAgents.HasValue)
+                {
+                    siteProperties.RestrictedContentDiscoveryforCopilotAndAgents = RestrictedContentDiscoveryforCopilotAndAgents.Value;
+                    executeQueryRequired = true;
+                }
+
                 if (ParameterSpecified(nameof(RestrictedAccessControl)) && RestrictedAccessControl.HasValue)
                 {
                     siteProperties.RestrictedAccessControl = RestrictedAccessControl.Value;
@@ -467,6 +541,11 @@ namespace PnP.PowerShell.Commands.Site
                     executeQueryRequired = true;
                 }
 
+                if (SiteVersionPolicyUtilities.ApplyToSiteProperties(siteProperties, GetSiteVersionPolicyOptions(), siteUrl, prompt => Force || ShouldContinue(prompt, string.Empty)))
+                {
+                    executeQueryRequired = true;
+                }
+
                 if (executeQueryRequired)
                 {
                     siteProperties.Update();
@@ -484,6 +563,19 @@ namespace PnP.PowerShell.Commands.Site
             }
         }
 
+		private SiteVersionPolicyOptions GetSiteVersionPolicyOptions() => new SiteVersionPolicyOptions
+		{
+			InheritVersionPolicyFromTenant = InheritVersionPolicyFromTenant.IsPresent,
+			EnableAutoExpirationVersionTrim = EnableAutoExpirationVersionTrim,
+			ExpireVersionsAfterDays = ExpireVersionsAfterDays,
+			MajorVersionLimit = MajorVersionLimit,
+			MajorWithMinorVersionsLimit = MajorWithMinorVersionsLimit,
+			FileTypesForVersionExpiration = FileTypesForVersionExpiration,
+			RemoveVersionExpirationFileTypeOverride = RemoveVersionExpirationFileTypeOverride,
+			ApplyToNewDocumentLibraries = ApplyToNewDocumentLibraries.IsPresent,
+			ApplyToExistingDocumentLibraries = ApplyToExistingDocumentLibraries.IsPresent
+		};
+
         private bool TimeoutFunction(TenantOperationMessage message)
         {
             if (message == TenantOperationMessage.SettingSiteProperties || message == TenantOperationMessage.SettingSiteLockState)
@@ -500,6 +592,8 @@ namespace PnP.PowerShell.Commands.Site
                 StorageMaximumLevel.HasValue ||
                 StorageWarningLevel.HasValue ||
                 AllowSelfServiceUpgrade.HasValue ||
+                DisableClassicPageBaselineSecurityMode.HasValue ||
+                DisableSiteBranding.HasValue ||
                 NoScriptSite.HasValue ||
                 CommentsOnSitePagesDisabled.HasValue ||
                 DefaultLinkPermission.HasValue ||
@@ -516,6 +610,9 @@ namespace PnP.PowerShell.Commands.Site
                 ParameterSpecified(nameof(OverrideTenantAnonymousLinkExpirationPolicy)) ||
                 DisableCompanyWideSharingLinks.HasValue ||
                 MediaTranscription.HasValue ||
+                AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled.HasValue ||
+                IsAuthoritative.HasValue ||
+                RestrictedContentDiscoveryforCopilotAndAgents.HasValue ||
                 RestrictedAccessControl.HasValue ||
                 RequestFilesLinkExpirationInDays.HasValue ||
                 RequestFilesLinkEnabled.HasValue ||
@@ -527,6 +624,7 @@ namespace PnP.PowerShell.Commands.Site
                 HidePeopleWhoHaveListsOpen.HasValue ||
                 ParameterSpecified(nameof(ExcludeBlockDownloadSharePointGroups)) ||
                 ReadOnlyForBlockDownloadPolicy.IsPresent ||
-                ClearGroupId.IsPresent;
+                ClearGroupId.IsPresent ||
+                SiteVersionPolicyUtilities.HasVersionPolicyParameters(GetSiteVersionPolicyOptions());
     }
 }

--- a/src/Commands/Site/SetSite.cs
+++ b/src/Commands/Site/SetSite.cs
@@ -117,7 +117,8 @@ namespace PnP.PowerShell.Commands.Site
         public bool? IsAuthoritative;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
-        public bool? RestrictedContentDiscoveryforCopilotAndAgents;
+        [Alias("RestrictedContentDiscoveryforCopilotAndAgents")]
+        public bool? RestrictedContentDiscoveryForCopilotAndAgents;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_PROPERTIES)]
         public string ScriptSafeDomainName;
@@ -469,9 +470,9 @@ namespace PnP.PowerShell.Commands.Site
                     executeQueryRequired = true;
                 }
 
-                if (ParameterSpecified(nameof(RestrictedContentDiscoveryforCopilotAndAgents)) && RestrictedContentDiscoveryforCopilotAndAgents.HasValue)
+                if (ParameterSpecified(nameof(RestrictedContentDiscoveryForCopilotAndAgents)) && RestrictedContentDiscoveryForCopilotAndAgents.HasValue)
                 {
-                    siteProperties.RestrictedContentDiscoveryforCopilotAndAgents = RestrictedContentDiscoveryforCopilotAndAgents.Value;
+                    siteProperties.RestrictedContentDiscoveryforCopilotAndAgents = RestrictedContentDiscoveryForCopilotAndAgents.Value;
                     executeQueryRequired = true;
                 }
 
@@ -612,7 +613,7 @@ namespace PnP.PowerShell.Commands.Site
                 MediaTranscription.HasValue ||
                 AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled.HasValue ||
                 IsAuthoritative.HasValue ||
-                RestrictedContentDiscoveryforCopilotAndAgents.HasValue ||
+                RestrictedContentDiscoveryForCopilotAndAgents.HasValue ||
                 RestrictedAccessControl.HasValue ||
                 RequestFilesLinkExpirationInDays.HasValue ||
                 RequestFilesLinkEnabled.HasValue ||

--- a/src/Commands/Utilities/SiteVersionPolicyUtilities.cs
+++ b/src/Commands/Utilities/SiteVersionPolicyUtilities.cs
@@ -1,0 +1,256 @@
+using Microsoft.Online.SharePoint.TenantAdministration;
+using System;
+using System.Linq;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Utilities
+{
+	internal sealed class SiteVersionPolicyOptions
+	{
+		public bool InheritVersionPolicyFromTenant { get; set; }
+		public bool? EnableAutoExpirationVersionTrim { get; set; }
+		public int? ExpireVersionsAfterDays { get; set; }
+		public int? MajorVersionLimit { get; set; }
+		public int? MajorWithMinorVersionsLimit { get; set; }
+		public string[] FileTypesForVersionExpiration { get; set; }
+		public string[] RemoveVersionExpirationFileTypeOverride { get; set; }
+		public bool ApplyToNewDocumentLibraries { get; set; }
+		public bool ApplyToExistingDocumentLibraries { get; set; }
+	}
+
+	internal static class SiteVersionPolicyUtilities
+	{
+		public static bool HasVersionPolicyParameters(SiteVersionPolicyOptions options)
+		{
+			if (options == null)
+			{
+				return false;
+			}
+
+			return options.InheritVersionPolicyFromTenant ||
+				options.EnableAutoExpirationVersionTrim.HasValue ||
+				options.ExpireVersionsAfterDays.HasValue ||
+				options.MajorVersionLimit.HasValue ||
+				options.MajorWithMinorVersionsLimit.HasValue ||
+				options.FileTypesForVersionExpiration != null ||
+				options.RemoveVersionExpirationFileTypeOverride != null ||
+				options.ApplyToNewDocumentLibraries ||
+				options.ApplyToExistingDocumentLibraries;
+		}
+
+		public static bool ApplyToSiteProperties(SiteProperties siteProperties, SiteVersionPolicyOptions options, string siteUrl, Func<string, bool> confirmAction = null)
+		{
+			if (!HasVersionPolicyParameters(options))
+			{
+				return false;
+			}
+
+			var normalizedFileTypes = NormalizeFileTypes(options.FileTypesForVersionExpiration, nameof(options.FileTypesForVersionExpiration));
+			var normalizedOverridesToRemove = NormalizeFileTypes(options.RemoveVersionExpirationFileTypeOverride, nameof(options.RemoveVersionExpirationFileTypeOverride));
+
+			if (options.InheritVersionPolicyFromTenant)
+			{
+				if (options.EnableAutoExpirationVersionTrim.HasValue ||
+					options.ExpireVersionsAfterDays.HasValue ||
+					options.MajorVersionLimit.HasValue ||
+					options.MajorWithMinorVersionsLimit.HasValue ||
+					normalizedFileTypes != null ||
+					normalizedOverridesToRemove != null ||
+					options.ApplyToNewDocumentLibraries ||
+					options.ApplyToExistingDocumentLibraries)
+				{
+					throw new PSArgumentException($"Don't specify other version policy related parameters when {nameof(options.InheritVersionPolicyFromTenant)} is specified.", nameof(options.InheritVersionPolicyFromTenant));
+				}
+
+				siteProperties.InheritVersionPolicyFromTenant = true;
+				siteProperties.EnableAutoExpirationVersionTrim = false;
+				siteProperties.ApplyToNewDocumentLibraries = false;
+				siteProperties.ApplyToExistingDocumentLibraries = false;
+				siteProperties.MajorVersionLimit = -1;
+				siteProperties.MajorWithMinorVersionsLimit = -1;
+				siteProperties.ExpireVersionsAfterDays = -1;
+				return true;
+			}
+
+			if (normalizedOverridesToRemove != null)
+			{
+				if (options.EnableAutoExpirationVersionTrim.HasValue ||
+					options.ExpireVersionsAfterDays.HasValue ||
+					options.MajorVersionLimit.HasValue ||
+					options.MajorWithMinorVersionsLimit.HasValue ||
+					normalizedFileTypes != null ||
+					options.ApplyToExistingDocumentLibraries)
+				{
+					throw new PSArgumentException($"Don't specify other version policy related parameters when {nameof(options.RemoveVersionExpirationFileTypeOverride)} is specified.", nameof(options.RemoveVersionExpirationFileTypeOverride));
+				}
+
+				if (!options.ApplyToNewDocumentLibraries)
+				{
+					throw new PSArgumentException($"You must specify {nameof(options.ApplyToNewDocumentLibraries)} when {nameof(options.RemoveVersionExpirationFileTypeOverride)} is specified.", nameof(options.ApplyToNewDocumentLibraries));
+				}
+
+				siteProperties.InheritVersionPolicyFromTenant = false;
+				siteProperties.EnableAutoExpirationVersionTrim = false;
+				siteProperties.ApplyToNewDocumentLibraries = true;
+				siteProperties.ApplyToExistingDocumentLibraries = false;
+				siteProperties.MajorVersionLimit = -1;
+				siteProperties.MajorWithMinorVersionsLimit = -1;
+				siteProperties.ExpireVersionsAfterDays = -1;
+				siteProperties.FileTypesForVersionExpiration = null;
+				siteProperties.RemoveVersionExpirationFileTypeOverride = normalizedOverridesToRemove;
+				return true;
+			}
+
+			if (!options.EnableAutoExpirationVersionTrim.HasValue)
+			{
+				if (normalizedFileTypes != null)
+				{
+					throw new PSArgumentException($"The parameter {nameof(options.FileTypesForVersionExpiration)} must be combined with {nameof(options.EnableAutoExpirationVersionTrim)}.", nameof(options.FileTypesForVersionExpiration));
+				}
+
+				if (options.ExpireVersionsAfterDays.HasValue ||
+					options.MajorVersionLimit.HasValue ||
+					options.MajorWithMinorVersionsLimit.HasValue ||
+					options.ApplyToNewDocumentLibraries ||
+					options.ApplyToExistingDocumentLibraries)
+				{
+					throw new PSArgumentException($"You must specify {nameof(options.EnableAutoExpirationVersionTrim)} when setting site version policy parameters.", nameof(options.EnableAutoExpirationVersionTrim));
+				}
+
+				return false;
+			}
+
+			var applyToNewDocumentLibraries = options.ApplyToNewDocumentLibraries || !options.ApplyToExistingDocumentLibraries;
+			var applyToExistingDocumentLibraries = options.ApplyToExistingDocumentLibraries || !options.ApplyToNewDocumentLibraries;
+
+			if (!(confirmAction?.Invoke(GetConfirmationPrompt(siteUrl, applyToNewDocumentLibraries, applyToExistingDocumentLibraries)) ?? true))
+			{
+				return false;
+			}
+
+			if (applyToExistingDocumentLibraries && normalizedFileTypes != null)
+			{
+				throw new PSArgumentException($"The parameter {nameof(options.FileTypesForVersionExpiration)} can't be used when {nameof(options.ApplyToExistingDocumentLibraries)} is specified.", nameof(options.FileTypesForVersionExpiration));
+			}
+
+			siteProperties.InheritVersionPolicyFromTenant = false;
+			siteProperties.EnableAutoExpirationVersionTrim = options.EnableAutoExpirationVersionTrim.Value;
+			siteProperties.ApplyToNewDocumentLibraries = applyToNewDocumentLibraries;
+			siteProperties.ApplyToExistingDocumentLibraries = applyToExistingDocumentLibraries;
+			siteProperties.RemoveVersionExpirationFileTypeOverride = null;
+
+			if (normalizedFileTypes != null)
+			{
+				siteProperties.FileTypesForVersionExpiration = normalizedFileTypes;
+			}
+
+			if (options.EnableAutoExpirationVersionTrim.Value)
+			{
+				if (options.ExpireVersionsAfterDays.HasValue)
+				{
+					throw new PSArgumentException($"Don't specify {nameof(options.ExpireVersionsAfterDays)} when {nameof(options.EnableAutoExpirationVersionTrim)} is true.", nameof(options.ExpireVersionsAfterDays));
+				}
+
+				if (options.MajorVersionLimit.HasValue)
+				{
+					throw new PSArgumentException($"Don't specify {nameof(options.MajorVersionLimit)} when {nameof(options.EnableAutoExpirationVersionTrim)} is true.", nameof(options.MajorVersionLimit));
+				}
+
+				if (options.MajorWithMinorVersionsLimit.HasValue)
+				{
+					throw new PSArgumentException($"Don't specify {nameof(options.MajorWithMinorVersionsLimit)} when {nameof(options.EnableAutoExpirationVersionTrim)} is true.", nameof(options.MajorWithMinorVersionsLimit));
+				}
+
+				siteProperties.ExpireVersionsAfterDays = -1;
+				siteProperties.MajorVersionLimit = -1;
+				siteProperties.MajorWithMinorVersionsLimit = -1;
+				return true;
+			}
+
+			if (!options.ExpireVersionsAfterDays.HasValue)
+			{
+				throw new PSArgumentException($"You must specify {nameof(options.ExpireVersionsAfterDays)} when {nameof(options.EnableAutoExpirationVersionTrim)} is false.", nameof(options.ExpireVersionsAfterDays));
+			}
+
+			if (!options.MajorVersionLimit.HasValue)
+			{
+				throw new PSArgumentException($"You must specify {nameof(options.MajorVersionLimit)} when {nameof(options.EnableAutoExpirationVersionTrim)} is false.", nameof(options.MajorVersionLimit));
+			}
+
+			if (options.ExpireVersionsAfterDays.Value != 0 && (options.ExpireVersionsAfterDays.Value < 30 || options.ExpireVersionsAfterDays.Value > 36500))
+			{
+				throw new PSArgumentException($"{nameof(options.ExpireVersionsAfterDays)} must be 0 or between 30 and 36500.", nameof(options.ExpireVersionsAfterDays));
+			}
+
+			if (options.MajorVersionLimit.Value < 1 || options.MajorVersionLimit.Value > 50000)
+			{
+				throw new PSArgumentException($"{nameof(options.MajorVersionLimit)} must be between 1 and 50000.", nameof(options.MajorVersionLimit));
+			}
+
+			siteProperties.ExpireVersionsAfterDays = options.ExpireVersionsAfterDays.Value;
+			siteProperties.MajorVersionLimit = options.MajorVersionLimit.Value;
+
+			if (applyToExistingDocumentLibraries)
+			{
+				if (!options.MajorWithMinorVersionsLimit.HasValue)
+				{
+					throw new PSArgumentException($"You must specify {nameof(options.MajorWithMinorVersionsLimit)} when {nameof(options.ApplyToExistingDocumentLibraries)} is specified and {nameof(options.EnableAutoExpirationVersionTrim)} is false.", nameof(options.MajorWithMinorVersionsLimit));
+				}
+
+				if (options.MajorWithMinorVersionsLimit.Value < 0 || options.MajorWithMinorVersionsLimit.Value > 50000)
+				{
+					throw new PSArgumentException($"{nameof(options.MajorWithMinorVersionsLimit)} must be between 0 and 50000.", nameof(options.MajorWithMinorVersionsLimit));
+				}
+
+				siteProperties.MajorWithMinorVersionsLimit = options.MajorWithMinorVersionsLimit.Value;
+			}
+			else
+			{
+				if (options.MajorWithMinorVersionsLimit.HasValue)
+				{
+					throw new PSArgumentException($"Don't specify {nameof(options.MajorWithMinorVersionsLimit)} when applying version policy to new document libraries only.", nameof(options.MajorWithMinorVersionsLimit));
+				}
+
+				siteProperties.MajorWithMinorVersionsLimit = -1;
+			}
+
+			return true;
+		}
+
+		private static string GetConfirmationPrompt(string siteUrl, bool applyToNewDocumentLibraries, bool applyToExistingDocumentLibraries)
+		{
+			if (applyToNewDocumentLibraries && applyToExistingDocumentLibraries)
+			{
+				return $"Set the site version policy for new and existing document libraries on {siteUrl}?";
+			}
+
+			if (applyToNewDocumentLibraries)
+			{
+				return $"Set the site version policy for new document libraries on {siteUrl}?";
+			}
+
+			return $"Set the site version policy for existing document libraries on {siteUrl}?";
+		}
+
+		private static string[] NormalizeFileTypes(string[] fileTypes, string parameterName)
+		{
+			if (fileTypes == null)
+			{
+				return null;
+			}
+
+			var normalizedFileTypes = fileTypes
+				.Select(fileType => fileType?.Trim())
+				.ToArray();
+
+			if (normalizedFileTypes.Length == 0 || normalizedFileTypes.Any(string.IsNullOrWhiteSpace))
+			{
+				throw new PSArgumentException($"The parameter {parameterName} must contain one or more non-empty file types.", parameterName);
+			}
+
+			return normalizedFileTypes
+				.Distinct(StringComparer.OrdinalIgnoreCase)
+				.ToArray();
+		}
+	}
+}

--- a/src/Commands/Utilities/SiteVersionPolicyUtilities.cs
+++ b/src/Commands/Utilities/SiteVersionPolicyUtilities.cs
@@ -123,25 +123,9 @@ namespace PnP.PowerShell.Commands.Utilities
 			var applyToNewDocumentLibraries = options.ApplyToNewDocumentLibraries || !options.ApplyToExistingDocumentLibraries;
 			var applyToExistingDocumentLibraries = options.ApplyToExistingDocumentLibraries || !options.ApplyToNewDocumentLibraries;
 
-			if (!(confirmAction?.Invoke(GetConfirmationPrompt(siteUrl, applyToNewDocumentLibraries, applyToExistingDocumentLibraries)) ?? true))
-			{
-				return false;
-			}
-
 			if (applyToExistingDocumentLibraries && normalizedFileTypes != null)
 			{
 				throw new PSArgumentException($"The parameter {nameof(options.FileTypesForVersionExpiration)} can't be used when {nameof(options.ApplyToExistingDocumentLibraries)} is specified.", nameof(options.FileTypesForVersionExpiration));
-			}
-
-			siteProperties.InheritVersionPolicyFromTenant = false;
-			siteProperties.EnableAutoExpirationVersionTrim = options.EnableAutoExpirationVersionTrim.Value;
-			siteProperties.ApplyToNewDocumentLibraries = applyToNewDocumentLibraries;
-			siteProperties.ApplyToExistingDocumentLibraries = applyToExistingDocumentLibraries;
-			siteProperties.RemoveVersionExpirationFileTypeOverride = null;
-
-			if (normalizedFileTypes != null)
-			{
-				siteProperties.FileTypesForVersionExpiration = normalizedFileTypes;
 			}
 
 			if (options.EnableAutoExpirationVersionTrim.Value)
@@ -160,31 +144,69 @@ namespace PnP.PowerShell.Commands.Utilities
 				{
 					throw new PSArgumentException($"Don't specify {nameof(options.MajorWithMinorVersionsLimit)} when {nameof(options.EnableAutoExpirationVersionTrim)} is true.", nameof(options.MajorWithMinorVersionsLimit));
 				}
+			}
+			else
+			{
+				if (!options.ExpireVersionsAfterDays.HasValue)
+				{
+					throw new PSArgumentException($"You must specify {nameof(options.ExpireVersionsAfterDays)} when {nameof(options.EnableAutoExpirationVersionTrim)} is false.", nameof(options.ExpireVersionsAfterDays));
+				}
 
+				if (!options.MajorVersionLimit.HasValue)
+				{
+					throw new PSArgumentException($"You must specify {nameof(options.MajorVersionLimit)} when {nameof(options.EnableAutoExpirationVersionTrim)} is false.", nameof(options.MajorVersionLimit));
+				}
+
+				if (options.ExpireVersionsAfterDays.Value != 0 && (options.ExpireVersionsAfterDays.Value < 30 || options.ExpireVersionsAfterDays.Value > 36500))
+				{
+					throw new PSArgumentException($"{nameof(options.ExpireVersionsAfterDays)} must be 0 or between 30 and 36500.", nameof(options.ExpireVersionsAfterDays));
+				}
+
+				if (options.MajorVersionLimit.Value < 1 || options.MajorVersionLimit.Value > 50000)
+				{
+					throw new PSArgumentException($"{nameof(options.MajorVersionLimit)} must be between 1 and 50000.", nameof(options.MajorVersionLimit));
+				}
+
+				if (applyToExistingDocumentLibraries)
+				{
+					if (!options.MajorWithMinorVersionsLimit.HasValue)
+					{
+						throw new PSArgumentException($"You must specify {nameof(options.MajorWithMinorVersionsLimit)} when {nameof(options.ApplyToExistingDocumentLibraries)} is specified and {nameof(options.EnableAutoExpirationVersionTrim)} is false.", nameof(options.MajorWithMinorVersionsLimit));
+					}
+
+					if (options.MajorWithMinorVersionsLimit.Value < 0 || options.MajorWithMinorVersionsLimit.Value > 50000)
+					{
+						throw new PSArgumentException($"{nameof(options.MajorWithMinorVersionsLimit)} must be between 0 and 50000.", nameof(options.MajorWithMinorVersionsLimit));
+					}
+				}
+				else if (options.MajorWithMinorVersionsLimit.HasValue)
+				{
+					throw new PSArgumentException($"Don't specify {nameof(options.MajorWithMinorVersionsLimit)} when applying version policy to new document libraries only.", nameof(options.MajorWithMinorVersionsLimit));
+				}
+			}
+
+			if (!(confirmAction?.Invoke(GetConfirmationPrompt(siteUrl, applyToNewDocumentLibraries, applyToExistingDocumentLibraries)) ?? true))
+			{
+				return false;
+			}
+
+			siteProperties.InheritVersionPolicyFromTenant = false;
+			siteProperties.EnableAutoExpirationVersionTrim = options.EnableAutoExpirationVersionTrim.Value;
+			siteProperties.ApplyToNewDocumentLibraries = applyToNewDocumentLibraries;
+			siteProperties.ApplyToExistingDocumentLibraries = applyToExistingDocumentLibraries;
+			siteProperties.RemoveVersionExpirationFileTypeOverride = null;
+
+			if (normalizedFileTypes != null)
+			{
+				siteProperties.FileTypesForVersionExpiration = normalizedFileTypes;
+			}
+
+			if (options.EnableAutoExpirationVersionTrim.Value)
+			{
 				siteProperties.ExpireVersionsAfterDays = -1;
 				siteProperties.MajorVersionLimit = -1;
 				siteProperties.MajorWithMinorVersionsLimit = -1;
 				return true;
-			}
-
-			if (!options.ExpireVersionsAfterDays.HasValue)
-			{
-				throw new PSArgumentException($"You must specify {nameof(options.ExpireVersionsAfterDays)} when {nameof(options.EnableAutoExpirationVersionTrim)} is false.", nameof(options.ExpireVersionsAfterDays));
-			}
-
-			if (!options.MajorVersionLimit.HasValue)
-			{
-				throw new PSArgumentException($"You must specify {nameof(options.MajorVersionLimit)} when {nameof(options.EnableAutoExpirationVersionTrim)} is false.", nameof(options.MajorVersionLimit));
-			}
-
-			if (options.ExpireVersionsAfterDays.Value != 0 && (options.ExpireVersionsAfterDays.Value < 30 || options.ExpireVersionsAfterDays.Value > 36500))
-			{
-				throw new PSArgumentException($"{nameof(options.ExpireVersionsAfterDays)} must be 0 or between 30 and 36500.", nameof(options.ExpireVersionsAfterDays));
-			}
-
-			if (options.MajorVersionLimit.Value < 1 || options.MajorVersionLimit.Value > 50000)
-			{
-				throw new PSArgumentException($"{nameof(options.MajorVersionLimit)} must be between 1 and 50000.", nameof(options.MajorVersionLimit));
 			}
 
 			siteProperties.ExpireVersionsAfterDays = options.ExpireVersionsAfterDays.Value;
@@ -192,25 +214,10 @@ namespace PnP.PowerShell.Commands.Utilities
 
 			if (applyToExistingDocumentLibraries)
 			{
-				if (!options.MajorWithMinorVersionsLimit.HasValue)
-				{
-					throw new PSArgumentException($"You must specify {nameof(options.MajorWithMinorVersionsLimit)} when {nameof(options.ApplyToExistingDocumentLibraries)} is specified and {nameof(options.EnableAutoExpirationVersionTrim)} is false.", nameof(options.MajorWithMinorVersionsLimit));
-				}
-
-				if (options.MajorWithMinorVersionsLimit.Value < 0 || options.MajorWithMinorVersionsLimit.Value > 50000)
-				{
-					throw new PSArgumentException($"{nameof(options.MajorWithMinorVersionsLimit)} must be between 0 and 50000.", nameof(options.MajorWithMinorVersionsLimit));
-				}
-
 				siteProperties.MajorWithMinorVersionsLimit = options.MajorWithMinorVersionsLimit.Value;
 			}
 			else
 			{
-				if (options.MajorWithMinorVersionsLimit.HasValue)
-				{
-					throw new PSArgumentException($"Don't specify {nameof(options.MajorWithMinorVersionsLimit)} when applying version policy to new document libraries only.", nameof(options.MajorWithMinorVersionsLimit));
-				}
-
 				siteProperties.MajorWithMinorVersionsLimit = -1;
 			}
 


### PR DESCRIPTION
- Introduced parameters for managing version policies including:
  - EnableAutoExpirationVersionTrim
  - ExpireVersionsAfterDays
  - MajorVersionLimit
  - MajorWithMinorVersionsLimit
  - FileTypesForVersionExpiration
  - RemoveVersionExpirationFileTypeOverride
  - ApplyToNewDocumentLibraries
  - ApplyToExistingDocumentLibraries
  - InheritVersionPolicyFromTenant
- Added new cmdlet New-PnPSiteManageVersionPolicyJob for batch version policy management.
- Updated documentation for Set-PnPTenantSite to reflect new parameters and examples.
- Implemented utility methods for version policy handling in SiteVersionPolicyUtilities.
- Enhanced SetSite and related commands to support new version policy parameters.

Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [ ] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #X, partially fixes #Y, mentioned in #Z, etc.

## What is in this Pull Request ? ##
Please describe the changes in the PR. 

### Guidance ###
* You can delete this section when you are submitting the pull request.* 
* *Please update this PR information accordingly. We use this as part of our release notes in monthly communications.*
* **Please target your PR to Dev branch. If you do not target the Dev branch we will not accept this PR.**
