### PR TITLE
Add Stop-PnPSiteContentMove cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Added `Get-PnPSiteContentMoveState` cmdlet to retrieve SharePoint Online site content move states. [#5365](https://github.com/pnp/powershell/pull/5365)
+- Added `Stop-PnPSiteContentMove` cmdlet to stop SharePoint Online multi-geo site content move jobs. [#5366](https://github.com/pnp/powershell/pull/5366)
 - Added `Get-PnPUnifiedGroupMoveState` cmdlet to retrieve SharePoint Online Microsoft 365 group move states. [#5362](https://github.com/pnp/powershell/pull/5362)
 - Added `Start-PnPUserAndContentMove` cmdlet to start SharePoint Online multi-geo user and OneDrive content move jobs. [#5355](https://github.com/pnp/powershell/pull/5355)
 - Added `Get-PnPUserAndContentMoveState` cmdlet to retrieve SharePoint Online user and OneDrive content move states.

--- a/documentation/Stop-PnPSiteContentMove.md
+++ b/documentation/Stop-PnPSiteContentMove.md
@@ -1,0 +1,71 @@
+---
+Module Name: PnP.PowerShell
+title: Stop-PnPSiteContentMove
+schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/Stop-PnPSiteContentMove.html
+---
+
+# Stop-PnPSiteContentMove
+
+## SYNOPSIS
+Stops a SharePoint Online multi-geo site content move job.
+
+## SYNTAX
+
+```powershell
+Stop-PnPSiteContentMove [-SourceSiteUrl] <String> [-Connection <PnPConnection>]
+```
+
+## DESCRIPTION
+Stops a SharePoint Online multi-geo site content move job for the specified source site URL.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Stop-PnPSiteContentMove -SourceSiteUrl https://contoso.sharepoint.com/sites/project
+```
+
+Stops the site content move job for the specified source site.
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by specifying `-ReturnConnection` on `Connect-PnPOnline` or by executing `Get-PnPConnection`.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceSiteUrl
+The URL of the source site whose site content move job should be stopped.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## OUTPUTS
+
+### System.String
+Returns `The given move job has been stopped.` when the move job has been stopped.
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/src/Commands/Admin/StopSiteContentMove.cs
+++ b/src/Commands/Admin/StopSiteContentMove.cs
@@ -1,0 +1,24 @@
+using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Utilities.MultiGeo;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Admin
+{
+	[Cmdlet(VerbsLifecycle.Stop, "PnPSiteContentMove")]
+	[RequiredApiApplicationPermissions("sharepoint/Sites.FullControl.All")]
+	[RequiredApiDelegatedPermissions("sharepoint/AllSites.FullControl")]
+	[OutputType(typeof(string))]
+	public class StopSiteContentMove : PnPSharePointOnlineAdminCmdlet
+	{
+		[Parameter(Mandatory = true, Position = 0)]
+		public string SourceSiteUrl { get; set; }
+
+		protected override void ExecuteCmdlet()
+		{
+			var multiGeoRestApiClient = new MultiGeoRestApiClient(AdminContext);
+			multiGeoRestApiClient.CancelSiteMoveJob(SourceSiteUrl);
+			WriteObject("The given move job has been stopped.");
+		}
+	}
+}

--- a/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
+++ b/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
@@ -47,6 +47,7 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 		private const string SiteMoveJobPathByUrl = "SiteMoveJobs(url='{0}')";
 		private const string SiteMoveJobPathByMoveId = "SiteMoveJobs/GetByMoveId(SiteMoveId='{0}')";
 		private const string SiteMoveJobsPathForMoveReport = "SiteMoveJobs/GetMoveReport(moveState={0},moveDirection={1},startTime='{2:u}',endTime='{3:u}',limit='{4}')";
+		private const string SiteMoveJobCancelPath = SiteMoveJobPathByUrl + "/Cancel";
 		private const int MaximumPagination = 10;
 		private const int ApiVersionCacheValidTimeInHours = 1;
 		private static readonly TimeSpan CreateTenantRenameJobTimeout = TimeSpan.FromSeconds(300);
@@ -226,6 +227,13 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 		{
 			var apiVersion = GetCurrentApiVersion(UserMoveJobsMinimumApiVersion);
 			var path = string.Format(CultureInfo.InvariantCulture, UserMoveJobCancelPath, ProcessSpecialChars(userPrincipalName));
+			PostWithEmptyBody(path, apiVersion);
+		}
+
+		internal void CancelSiteMoveJob(string sourceSiteUrl)
+		{
+			var apiVersion = GetCurrentApiVersion(SiteMoveJobsMinimumApiVersion);
+			var path = string.Format(CultureInfo.InvariantCulture, SiteMoveJobCancelPath, ProcessSpecialChars(sourceSiteUrl));
 			PostWithEmptyBody(path, apiVersion);
 		}
 


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Adds `Stop-PnPSiteContentMove` to stop SharePoint Online multi-geo site content move jobs. The cmdlet mirrors `Stop-SPOSiteContentMove` with a mandatory `SourceSiteUrl` parameter and reuses the existing multigeo REST client to call `SiteMoveJobs(url='{0}')/Cancel` with API version `1.3.0`.

The change also adds cmdlet documentation and a `Current nightly` changelog entry. Validated with `dotnet build src\Commands\PnP.PowerShell.csproj --no-restore --verbosity minimal`.

## Guidance ##
N/A