### PR TITLE
Add Stop-PnPUserAndContentMove cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added `Start-PnPUserAndContentMove` cmdlet to start SharePoint Online multi-geo user and OneDrive content move jobs. [#5355](https://github.com/pnp/powershell/pull/5355)
 - Added `Get-PnPUserAndContentMoveState` cmdlet to retrieve SharePoint Online user and OneDrive content move states.
-- Added `Stop-PnPUserAndContentMove` cmdlet to stop SharePoint Online multi-geo user and OneDrive content move jobs.
+- Added `Stop-PnPUserAndContentMove` cmdlet to stop SharePoint Online multi-geo user and OneDrive content move jobs. [#5363](https://github.com/pnp/powershell/pull/5363)
 - Added `Get-PnPMultiGeoCompanyAllowedDataLocation` cmdlet to retrieve SharePoint Online multi-geo allowed data locations. [#5336](https://github.com/pnp/powershell/pull/5336)
 - Added `Get-PnPGeoMoveCrossCompatibilityStatus` cmdlet to retrieve SharePoint Online multi-geo move compatibility statuses.
 - Added `Get-PnPEntraIDAppListItemPermission`, `Grant-PnPEntraIDAppListItemPermission`, `Set-PnPEntraIDAppListItemPermission`, `Revoke-PnPEntraIDAppListItemPermission` to allow working with list item level app permissions [#5294](https://github.com/pnp/powershell/pull/5294)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added `Start-PnPUserAndContentMove` cmdlet to start SharePoint Online multi-geo user and OneDrive content move jobs. [#5355](https://github.com/pnp/powershell/pull/5355)
 - Added `Get-PnPUserAndContentMoveState` cmdlet to retrieve SharePoint Online user and OneDrive content move states.
+- Added `Stop-PnPUserAndContentMove` cmdlet to stop SharePoint Online multi-geo user and OneDrive content move jobs.
 - Added `Get-PnPMultiGeoCompanyAllowedDataLocation` cmdlet to retrieve SharePoint Online multi-geo allowed data locations. [#5336](https://github.com/pnp/powershell/pull/5336)
 - Added `Get-PnPGeoMoveCrossCompatibilityStatus` cmdlet to retrieve SharePoint Online multi-geo move compatibility statuses.
 - Added `Get-PnPEntraIDAppListItemPermission`, `Grant-PnPEntraIDAppListItemPermission`, `Set-PnPEntraIDAppListItemPermission`, `Revoke-PnPEntraIDAppListItemPermission` to allow working with list item level app permissions [#5294](https://github.com/pnp/powershell/pull/5294)

--- a/documentation/Get-PnPUserAndContentMoveState.md
+++ b/documentation/Get-PnPUserAndContentMoveState.md
@@ -190,4 +190,8 @@ Returns objects with `UserPrincipalName`, `MoveJobId`, `SourceDataLocation`, `De
 
 ## RELATED LINKS
 
+[Start-PnPUserAndContentMove](Start-PnPUserAndContentMove.md)
+
+[Stop-PnPUserAndContentMove](Stop-PnPUserAndContentMove.md)
+
 [Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/documentation/Start-PnPUserAndContentMove.md
+++ b/documentation/Start-PnPUserAndContentMove.md
@@ -180,6 +180,8 @@ Returns an object with `UserPrincipalName`, `MoveJobId`, `SourceDataLocation`, `
 
 [Get-PnPUserAndContentMoveState](Get-PnPUserAndContentMoveState.md)
 
+[Stop-PnPUserAndContentMove](Stop-PnPUserAndContentMove.md)
+
 [Get-PnPMultiGeoCompanyAllowedDataLocation](Get-PnPMultiGeoCompanyAllowedDataLocation.md)
 
 [Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/documentation/Stop-PnPUserAndContentMove.md
+++ b/documentation/Stop-PnPUserAndContentMove.md
@@ -1,0 +1,75 @@
+---
+Module Name: PnP.PowerShell
+title: Stop-PnPUserAndContentMove
+schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/Stop-PnPUserAndContentMove.html
+---
+
+# Stop-PnPUserAndContentMove
+
+## SYNOPSIS
+Stops a SharePoint Online multi-geo user and OneDrive content move job.
+
+## SYNTAX
+
+```powershell
+Stop-PnPUserAndContentMove [-UserPrincipalName] <String> [-Connection <PnPConnection>]
+```
+
+## DESCRIPTION
+Stops a SharePoint Online multi-geo move job for a user and the user's OneDrive content.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Stop-PnPUserAndContentMove -UserPrincipalName user@contoso.com
+```
+
+Stops the move job for the specified user.
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by specifying `-ReturnConnection` on `Connect-PnPOnline` or by executing `Get-PnPConnection`.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UserPrincipalName
+The user principal name of the user whose user and OneDrive content move job should be stopped.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## OUTPUTS
+
+### System.String
+Returns `The given move job has been stopped. Please run start cmdlet to restart the move.` when the move job has been stopped.
+
+## RELATED LINKS
+
+[Get-PnPUserAndContentMoveState](Get-PnPUserAndContentMoveState.md)
+
+[Start-PnPUserAndContentMove](Start-PnPUserAndContentMove.md)
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/src/Commands/Admin/StopUserAndContentMove.cs
+++ b/src/Commands/Admin/StopUserAndContentMove.cs
@@ -1,0 +1,24 @@
+using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Utilities.MultiGeo;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Admin
+{
+	[Cmdlet(VerbsLifecycle.Stop, "PnPUserAndContentMove")]
+	[RequiredApiApplicationPermissions("sharepoint/Sites.FullControl.All")]
+	[RequiredApiDelegatedPermissions("sharepoint/AllSites.FullControl")]
+	[OutputType(typeof(string))]
+	public class StopUserAndContentMove : PnPSharePointOnlineAdminCmdlet
+	{
+		[Parameter(Mandatory = true, Position = 1)]
+		public string UserPrincipalName { get; set; }
+
+		protected override void ExecuteCmdlet()
+		{
+			var multiGeoRestApiClient = new MultiGeoRestApiClient(AdminContext);
+			multiGeoRestApiClient.CancelUserMoveJob(UserPrincipalName);
+			WriteObject("The given move job has been stopped. Please run start cmdlet to restart the move.");
+		}
+	}
+}

--- a/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
+++ b/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
@@ -37,6 +37,7 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 		private const string UserMoveJobsPath = "UserMoveJobs";
 		private const string UserMoveJobPathByUpn = "UserMoveJobs(upn='{0}')";
 		private const string UserMoveJobPathByMoveId = "UserMoveJobs/GetByMoveId(odbMoveId='{0}')";
+		private const string UserMoveJobCancelPath = "UserMoveJobs(upn='{0}')/Cancel";
 		private const string UserMoveJobsPathForMoveReport = "UserMoveJobs/GetMoveReport(moveState={0},moveDirection={1},startTime='{2:u}',endTime='{3:u}',limit='{4}')";
 		private const int MaximumPagination = 10;
 		private const int ApiVersionCacheValidTimeInHours = 1;
@@ -168,6 +169,13 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 			return Post<UserAndContentMoveState>(UserMoveJobsPath, job, apiVersion: UserMoveJobsMinimumApiVersion);
 		}
 
+		internal void CancelUserMoveJob(string userPrincipalName)
+		{
+			var apiVersion = GetCurrentApiVersion(UserMoveJobsMinimumApiVersion);
+			var path = string.Format(CultureInfo.InvariantCulture, UserMoveJobCancelPath, ProcessSpecialChars(userPrincipalName));
+			PostWithEmptyBody(path, apiVersion);
+		}
+
 		internal void CancelTenantRenameJob()
 		{
 			Post<string>(TenantRenameJobsPathToCancelAJob, payload: null, apiVersion: TenantRenameCancelApiVersion);
@@ -227,6 +235,11 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 			var jsonPayload = payload == null ? null : JsonSerializer.Serialize(payload, SerializerOptions);
 			var responseText = Send(() => CreateRequest(HttpMethod.Post, path, apiVersion, jsonPayload), timeout, allowRetries: false);
 			return DeserializeResponse<T>(responseText);
+		}
+
+		private void PostWithEmptyBody(string path, string apiVersion)
+		{
+			Send(() => CreateRequest(HttpMethod.Post, path, apiVersion, string.Empty), timeout: null, allowRetries: false);
 		}
 
 		private HttpRequestMessage CreateRequest(HttpMethod method, string path, string apiVersion, string jsonPayload = null)

--- a/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
+++ b/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
@@ -37,7 +37,7 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 		private const string UserMoveJobsPath = "UserMoveJobs";
 		private const string UserMoveJobPathByUpn = "UserMoveJobs(upn='{0}')";
 		private const string UserMoveJobPathByMoveId = "UserMoveJobs/GetByMoveId(odbMoveId='{0}')";
-		private const string UserMoveJobCancelPath = "UserMoveJobs(upn='{0}')/Cancel";
+		private const string UserMoveJobCancelPath = UserMoveJobPathByUpn + "/Cancel";
 		private const string UserMoveJobsPathForMoveReport = "UserMoveJobs/GetMoveReport(moveState={0},moveDirection={1},startTime='{2:u}',endTime='{3:u}',limit='{4}')";
 		private const int MaximumPagination = 10;
 		private const int ApiVersionCacheValidTimeInHours = 1;


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
This adds a PnP equivalent for the SharePoint Online Management Shell `Stop-SPOUserAndContentMove` cmdlet so administrators can stop multi-geo user and OneDrive content move jobs from PnP PowerShell.

The cmdlet keeps the SPO behavior intentionally minimal: it accepts only `-UserPrincipalName`, uses the existing multigeo REST client, posts to the same `UserMoveJobs(upn='{user}')/Cancel` endpoint with an empty body, and returns the same success message as the SPO cmdlet. Documentation, related links, and the current nightly changelog were updated.

### Guidance ###
N/A