### PR TITLE
ConvertSiteTemplateToMarkdown: fix use of ShouldContinue without checking Force

### DIFF
--- a/src/Commands/Provisioning/Site/ConvertSiteTemplateToMarkdown.cs
+++ b/src/Commands/Provisioning/Site/ConvertSiteTemplateToMarkdown.cs
@@ -3,14 +3,13 @@ using PnP.Framework.Provisioning.Providers.Markdown;
 using PnP.PowerShell.Commands.Base;
 using PnP.PowerShell.Commands.Properties;
 using PnP.PowerShell.Commands.Utilities;
+
 using System.IO;
 using System.Management.Automation;
 
 namespace PnP.PowerShell.Commands.Provisioning.Site
 {
-
     [Cmdlet(VerbsData.Convert, "PnPSiteTemplateToMarkdown", SupportsShouldProcess = true)]
-
     public class ConvertSiteTemplateToMarkdown : BasePSCmdlet
     {
         [Parameter(Mandatory = true)]
@@ -21,6 +20,7 @@ namespace PnP.PowerShell.Commands.Provisioning.Site
 
         [Parameter(Mandatory = false)]
         public SwitchParameter Force;
+
         protected override void ExecuteCmdlet()
         {
             LogWarning("This cmdlet is work in progress, the markdown report will improve/grow with later releases.");
@@ -34,53 +34,43 @@ namespace PnP.PowerShell.Commands.Provisioning.Site
                 throw new PSArgumentException("File does not exist", nameof(TemplatePath));
             }
 
-            if (ShouldContinue($"Converts a PnP Site Template to markdown format", Properties.Resources.Confirm))
+            if (!ShouldProcess($"Converts a PnP Site Template to markdown format", Properties.Resources.Confirm))
             {
-                var process = false;
-                var template = ProvisioningHelper.LoadSiteTemplateFromFile(TemplatePath, null, (exception) =>
-                     {
-                         throw new PSInvalidOperationException("Invalid template", exception);
-                     });
-                ITemplateFormatter mdFormatter = new MarkdownPnPFormatter();
-                if (ParameterSpecified(nameof(Out)))
+                return;
+            }
+
+            var template = ProvisioningHelper.LoadSiteTemplateFromFile(TemplatePath, null, (exception) =>
+            {
+                throw new PSInvalidOperationException("Invalid template", exception);
+            });
+
+            ITemplateFormatter mdFormatter = new MarkdownPnPFormatter();
+            using var outputStream = mdFormatter.ToFormattedTemplate(template);
+
+            if (ParameterSpecified(nameof(Out)))
+            {
+                if (!Path.IsPathRooted(Out))
                 {
-                    if (!Path.IsPathRooted(Out))
-                    {
-                        Out = System.IO.Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, Out);
-                    }
-                    if (File.Exists(Out))
-                    {
-                        if (Force || ShouldContinue(string.Format(Resources.File0ExistsOverwrite, Out), Resources.Confirm))
-                        {
-                            process = true;
-                        }
-                    }
-                    else
-                    {
-                        process = true;
-                    }
-                    if (process)
-                    {
-                        using (var outputStream = mdFormatter.ToFormattedTemplate(template))
-                        {
-                            using (var fileStream = File.Create(Out))
-                            {
-                                outputStream.Seek(0, SeekOrigin.Begin);
-                                outputStream.CopyTo(fileStream);
-                                fileStream.Close();
-                            }
-                        }
-                    }
+                    Out = System.IO.Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, Out);
                 }
-                else
+
+                if (File.Exists(Out)
+                    && !Force
+                    && !ShouldContinue(string.Format(Resources.File0ExistsOverwrite, Out), Resources.Confirm))
                 {
-                    using (var outputStream = mdFormatter.ToFormattedTemplate(template))
-                    {
-                        using (var reader = new StreamReader(outputStream))
-                        {
-                            WriteObject(reader.ReadToEnd());
-                        }
-                    }
+                    return;
+                }
+   
+                using (var fileStream = File.Create(Out))
+                {
+                    outputStream.CopyTo(fileStream);
+                }
+            }
+            else
+            {
+                using (var reader = new StreamReader(outputStream))
+                {
+                    WriteObject(reader.ReadToEnd());
                 }
             }
         }


### PR DESCRIPTION
allowing use in non-interactive scripts

this was broken in https://github.com/pnp/powershell/pull/4456