### PR TITLE
Adding launch profile for Visual Studio which builds in the VSCode way

### DIFF
--- a/src/Commands/Properties/launchSettings.json
+++ b/src/Commands/Properties/launchSettings.json
@@ -5,6 +5,12 @@
       "executablePath": "pwsh",
       "commandLineArgs": "-NoExit -NoProfile -Command Import-Module  $(ProjectDir)/_debug/debug.ps1",
       "workingDirectory": "$(ProjectDir)\\..\\..\\"
+    },
+    "PnP.PowerShell (VSCode style)": {
+      "commandName": "Executable",
+      "executablePath": "pwsh",
+      "commandLineArgs": "-NoExit -NoProfile -File $(SolutionDir)/../build/Build-Debug.ps1",
+      "workingDirectory": "$(ProjectDir)\\..\\..\\"
     }
   }
 }


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Adding launch profile for Visual Studio which builds in the Visual Studio Code way, so by generating a PSD1 and copying it over to the local profile folder instead of directly loading the DLLs from the debug folder