### PR TITLE
Add Get-PnPSiteContentMoveState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Current nightly]
 
 ### Added
+- Added `Get-PnPSiteContentMoveState` cmdlet to retrieve SharePoint Online site content move states.
 - Added `Get-PnPUnifiedGroupMoveState` cmdlet to retrieve SharePoint Online Microsoft 365 group move states. [#5362](https://github.com/pnp/powershell/pull/5362)
 - Added `Start-PnPUserAndContentMove` cmdlet to start SharePoint Online multi-geo user and OneDrive content move jobs. [#5355](https://github.com/pnp/powershell/pull/5355)
 - Added `Get-PnPUserAndContentMoveState` cmdlet to retrieve SharePoint Online user and OneDrive content move states.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Current nightly]
 
 ### Added
-- Added `Get-PnPSiteContentMoveState` cmdlet to retrieve SharePoint Online site content move states.
+- Added `Get-PnPSiteContentMoveState` cmdlet to retrieve SharePoint Online site content move states. [#5365](https://github.com/pnp/powershell/pull/5365)
 - Added `Get-PnPUnifiedGroupMoveState` cmdlet to retrieve SharePoint Online Microsoft 365 group move states. [#5362](https://github.com/pnp/powershell/pull/5362)
 - Added `Start-PnPUserAndContentMove` cmdlet to start SharePoint Online multi-geo user and OneDrive content move jobs. [#5355](https://github.com/pnp/powershell/pull/5355)
 - Added `Get-PnPUserAndContentMoveState` cmdlet to retrieve SharePoint Online user and OneDrive content move states.

--- a/documentation/Get-PnPSiteContentMoveState.md
+++ b/documentation/Get-PnPSiteContentMoveState.md
@@ -1,0 +1,197 @@
+---
+Module Name: PnP.PowerShell
+title: Get-PnPSiteContentMoveState
+schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/Get-PnPSiteContentMoveState.html
+---
+
+# Get-PnPSiteContentMoveState
+
+## SYNOPSIS
+Returns the state of SharePoint Online site content move jobs.
+
+## SYNTAX
+
+### MoveReport
+
+```powershell
+Get-PnPSiteContentMoveState [-Limit <UInt32>] [-MoveStartTime <DateTime>] [-MoveEndTime <DateTime>] [-MoveState <MoveState>] [-MoveDirection <MoveDirection>] [-Connection <PnPConnection>]
+```
+
+### SourceSiteUrl
+
+```powershell
+Get-PnPSiteContentMoveState -SourceSiteUrl <String> [-Connection <PnPConnection>]
+```
+
+### SiteMoveId
+
+```powershell
+Get-PnPSiteContentMoveState -SiteMoveId <Guid> [-Connection <PnPConnection>]
+```
+
+## DESCRIPTION
+Returns status information for SharePoint Online multi-geo site content move jobs. You can retrieve one move job by source site URL or site move ID, or retrieve a move report filtered by state, direction, time window, and limit. When no move state or direction is specified, all states and directions are returned.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Get-PnPSiteContentMoveState -SourceSiteUrl https://contoso.sharepoint.com/sites/project
+```
+
+Returns the move state for the specified source site.
+
+### EXAMPLE 2
+
+```powershell
+Get-PnPSiteContentMoveState -SiteMoveId 8f6f8e3a-2c1f-4d5b-9a7e-6b3c2a1f0e9d
+```
+
+Returns the move state for the specified site move job ID.
+
+### EXAMPLE 3
+
+```powershell
+Get-PnPSiteContentMoveState -MoveState All -MoveDirection All -Limit 100
+```
+
+Returns up to 100 site content move jobs regardless of state or direction.
+
+### EXAMPLE 4
+
+```powershell
+Get-PnPSiteContentMoveState -MoveStartTime (Get-Date).AddDays(-7) -MoveEndTime (Get-Date) -MoveState Failed -MoveDirection MoveOut -Verbose
+```
+
+Returns failed site move-out jobs from the last seven days and includes additional diagnostic properties.
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by specifying `-ReturnConnection` on `Connect-PnPOnline` or by executing `Get-PnPConnection`.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Limit
+Limits the number of move report entries returned. The value must be between 1 and 1000.
+
+```yaml
+Type: UInt32
+Parameter Sets: MoveReport
+
+Required: False
+Position: Named
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MoveDirection
+Filters move report entries by move direction. Valid values are `MoveOut`, `MoveIn`, and `All`.
+
+```yaml
+Type: MoveDirection
+Parameter Sets: MoveReport
+
+Required: False
+Position: Named
+Default value: All
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MoveEndTime
+Filters move report entries to moves ending at or before the specified date and time. The value is converted to UTC before it is sent to SharePoint Online.
+
+```yaml
+Type: DateTime
+Parameter Sets: MoveReport
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MoveStartTime
+Filters move report entries to moves starting at or after the specified date and time. The value is converted to UTC before it is sent to SharePoint Online.
+
+```yaml
+Type: DateTime
+Parameter Sets: MoveReport
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MoveState
+Filters move report entries by move state. Valid values are `NotStarted`, `InProgress`, `Success`, `Failed`, `Stopped`, `Queued`, `NotSupported`, `Rescheduled`, and `All`.
+
+```yaml
+Type: MoveState
+Parameter Sets: MoveReport
+
+Required: False
+Position: Named
+Default value: All
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SiteMoveId
+The site move job ID whose state should be retrieved.
+
+```yaml
+Type: Guid
+Parameter Sets: SiteMoveId
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceSiteUrl
+The source URL of the site collection whose move state should be retrieved.
+
+```yaml
+Type: String
+Parameter Sets: SourceSiteUrl
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## OUTPUTS
+
+### System.Management.Automation.PSObject
+Returns objects with `SourceSiteUrl`, `TargetSiteUrl`, `MoveJobId`, `SourceDataLocation`, `DestinationDataLocation`, `TimeStamp`, and `MoveState` properties. Validation-only move jobs return `ValidationState` instead of `TimeStamp` and `MoveState`. When `-Verbose` is specified, additional move job details are returned.
+
+## RELATED LINKS
+
+[Get-PnPUserAndContentMoveState](Get-PnPUserAndContentMoveState.md)
+
+[Get-PnPUnifiedGroupMoveState](Get-PnPUnifiedGroupMoveState.md)
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/src/Commands/Admin/GetSiteContentMoveState.cs
+++ b/src/Commands/Admin/GetSiteContentMoveState.cs
@@ -1,0 +1,85 @@
+using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Model;
+using PnP.PowerShell.Commands.Utilities.MultiGeo;
+using System;
+using System.Linq;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Admin
+{
+	[Cmdlet(VerbsCommon.Get, "PnPSiteContentMoveState", DefaultParameterSetName = ParameterSetMoveReport)]
+	[RequiredApiApplicationPermissions("sharepoint/Sites.FullControl.All")]
+	[RequiredApiDelegatedPermissions("sharepoint/AllSites.FullControl")]
+	[OutputType(typeof(PSObject))]
+	public class GetSiteContentMoveState : PnPSharePointOnlineAdminCmdlet
+	{
+		private const string ParameterSetMoveReport = "MoveReport";
+		private const string ParameterSetSourceSiteUrl = "SourceSiteUrl";
+		private const string ParameterSetSiteMoveId = "SiteMoveId";
+
+		[Parameter(Mandatory = true, ParameterSetName = ParameterSetSourceSiteUrl)]
+		[ValidateNotNullOrEmpty]
+		public string SourceSiteUrl { get; set; }
+
+		[Parameter(Mandatory = true, ParameterSetName = ParameterSetSiteMoveId)]
+		[ValidateNotNullOrEmpty]
+		public Guid SiteMoveId { get; set; }
+
+		[Parameter(Mandatory = false, ParameterSetName = ParameterSetMoveReport)]
+		[ValidateRange(1, 1000)]
+		public uint Limit { get; set; }
+
+		[Parameter(Mandatory = false, ParameterSetName = ParameterSetMoveReport)]
+		public DateTime MoveStartTime { get; set; }
+
+		[Parameter(Mandatory = false, ParameterSetName = ParameterSetMoveReport)]
+		public DateTime MoveEndTime { get; set; }
+
+		[Parameter(Mandatory = false, ParameterSetName = ParameterSetMoveReport)]
+		public MoveState MoveState { get; set; } = MoveState.All;
+
+		[Parameter(Mandatory = false, ParameterSetName = ParameterSetMoveReport)]
+		public MoveDirection MoveDirection { get; set; } = MoveDirection.All;
+
+		protected override void ExecuteCmdlet()
+		{
+			var multiGeoRestApiClient = new MultiGeoRestApiClient(AdminContext);
+			var includeVerboseProperties = IsVerboseMode();
+
+			if (ParameterSetName == ParameterSetSourceSiteUrl)
+			{
+				WriteMoveState(multiGeoRestApiClient.GetSiteMoveJob(SourceSiteUrl), includeVerboseProperties);
+				return;
+			}
+
+			if (ParameterSetName == ParameterSetSiteMoveId)
+			{
+				WriteMoveState(multiGeoRestApiClient.GetSiteMoveJob(SiteMoveId), includeVerboseProperties);
+				return;
+			}
+
+			var moveStartTimeInUtc = MoveStartTime == DateTime.MinValue ? DateTime.MinValue : MoveStartTime.ToUniversalTime();
+			var moveEndTimeInUtc = MoveEndTime == DateTime.MinValue ? DateTime.MinValue : MoveEndTime.ToUniversalTime();
+			var moveStates = multiGeoRestApiClient.GetSiteMoveJobs(MoveState, MoveDirection, moveStartTimeInUtc, moveEndTimeInUtc, Limit)
+				.Where(moveState => moveState != null)
+				.OrderByDescending(moveState => moveState.LastModified)
+				.Select(moveState => UserAndContentMoveStateFormatter.ConvertSiteMoveStateToPSObject(moveState, includeVerboseProperties));
+
+			WriteObject(moveStates, true);
+		}
+
+		private void WriteMoveState(SiteMoveJob moveState, bool includeVerboseProperties)
+		{
+			if (moveState != null)
+			{
+				WriteObject(UserAndContentMoveStateFormatter.ConvertSiteMoveStateToPSObject(moveState, includeVerboseProperties));
+			}
+		}
+
+		private bool IsVerboseMode()
+		{
+			return MyInvocation.BoundParameters.TryGetValue("Verbose", out var verboseValue) && verboseValue is SwitchParameter verbose && verbose.ToBool();
+		}
+	}
+}

--- a/src/Commands/Model/SiteMoveJob.cs
+++ b/src/Commands/Model/SiteMoveJob.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace PnP.PowerShell.Commands.Model
+{
+	/// <summary>
+	/// Contains the state of a SharePoint Online site content move job.
+	/// </summary>
+	public class SiteMoveJob
+	{
+		public string ApiVersion { get; set; }
+
+		public Guid Id { get; set; }
+
+		[JsonConverter(typeof(JsonStringEnumConverter))]
+		public MoveOption Option { get; set; }
+
+		public string Reserve { get; set; }
+
+		[JsonConverter(typeof(JsonStringEnumConverter))]
+		public JobSubType SubType { get; set; }
+
+		[JsonConverter(typeof(JsonStringEnumConverter))]
+		public JobType Type { get; set; }
+
+		public Guid BatchId { get; set; }
+
+		public string CancelTriggeredBy { get; set; }
+
+		public string DestinationDataLocation { get; set; }
+
+		[JsonConverter(typeof(JsonStringEnumConverter))]
+		public MoveDirection Direction { get; set; }
+
+		public string ErrorMessage { get; set; }
+
+		public DateTime FinishedDateInUtc { get; set; }
+
+		public bool IsReadOnlyAlertRaised { get; set; }
+
+		[JsonConverter(typeof(JsonStringEnumConverter))]
+		public MoveJobPhase JobPhase { get; set; }
+
+		public string Notify { get; set; }
+
+		public DateTime PreferredMoveBeginDateInUtc { get; set; }
+
+		public DateTime PreferredMoveEndDateInUtc { get; set; }
+
+		public Guid SiteId { get; set; }
+
+		public string SourceDataLocation { get; set; }
+
+		[JsonConverter(typeof(JsonStringEnumConverter))]
+		public MoveState State { get; set; }
+
+		public string TriggeredBy { get; set; }
+
+		public bool EnableRestoreOnSiteToMove { get; set; }
+
+		public bool EnableSiteToMoveDatastore { get; set; }
+
+		public Guid SourceCompanyId { get; set; }
+
+		public Guid SourceInstanceId { get; set; }
+
+		public string SourceMySiteHostUrl { get; set; }
+
+		public Guid SourceSiteSubscriptionId { get; set; }
+
+		public string SourceSiteUrl { get; set; }
+
+		public Guid TargetCompanyId { get; set; }
+
+		public string TargetFarmId { get; set; }
+
+		public Guid TargetInstanceId { get; set; }
+
+		public Guid TargetSiteSubscriptionId { get; set; }
+
+		public string TargetSiteUrl { get; set; }
+
+		public string TenantMergeSourceMySiteHostUrl { get; set; }
+
+		public string TenantMergeTargetMySiteHostUrl { get; set; }
+
+		public bool IsContentMoved { get; set; }
+
+		public DateTime LastModified { get; set; }
+
+		public DateTime StartedDateInUtc { get; set; }
+
+		public string StateName { get; set; }
+	}
+}

--- a/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
+++ b/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
@@ -42,6 +42,11 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 		private const string GroupMoveJobsMinimumApiVersion = "1.3.0";
 		private const string GroupMoveJobsPath = "GroupMoveJobs";
 		private const string GroupMoveJobPathByGroupName = "GroupMoveJobs(groupname='{0}')";
+		private const string SiteMoveJobsMinimumApiVersion = "1.3.0";
+		private const string SiteMoveJobsReportMinimumApiVersion = "1.3.8";
+		private const string SiteMoveJobPathByUrl = "SiteMoveJobs(url='{0}')";
+		private const string SiteMoveJobPathByMoveId = "SiteMoveJobs/GetByMoveId(SiteMoveId='{0}')";
+		private const string SiteMoveJobsPathForMoveReport = "SiteMoveJobs/GetMoveReport(moveState={0},moveDirection={1},startTime='{2:u}',endTime='{3:u}',limit='{4}')";
 		private const int MaximumPagination = 10;
 		private const int ApiVersionCacheValidTimeInHours = 1;
 		private static readonly TimeSpan CreateTenantRenameJobTimeout = TimeSpan.FromSeconds(300);
@@ -166,6 +171,27 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 			var apiVersion = GetCurrentApiVersion(GroupMoveJobsMinimumApiVersion);
 			var path = string.Format(CultureInfo.InvariantCulture, GroupMoveJobPathByGroupName, ProcessSpecialChars(groupAlias));
 			return Get<UserAndContentMoveState>(path, apiVersion);
+		}
+
+		internal SiteMoveJob GetSiteMoveJob(string sourceSiteUrl)
+		{
+			var apiVersion = GetCurrentApiVersion(SiteMoveJobsMinimumApiVersion);
+			var path = string.Format(CultureInfo.InvariantCulture, SiteMoveJobPathByUrl, ProcessSpecialChars(sourceSiteUrl));
+			return Get<SiteMoveJob>(path, apiVersion);
+		}
+
+		internal SiteMoveJob GetSiteMoveJob(Guid siteMoveId)
+		{
+			var apiVersion = GetCurrentApiVersion(SiteMoveJobsMinimumApiVersion);
+			var path = string.Format(CultureInfo.InvariantCulture, SiteMoveJobPathByMoveId, siteMoveId);
+			return Get<SiteMoveJob>(path, apiVersion);
+		}
+
+		internal IEnumerable<SiteMoveJob> GetSiteMoveJobs(MoveState moveState, MoveDirection moveDirection, DateTime startTime, DateTime endTime, uint limit)
+		{
+			var apiVersion = GetCurrentApiVersion(SiteMoveJobsReportMinimumApiVersion);
+			var path = string.Format(CultureInfo.InvariantCulture, SiteMoveJobsPathForMoveReport, (int)moveState, (int)moveDirection, startTime, endTime, limit);
+			return GetFeed<SiteMoveJob>(path, apiVersion);
 		}
 
 		internal UserAndContentMoveState CreateUserMoveJob(UserMoveJobEntityData job)

--- a/src/Commands/Utilities/MultiGeo/UserAndContentMoveStateFormatter.cs
+++ b/src/Commands/Utilities/MultiGeo/UserAndContentMoveStateFormatter.cs
@@ -25,6 +25,37 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 			return ConvertToPSObject(moveState, includeVerboseProperties, JobType.GroupMove, includeTimeStamp, useStateName);
 		}
 
+		internal static PSObject ConvertSiteMoveStateToPSObject(SiteMoveJob moveState, bool includeVerboseProperties)
+		{
+			var result = new PSObject();
+			AddProperty(result, "SourceSiteUrl", moveState.SourceSiteUrl);
+			AddProperty(result, "TargetSiteUrl", moveState.TargetSiteUrl);
+			AddProperty(result, "MoveJobId", moveState.Id);
+			AddProperty(result, "SourceDataLocation", moveState.SourceDataLocation);
+			AddProperty(result, "DestinationDataLocation", moveState.DestinationDataLocation);
+
+			if (!moveState.Option.HasFlag(MoveOption.ValidationOnly))
+			{
+				AddProperty(result, "TimeStamp", moveState.LastModified.ToLocalTime());
+			}
+
+			if (moveState.Option.HasFlag(MoveOption.ValidationOnly))
+			{
+				AddProperty(result, "ValidationState", "Success");
+			}
+			else
+			{
+				AddProperty(result, "MoveState", GetMoveStateDisplayValue(moveState.StateName, moveState.State, moveState.JobPhase));
+			}
+
+			if (includeVerboseProperties)
+			{
+				AddVerboseProperties(result, moveState);
+			}
+
+			return result;
+		}
+
 		private static PSObject ConvertToPSObject(UserAndContentMoveState moveState, bool includeVerboseProperties, JobType moveJobType, bool includeTimeStamp, bool useStateName)
 		{
 			var result = new PSObject();
@@ -96,19 +127,44 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 			AddProperty(result, "TriggeredBy", moveState.TriggeredBy);
 		}
 
-		private static string GetMoveStateDisplayValue(UserAndContentMoveState moveState)
+		private static void AddVerboseProperties(PSObject result, SiteMoveJob moveState)
 		{
-			if (!string.IsNullOrWhiteSpace(moveState.StateName))
+			if (moveState.State == MoveState.Success)
 			{
-				return moveState.StateName;
+				AddProperty(result, "IsContentMoved", moveState.IsContentMoved);
 			}
 
-			return moveState.State switch
+			AddProperty(result, "ErrorMessage", moveState.ErrorMessage);
+			AddProperty(result, "SiteId", moveState.SiteId);
+			AddProperty(result, "MoveDirection", moveState.Direction);
+			AddProperty(result, "MoveJobPhase", moveState.JobPhase);
+			AddProperty(result, "MoveJobType", moveState.Type);
+			AddProperty(result, "PreferredMoveBeginDate", FormatSpecificDate(moveState.PreferredMoveBeginDateInUtc));
+			AddProperty(result, "PreferredMoveEndDate", FormatSpecificDate(moveState.PreferredMoveEndDateInUtc));
+			AddProperty(result, "StartedDate", FormatSpecificDate(moveState.StartedDateInUtc));
+			AddProperty(result, "FinishedDate", FormatSpecificDate(moveState.FinishedDateInUtc));
+			AddProperty(result, "Option", moveState.Option);
+			AddProperty(result, "TriggeredBy", moveState.TriggeredBy);
+		}
+
+		private static string GetMoveStateDisplayValue(UserAndContentMoveState moveState)
+		{
+			return GetMoveStateDisplayValue(moveState.StateName, moveState.State, moveState.JobPhase);
+		}
+
+		private static string GetMoveStateDisplayValue(string stateName, MoveState state, MoveJobPhase jobPhase)
+		{
+			if (!string.IsNullOrWhiteSpace(stateName))
+			{
+				return stateName;
+			}
+
+			return state switch
 			{
 				MoveState.NotStarted => "ReadyToTrigger",
 				MoveState.Queued => "Scheduled",
-				MoveState.InProgress => string.Format(CultureInfo.InvariantCulture, "{0}({1}/4)", moveState.State, (int)moveState.JobPhase),
-				_ => moveState.State.ToString()
+				MoveState.InProgress => string.Format(CultureInfo.InvariantCulture, "{0}({1}/4)", state, (int)jobPhase),
+				_ => state.ToString()
 			};
 		}
 


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Adds `Get-PnPSiteContentMoveState` so administrators can retrieve SharePoint Online multi-geo site content move state by source site URL, site move ID, or move report filters.

The implementation reuses the existing multi-geo REST client and API version negotiation, adds SPO-compatible `SiteMoveJobs` endpoints, formats output to match the SPO cmdlet shape, and includes cmdlet documentation plus a Current nightly changelog entry.

### Guidance ###
N/A