### PR TITLE
Add Get-PnPUnifiedGroupMoveState cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Current nightly]
 
 ### Added
-- Added `Get-PnPUnifiedGroupMoveState` cmdlet to retrieve SharePoint Online Microsoft 365 group move states.
+- Added `Get-PnPUnifiedGroupMoveState` cmdlet to retrieve SharePoint Online Microsoft 365 group move states. [#5362](https://github.com/pnp/powershell/pull/5362)
 - Added `Start-PnPUserAndContentMove` cmdlet to start SharePoint Online multi-geo user and OneDrive content move jobs. [#5355](https://github.com/pnp/powershell/pull/5355)
 - Added `Get-PnPUserAndContentMoveState` cmdlet to retrieve SharePoint Online user and OneDrive content move states.
 - Added `Get-PnPMultiGeoCompanyAllowedDataLocation` cmdlet to retrieve SharePoint Online multi-geo allowed data locations. [#5336](https://github.com/pnp/powershell/pull/5336)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Current nightly]
 
 ### Added
+- Added `Get-PnPUnifiedGroupMoveState` cmdlet to retrieve SharePoint Online Microsoft 365 group move states.
 - Added `Start-PnPUserAndContentMove` cmdlet to start SharePoint Online multi-geo user and OneDrive content move jobs. [#5355](https://github.com/pnp/powershell/pull/5355)
 - Added `Get-PnPUserAndContentMoveState` cmdlet to retrieve SharePoint Online user and OneDrive content move states.
 - Added `Get-PnPMultiGeoCompanyAllowedDataLocation` cmdlet to retrieve SharePoint Online multi-geo allowed data locations. [#5336](https://github.com/pnp/powershell/pull/5336)

--- a/documentation/Get-PnPUnifiedGroupMoveState.md
+++ b/documentation/Get-PnPUnifiedGroupMoveState.md
@@ -1,0 +1,79 @@
+---
+Module Name: PnP.PowerShell
+title: Get-PnPUnifiedGroupMoveState
+schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/Get-PnPUnifiedGroupMoveState.html
+---
+
+# Get-PnPUnifiedGroupMoveState
+
+## SYNOPSIS
+Returns the state of a SharePoint Online Microsoft 365 group move job.
+
+## SYNTAX
+
+```powershell
+Get-PnPUnifiedGroupMoveState [-GroupAlias] <String> [-Connection <PnPConnection>]
+```
+
+## DESCRIPTION
+Returns status information for a SharePoint Online multi-geo Microsoft 365 group move job by group alias.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Get-PnPUnifiedGroupMoveState -GroupAlias "contoso-marketing"
+```
+
+Returns the move state for the specified Microsoft 365 group.
+
+### EXAMPLE 2
+
+```powershell
+Get-PnPUnifiedGroupMoveState -GroupAlias "contoso-marketing" -Verbose
+```
+
+Returns the move state for the specified Microsoft 365 group and includes additional diagnostic properties.
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by specifying `-ReturnConnection` on `Connect-PnPOnline` or by executing `Get-PnPConnection`.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -GroupAlias
+The alias of the Microsoft 365 group whose move state should be retrieved.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## OUTPUTS
+
+### System.Management.Automation.PSObject
+Returns an object with `GroupName`, `MoveJobId`, `SourceDataLocation`, `DestinationDataLocation`, `TimeStamp`, and `MoveState` properties. Validation-only move jobs return `ValidationState` instead of `TimeStamp` and `MoveState`. When `-Verbose` is specified, additional move job details are returned.
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/src/Commands/Admin/GetUnifiedGroupMoveState.cs
+++ b/src/Commands/Admin/GetUnifiedGroupMoveState.cs
@@ -1,0 +1,29 @@
+using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Utilities.MultiGeo;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Admin
+{
+	[Cmdlet(VerbsCommon.Get, "PnPUnifiedGroupMoveState")]
+	[RequiredApiApplicationPermissions("sharepoint/Sites.FullControl.All")]
+	[RequiredApiDelegatedPermissions("sharepoint/AllSites.FullControl")]
+	[OutputType(typeof(PSObject))]
+	public class GetUnifiedGroupMoveState : PnPSharePointOnlineAdminCmdlet
+	{
+		[Parameter(Mandatory = true, Position = 0)]
+		public string GroupAlias { get; set; }
+
+		protected override void ExecuteCmdlet()
+		{
+			var multiGeoRestApiClient = new MultiGeoRestApiClient(AdminContext);
+			var moveState = multiGeoRestApiClient.GetUnifiedGroupMoveState(GroupAlias);
+			WriteObject(UserAndContentMoveStateFormatter.ConvertGroupMoveStateToPSObject(moveState, IsVerboseMode()));
+		}
+
+		private bool IsVerboseMode()
+		{
+			return MyInvocation.BoundParameters.TryGetValue("Verbose", out var verboseValue) && verboseValue is SwitchParameter verbose && verbose.ToBool();
+		}
+	}
+}

--- a/src/Commands/Admin/GetUnifiedGroupMoveState.cs
+++ b/src/Commands/Admin/GetUnifiedGroupMoveState.cs
@@ -12,13 +12,17 @@ namespace PnP.PowerShell.Commands.Admin
 	public class GetUnifiedGroupMoveState : PnPSharePointOnlineAdminCmdlet
 	{
 		[Parameter(Mandatory = true, Position = 0)]
+		[ValidateNotNullOrEmpty]
 		public string GroupAlias { get; set; }
 
 		protected override void ExecuteCmdlet()
 		{
 			var multiGeoRestApiClient = new MultiGeoRestApiClient(AdminContext);
 			var moveState = multiGeoRestApiClient.GetUnifiedGroupMoveState(GroupAlias);
-			WriteObject(UserAndContentMoveStateFormatter.ConvertGroupMoveStateToPSObject(moveState, IsVerboseMode()));
+			if (moveState != null)
+			{
+				WriteObject(UserAndContentMoveStateFormatter.ConvertGroupMoveStateToPSObject(moveState, IsVerboseMode()));
+			}
 		}
 
 		private bool IsVerboseMode()

--- a/src/Commands/Model/UserAndContentMoveState.cs
+++ b/src/Commands/Model/UserAndContentMoveState.cs
@@ -122,7 +122,7 @@ namespace PnP.PowerShell.Commands.Model
 		SuppressBcsCheck = 128,
 		EnableGLSSupportForXGeoMove = 256,
 		SuppressAllWarning = int.MinValue,
-		Force = int.MinValue
+		Force = SuppressAllWarning
 	}
 
 	public enum JobType

--- a/src/Commands/Model/UserAndContentMoveState.cs
+++ b/src/Commands/Model/UserAndContentMoveState.cs
@@ -60,6 +60,8 @@ namespace PnP.PowerShell.Commands.Model
 
 		public string UserPrincipalName { get; set; }
 
+		public string GroupName { get; set; }
+
 		[JsonConverter(typeof(JsonStringEnumConverter))]
 		public PreferredDataLocationValidationResult ValidationResult { get; set; }
 
@@ -119,6 +121,7 @@ namespace PnP.PowerShell.Commands.Model
 		ValidationOnlySource = 64,
 		SuppressBcsCheck = 128,
 		EnableGLSSupportForXGeoMove = 256,
+		SuppressAllWarning = int.MinValue,
 		Force = int.MinValue
 	}
 

--- a/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
+++ b/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
@@ -38,6 +38,8 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 		private const string UserMoveJobPathByUpn = "UserMoveJobs(upn='{0}')";
 		private const string UserMoveJobPathByMoveId = "UserMoveJobs/GetByMoveId(odbMoveId='{0}')";
 		private const string UserMoveJobsPathForMoveReport = "UserMoveJobs/GetMoveReport(moveState={0},moveDirection={1},startTime='{2:u}',endTime='{3:u}',limit='{4}')";
+		private const string GroupMoveJobsMinimumApiVersion = "1.3.0";
+		private const string GroupMoveJobPathByGroupName = "GroupMoveJobs(groupname='{0}')";
 		private const int MaximumPagination = 10;
 		private const int ApiVersionCacheValidTimeInHours = 1;
 		private static readonly TimeSpan CreateTenantRenameJobTimeout = TimeSpan.FromSeconds(300);
@@ -155,6 +157,13 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 			var apiVersion = GetCurrentApiVersion(UserMoveJobsReportMinimumApiVersion);
 			var path = string.Format(CultureInfo.InvariantCulture, UserMoveJobsPathForMoveReport, (int)moveState, (int)moveDirection, startTime, endTime, limit);
 			return GetFeed<UserAndContentMoveState>(path, apiVersion);
+		}
+
+		internal UserAndContentMoveState GetUnifiedGroupMoveState(string groupAlias)
+		{
+			var apiVersion = GetCurrentApiVersion(GroupMoveJobsMinimumApiVersion);
+			var path = string.Format(CultureInfo.InvariantCulture, GroupMoveJobPathByGroupName, ProcessSpecialChars(groupAlias));
+			return Get<UserAndContentMoveState>(path, apiVersion);
 		}
 
 		internal UserAndContentMoveState CreateUserMoveJob(UserMoveJobEntityData job)

--- a/src/Commands/Utilities/MultiGeo/UserAndContentMoveStateFormatter.cs
+++ b/src/Commands/Utilities/MultiGeo/UserAndContentMoveStateFormatter.cs
@@ -23,11 +23,6 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 		private static PSObject ConvertToPSObject(UserAndContentMoveState moveState, bool includeVerboseProperties, JobType moveJobType)
 		{
 			var result = new PSObject();
-			if (moveState == null)
-			{
-				return result;
-			}
-
 			AddMoveJobIdentityProperty(result, moveState, moveJobType);
 			AddProperty(result, "MoveJobId", moveState.Id);
 			AddProperty(result, "SourceDataLocation", moveState.SourceDataLocation);

--- a/src/Commands/Utilities/MultiGeo/UserAndContentMoveStateFormatter.cs
+++ b/src/Commands/Utilities/MultiGeo/UserAndContentMoveStateFormatter.cs
@@ -12,8 +12,23 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 
 		internal static PSObject ConvertToPSObject(UserAndContentMoveState moveState, bool includeVerboseProperties)
 		{
+			return ConvertToPSObject(moveState, includeVerboseProperties, JobType.UserMove);
+		}
+
+		internal static PSObject ConvertGroupMoveStateToPSObject(UserAndContentMoveState moveState, bool includeVerboseProperties)
+		{
+			return ConvertToPSObject(moveState, includeVerboseProperties, JobType.GroupMove);
+		}
+
+		private static PSObject ConvertToPSObject(UserAndContentMoveState moveState, bool includeVerboseProperties, JobType moveJobType)
+		{
 			var result = new PSObject();
-			AddProperty(result, "UserPrincipalName", moveState.UserPrincipalName);
+			if (moveState == null)
+			{
+				return result;
+			}
+
+			AddMoveJobIdentityProperty(result, moveState, moveJobType);
 			AddProperty(result, "MoveJobId", moveState.Id);
 			AddProperty(result, "SourceDataLocation", moveState.SourceDataLocation);
 			AddProperty(result, "DestinationDataLocation", moveState.DestinationDataLocation);
@@ -30,16 +45,30 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 
 			if (includeVerboseProperties)
 			{
-				AddVerboseProperties(result, moveState);
+				AddVerboseProperties(result, moveState, moveJobType);
 			}
 
 			return result;
 		}
 
-		private static void AddVerboseProperties(PSObject result, UserAndContentMoveState moveState)
+		private static void AddMoveJobIdentityProperty(PSObject result, UserAndContentMoveState moveState, JobType moveJobType)
 		{
-			AddProperty(result, "IsValidPDL", moveState.ValidationResult == PreferredDataLocationValidationResult.Valid);
-			AddProperty(result, "HasODBInCurrentLocation", moveState.HasOdbInSourceDataLocation);
+			if (moveJobType == JobType.GroupMove)
+			{
+				AddProperty(result, "GroupName", moveState.GroupName);
+				return;
+			}
+
+			AddProperty(result, "UserPrincipalName", moveState.UserPrincipalName);
+		}
+
+		private static void AddVerboseProperties(PSObject result, UserAndContentMoveState moveState, JobType moveJobType)
+		{
+			if (moveJobType == JobType.UserMove)
+			{
+				AddProperty(result, "IsValidPDL", moveState.ValidationResult == PreferredDataLocationValidationResult.Valid);
+				AddProperty(result, "HasODBInCurrentLocation", moveState.HasOdbInSourceDataLocation);
+			}
 
 			if (moveState.State == MoveState.Success)
 			{


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Adds `Get-PnPUnifiedGroupMoveState` to retrieve SharePoint Online multi-geo Microsoft 365 group move state by group alias, matching the SPO management shell request shape for `GroupMoveJobs(groupname='{0}')` with API version negotiation from `1.3.0`.

The cmdlet reuses the existing MultiGeo REST client and move-state formatter, adding only the group-specific response property and output path needed to produce the SPO-equivalent `PSObject` output. Documentation and the current nightly changelog entry are included.

### Guidance ###
N/A