### PR TITLE
Add Start-PnPSiteContentMove cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `Stop-PnPUserAndContentMove` cmdlet to stop SharePoint Online multi-geo user and OneDrive content move jobs. [#5363](https://github.com/pnp/powershell/pull/5363)
 - Added `Get-PnPMultiGeoCompanyAllowedDataLocation` cmdlet to retrieve SharePoint Online multi-geo allowed data locations. [#5336](https://github.com/pnp/powershell/pull/5336)
 - Added `Get-PnPGeoMoveCrossCompatibilityStatus` cmdlet to retrieve SharePoint Online multi-geo move compatibility statuses.
+- Added `Start-PnPSiteContentMove` cmdlet to start SharePoint Online multi-geo site content move jobs.
 - Added `Get-PnPEntraIDAppListItemPermission`, `Grant-PnPEntraIDAppListItemPermission`, `Set-PnPEntraIDAppListItemPermission`, `Revoke-PnPEntraIDAppListItemPermission` to allow working with list item level app permissions [#5294](https://github.com/pnp/powershell/pull/5294)
 - Added `Get-PnPEntraIDAppListPermission`, `Grant-PnPEntraIDAppListPermission`, `Set-PnPEntraIDAppListPermission`, `Revoke-PnPEntraIDAppListPermission` to allow working with list level app permissions [#5293](https://github.com/pnp/powershell/pull/5293)
 - Added `Get-PnPEntraIDAppFilePermission`, `Grant-PnPEntraIDAppFilePermission`, `Set-PnPEntraIDAppFilePermission`, `Revoke-PnPEntraIDAppFilePermission` to allow working with file item app permissions [#5295](https://github.com/pnp/powershell/pull/5295)

--- a/documentation/Start-PnPSiteContentMove.md
+++ b/documentation/Start-PnPSiteContentMove.md
@@ -1,0 +1,271 @@
+---
+Module Name: PnP.PowerShell
+title: Start-PnPSiteContentMove
+schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/Start-PnPSiteContentMove.html
+---
+
+# Start-PnPSiteContentMove
+
+## SYNOPSIS
+Starts a SharePoint Online multi-geo site content move job.
+
+## SYNTAX
+
+### UrlAndDestinationDataLocation
+
+```powershell
+Start-PnPSiteContentMove [-SourceSiteUrl] <String> [-DestinationDataLocation] <String> [[-PreferredMoveBeginDate] <DateTime>] [[-PreferredMoveEndDate] <DateTime>] [[-Reserved] <String>] [-ValidationOnly] [-Force] [-SuppressMarketplaceAppCheck] [-SuppressWorkflow2013Check] [-SuppressAllWarnings] [-SuppressBcsCheck] [-Connection <PnPConnection>]
+```
+
+### UrlAndDestinationUrl
+
+```powershell
+Start-PnPSiteContentMove [-SourceSiteUrl] <String> [-DestinationUrl] <String> [[-PreferredMoveBeginDate] <DateTime>] [[-PreferredMoveEndDate] <DateTime>] [[-Reserved] <String>] [-ValidationOnly] [-Force] [-SuppressMarketplaceAppCheck] [-SuppressWorkflow2013Check] [-SuppressAllWarnings] [-SuppressBcsCheck] [-Connection <PnPConnection>]
+```
+
+## DESCRIPTION
+Starts a SharePoint Online multi-geo move job for a site collection. The move can target a destination data location or a destination site URL.
+
+Use `-ValidationOnly` to validate whether the site content can be moved without starting the move.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Start-PnPSiteContentMove -SourceSiteUrl "https://contoso.sharepoint.com/sites/project" -DestinationDataLocation EUR
+```
+
+Starts a move job for the specified site to the `EUR` data location.
+
+### EXAMPLE 2
+
+```powershell
+Start-PnPSiteContentMove -SourceSiteUrl "https://contoso.sharepoint.com/sites/project" -DestinationUrl "https://contoso.sharepoint.de/sites/project"
+```
+
+Starts a move job for the specified site to the destination URL.
+
+### EXAMPLE 3
+
+```powershell
+Start-PnPSiteContentMove -SourceSiteUrl "https://contoso.sharepoint.com/sites/project" -DestinationDataLocation EUR -PreferredMoveBeginDate "2026-06-20T22:00:00" -PreferredMoveEndDate "2026-06-21T04:00:00"
+```
+
+Starts a move job with a preferred move window. The preferred dates are converted to UTC before being sent to SharePoint Online.
+
+### EXAMPLE 4
+
+```powershell
+Start-PnPSiteContentMove -SourceSiteUrl "https://contoso.sharepoint.com/sites/project" -DestinationDataLocation EUR -ValidationOnly
+```
+
+Validates whether the site content can be moved to the `EUR` data location without starting the move.
+
+### EXAMPLE 5
+
+```powershell
+Start-PnPSiteContentMove -SourceSiteUrl "https://contoso.sharepoint.com/sites/project" -DestinationDataLocation EUR -SuppressMarketplaceAppCheck -SuppressWorkflow2013Check
+```
+
+Starts a move job and suppresses marketplace app and SharePoint 2013 workflow checks.
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by specifying `-ReturnConnection` on `Connect-PnPOnline` or by executing `Get-PnPConnection`.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DestinationDataLocation
+The destination SharePoint Online multi-geo data location code, such as `NAM` or `EUR`.
+
+```yaml
+Type: String
+Parameter Sets: UrlAndDestinationDataLocation
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DestinationUrl
+The destination site URL for the site content move job.
+
+```yaml
+Type: String
+Parameter Sets: UrlAndDestinationUrl
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+Suppresses all warnings returned by SharePoint Online for the move job request.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: 6
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PreferredMoveBeginDate
+The preferred date and time at which the move should begin. The value is converted to UTC before it is sent to SharePoint Online.
+
+```yaml
+Type: DateTime
+Parameter Sets: (All)
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PreferredMoveEndDate
+The preferred date and time at which the move should end. The value is converted to UTC before it is sent to SharePoint Online.
+
+```yaml
+Type: DateTime
+Parameter Sets: (All)
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Reserved
+Reserved for future use.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceSiteUrl
+The URL of the source site collection to move.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SuppressAllWarnings
+Suppresses all warnings returned by SharePoint Online for the move job request.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: 9
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SuppressBcsCheck
+Suppresses Business Connectivity Services checks for the move job request.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: 10
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SuppressMarketplaceAppCheck
+Suppresses marketplace app checks for the move job request.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: 7
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SuppressWorkflow2013Check
+Suppresses SharePoint 2013 workflow checks for the move job request.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: 8
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ValidationOnly
+Validates whether the site content can be moved without starting the move.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## OUTPUTS
+
+### System.Management.Automation.PSObject
+Returns an object with `SourceSiteUrl`, `TargetSiteUrl`, `MoveJobId`, `SourceDataLocation`, `DestinationDataLocation`, and `MoveState` properties. `TimeStamp` is included for non-validation move jobs when supported by the tenant Multi-Geo API version. Validation-only move jobs return `ValidationState` instead of `TimeStamp` and `MoveState`. When `-Verbose` is specified, additional move job details are returned.
+
+## RELATED LINKS
+
+[Get-PnPMultiGeoCompanyAllowedDataLocation](Get-PnPMultiGeoCompanyAllowedDataLocation.md)
+
+[Get-PnPGeoMoveCrossCompatibilityStatus](Get-PnPGeoMoveCrossCompatibilityStatus.md)
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/src/Commands/Admin/StartSiteContentMove.cs
+++ b/src/Commands/Admin/StartSiteContentMove.cs
@@ -1,0 +1,117 @@
+using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Model;
+using PnP.PowerShell.Commands.Utilities.MultiGeo;
+using System;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Admin
+{
+	[Cmdlet(VerbsLifecycle.Start, "PnPSiteContentMove", DefaultParameterSetName = ParameterSetUrlAndDestinationDataLocation)]
+	[RequiredApiApplicationPermissions("sharepoint/Sites.FullControl.All")]
+	[RequiredApiDelegatedPermissions("sharepoint/AllSites.FullControl")]
+	[OutputType(typeof(PSObject))]
+	public class StartSiteContentMove : PnPSharePointOnlineAdminCmdlet
+	{
+		private const string ParameterSetUrlAndDestinationDataLocation = "UrlAndDestinationDataLocation";
+		private const string ParameterSetUrlAndDestinationUrl = "UrlAndDestinationUrl";
+		private static readonly DateTime MinimumSpecifiedMoveDate = DateTime.MinValue.AddDays(1);
+
+		[Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetUrlAndDestinationDataLocation)]
+		[Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetUrlAndDestinationUrl)]
+		public string SourceSiteUrl { get; set; }
+
+		[Parameter(Mandatory = true, Position = 1, ParameterSetName = ParameterSetUrlAndDestinationDataLocation)]
+		public string DestinationDataLocation { get; set; }
+
+		[Parameter(Mandatory = true, Position = 1, ParameterSetName = ParameterSetUrlAndDestinationUrl)]
+		public string DestinationUrl { get; set; }
+
+		[Parameter(Mandatory = false, Position = 2)]
+		public DateTime PreferredMoveBeginDate { get; set; }
+
+		[Parameter(Mandatory = false, Position = 3)]
+		public DateTime PreferredMoveEndDate { get; set; }
+
+		[Parameter(Mandatory = false, Position = 4)]
+		public string Reserved { get; set; }
+
+		[Parameter(Mandatory = false, Position = 5)]
+		public SwitchParameter ValidationOnly { get; set; }
+
+		[Parameter(Mandatory = false, Position = 6)]
+		public SwitchParameter Force { get; set; }
+
+		[Parameter(Mandatory = false, Position = 7)]
+		public SwitchParameter SuppressMarketplaceAppCheck { get; set; }
+
+		[Parameter(Mandatory = false, Position = 8)]
+		public SwitchParameter SuppressWorkflow2013Check { get; set; }
+
+		[Parameter(Mandatory = false, Position = 9)]
+		public SwitchParameter SuppressAllWarnings { get; set; }
+
+		[Parameter(Mandatory = false, Position = 10)]
+		public SwitchParameter SuppressBcsCheck { get; set; }
+
+		protected override void ExecuteCmdlet()
+		{
+			var moveJob = new SiteMoveJobEntityData
+			{
+				SourceSiteUrl = SourceSiteUrl,
+				DestinationDataLocation = DestinationDataLocation,
+				TargetSiteUrl = DestinationUrl,
+				Reserve = Reserved
+			};
+
+			if (PreferredMoveBeginDate > MinimumSpecifiedMoveDate)
+			{
+				moveJob.PreferredMoveBeginDateInUtc = PreferredMoveBeginDate.ToUniversalTime();
+			}
+
+			if (PreferredMoveEndDate > MinimumSpecifiedMoveDate)
+			{
+				moveJob.PreferredMoveEndDateInUtc = PreferredMoveEndDate.ToUniversalTime();
+			}
+
+			if (ValidationOnly.ToBool())
+			{
+				moveJob.Option |= MoveOption.ValidationOnly;
+			}
+
+			if (Force.ToBool() || SuppressAllWarnings.ToBool())
+			{
+				moveJob.Option |= MoveOption.Force;
+			}
+
+			if (SuppressMarketplaceAppCheck.ToBool())
+			{
+				moveJob.Option |= MoveOption.SuppressMarketplaceAppCheck;
+			}
+
+			if (SuppressWorkflow2013Check.ToBool())
+			{
+				moveJob.Option |= MoveOption.SuppressWorkflow2013Check;
+			}
+
+			if (SuppressBcsCheck.ToBool())
+			{
+				moveJob.Option |= MoveOption.SuppressBcsCheck;
+			}
+
+			var multiGeoRestApiClient = new MultiGeoRestApiClient(AdminContext);
+			var createdMoveJob = multiGeoRestApiClient.CreateSiteMoveJob(moveJob);
+			if (createdMoveJob == null)
+			{
+				throw new PSInvalidOperationException("The site content move job could not be created. SharePoint Online did not return a response.");
+			}
+
+			WriteObject(UserAndContentMoveStateFormatter.ConvertSiteMoveStateToPSObject(createdMoveJob, IsVerboseMode()));
+		}
+
+		private bool IsVerboseMode()
+		{
+			return MyInvocation.BoundParameters.TryGetValue("Verbose", out var verboseValue) && verboseValue is SwitchParameter verbose && verbose.ToBool();
+		}
+	}
+}

--- a/src/Commands/Model/SiteMoveJobEntityData.cs
+++ b/src/Commands/Model/SiteMoveJobEntityData.cs
@@ -1,0 +1,50 @@
+using System;
+
+namespace PnP.PowerShell.Commands.Model
+{
+	/// <summary>
+	/// Contains the request data for a SharePoint Online site content multi-geo move job.
+	/// </summary>
+	internal class SiteMoveJobEntityData
+	{
+		public string ApiVersion { get; set; }
+
+		public Guid Id { get; set; }
+
+		public JobType Type { get; set; }
+
+		public MoveOption Option { get; set; }
+
+		public string Reserve { get; set; }
+
+		public MoveState State { get; set; }
+
+		public MoveJobPhase JobPhase { get; set; }
+
+		public MoveDirection Direction { get; set; }
+
+		public Guid SiteId { get; set; }
+
+		public string SourceDataLocation { get; set; }
+
+		public string DestinationDataLocation { get; set; }
+
+		public DateTime PreferredMoveBeginDateInUtc { get; set; }
+
+		public DateTime PreferredMoveEndDateInUtc { get; set; }
+
+		public DateTime FinishedDateInUtc { get; set; }
+
+		public string TriggeredBy { get; set; }
+
+		public string CancelTriggeredBy { get; set; }
+
+		public string ErrorMessage { get; set; }
+
+		public string Notify { get; set; }
+
+		public string SourceSiteUrl { get; set; }
+
+		public string TargetSiteUrl { get; set; }
+	}
+}

--- a/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
+++ b/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
@@ -44,6 +44,7 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 		private const string GroupMoveJobPathByGroupName = "GroupMoveJobs(groupname='{0}')";
 		private const string SiteMoveJobsMinimumApiVersion = "1.3.0";
 		private const string SiteMoveJobsReportMinimumApiVersion = "1.3.8";
+		private const string SiteMoveJobsPath = "SiteMoveJobs";
 		private const string SiteMoveJobPathByUrl = "SiteMoveJobs(url='{0}')";
 		private const string SiteMoveJobPathByMoveId = "SiteMoveJobs/GetByMoveId(SiteMoveId='{0}')";
 		private const string SiteMoveJobsPathForMoveReport = "SiteMoveJobs/GetMoveReport(moveState={0},moveDirection={1},startTime='{2:u}',endTime='{3:u}',limit='{4}')";
@@ -216,6 +217,18 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 			var apiVersion = GetCurrentApiVersion(GroupMoveJobsMinimumApiVersion);
 			job.ApiVersion = apiVersion;
 			return Post<UserAndContentMoveState>(GroupMoveJobsPath, job, apiVersion: apiVersion);
+		}
+
+		internal SiteMoveJob CreateSiteMoveJob(SiteMoveJobEntityData job)
+		{
+			if (job == null)
+			{
+				throw new ArgumentNullException(nameof(job));
+			}
+
+			var apiVersion = GetCurrentApiVersion(SiteMoveJobsMinimumApiVersion);
+			job.ApiVersion = apiVersion;
+			return Post<SiteMoveJob>(SiteMoveJobsPath, job, apiVersion: apiVersion);
 		}
 
 		internal bool IsCurrentApiVersionSupported(string minimumApiVersion)

--- a/src/Commands/Utilities/MultiGeo/UserAndContentMoveStateFormatter.cs
+++ b/src/Commands/Utilities/MultiGeo/UserAndContentMoveStateFormatter.cs
@@ -98,6 +98,13 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 				return;
 			}
 
+			if (moveJobType == JobType.SiteMove)
+			{
+				AddProperty(result, "SourceSiteUrl", moveState.SourceSiteUrl);
+				AddProperty(result, "TargetSiteUrl", moveState.TargetSiteUrl);
+				return;
+			}
+
 			AddProperty(result, "UserPrincipalName", moveState.UserPrincipalName);
 		}
 

--- a/src/Commands/Utilities/MultiGeo/UserAndContentMoveStateFormatter.cs
+++ b/src/Commands/Utilities/MultiGeo/UserAndContentMoveStateFormatter.cs
@@ -98,13 +98,6 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 				return;
 			}
 
-			if (moveJobType == JobType.SiteMove)
-			{
-				AddProperty(result, "SourceSiteUrl", moveState.SourceSiteUrl);
-				AddProperty(result, "TargetSiteUrl", moveState.TargetSiteUrl);
-				return;
-			}
-
 			AddProperty(result, "UserPrincipalName", moveState.UserPrincipalName);
 		}
 


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Adds `Start-PnPSiteContentMove` so administrators can start SharePoint Online multi-geo site content move jobs from PnP PowerShell with parity to the SPO Management Shell contract.

The cmdlet reuses the existing MultiGeo REST client and API version negotiation, calls the `SiteMoveJobs` endpoint, maps the SPO move option switches, and extends the common move-state formatter to include `SourceSiteUrl` and `TargetSiteUrl`. Documentation and a Current nightly changelog entry are included.

Validation performed: restored and built `src\Commands\PnP.PowerShell.csproj`, then reflected the compiled cmdlet metadata to verify the expected parameter sets.

### Guidance ###
N/A