### PR TITLE
Add Set-PnPMultiGeoExperience cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Current nightly]
 
 ### Added
+- Added `Set-PnPMultiGeoExperience` cmdlet to upgrade the tenant multi-geo experience to include SharePoint Online Multi-Geo.
 - Added `Get-PnPSiteContentMoveState` cmdlet to retrieve SharePoint Online site content move states. [#5365](https://github.com/pnp/powershell/pull/5365)
 - Added `Stop-PnPSiteContentMove` cmdlet to stop SharePoint Online multi-geo site content move jobs. [#5366](https://github.com/pnp/powershell/pull/5366)
 - Added `Get-PnPUnifiedGroupMoveState` cmdlet to retrieve SharePoint Online Microsoft 365 group move states. [#5362](https://github.com/pnp/powershell/pull/5362)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Current nightly]
 
 ### Added
-- Added `Set-PnPMultiGeoExperience` cmdlet to upgrade the tenant multi-geo experience to include SharePoint Online Multi-Geo.
+- Added `Set-PnPMultiGeoExperience` cmdlet to upgrade the tenant multi-geo experience to include SharePoint Online Multi-Geo. [#5369](https://github.com/pnp/powershell/pull/5369)
 - Added `Get-PnPSiteContentMoveState` cmdlet to retrieve SharePoint Online site content move states. [#5365](https://github.com/pnp/powershell/pull/5365)
 - Added `Stop-PnPSiteContentMove` cmdlet to stop SharePoint Online multi-geo site content move jobs. [#5366](https://github.com/pnp/powershell/pull/5366)
 - Added `Get-PnPUnifiedGroupMoveState` cmdlet to retrieve SharePoint Online Microsoft 365 group move states. [#5362](https://github.com/pnp/powershell/pull/5362)

--- a/documentation/Set-PnPMultiGeoExperience.md
+++ b/documentation/Set-PnPMultiGeoExperience.md
@@ -102,7 +102,9 @@ Accept wildcard characters: False
 ## OUTPUTS
 
 ### System.String
-Returns `This upgrade operation will take some time to take effect. Please run the cmdlet Get-SPOMultiGeoExperience to check the latest mode.`
+Returns the SharePoint Online Management Shell completion message: `This upgrade operation will take some time to take effect. Please run the cmdlet Get-SPOMultiGeoExperience to check the latest mode.`
+
+`Get-SPOMultiGeoExperience` is a SharePoint Online Management Shell cmdlet.
 
 ## RELATED LINKS
 

--- a/documentation/Set-PnPMultiGeoExperience.md
+++ b/documentation/Set-PnPMultiGeoExperience.md
@@ -1,0 +1,109 @@
+---
+Module Name: PnP.PowerShell
+title: Set-PnPMultiGeoExperience
+schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/Set-PnPMultiGeoExperience.html
+---
+ 
+# Set-PnPMultiGeoExperience
+
+## SYNOPSIS
+Upgrades the tenant multi-geo experience to include SharePoint Online Multi-Geo.
+
+## SYNTAX
+
+```powershell
+Set-PnPMultiGeoExperience [-AllInstances] [-Connection <PnPConnection>] [-WhatIf] [-Confirm]
+```
+
+## DESCRIPTION
+Upgrades the tenant multi-geo experience to include SharePoint Online Multi-Geo. This operation is not reversible and prompts for confirmation before it starts.
+
+The upgrade operation takes some time to take effect.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Set-PnPMultiGeoExperience
+```
+
+Upgrades the current instance's multi-geo experience to include SharePoint Online Multi-Geo.
+
+### EXAMPLE 2
+
+```powershell
+Set-PnPMultiGeoExperience -AllInstances
+```
+
+Upgrades all instances' multi-geo experience to include SharePoint Online Multi-Geo.
+
+## PARAMETERS
+
+### -AllInstances
+Upgrades all instances to the SharePoint Online Multi-Geo experience.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by specifying `-ReturnConnection` on `Connect-PnPOnline` or by executing `Get-PnPConnection`.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## OUTPUTS
+
+### System.String
+Returns `This upgrade operation will take some time to take effect. Please run the cmdlet Get-SPOMultiGeoExperience to check the latest mode.`
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/src/Commands/Admin/SetMultiGeoExperience.cs
+++ b/src/Commands/Admin/SetMultiGeoExperience.cs
@@ -19,6 +19,11 @@ namespace PnP.PowerShell.Commands.Admin
 
 		protected override void ExecuteCmdlet()
 		{
+			if (!ShouldProcess(AllInstances.ToBool() ? "all instances' multi-geo experience" : "current instance's multi-geo experience", "Upgrade to include SharePoint Online Multi-Geo"))
+			{
+				return;
+			}
+
 			var multiGeoRestApiClient = new MultiGeoRestApiClient(AdminContext);
 			multiGeoRestApiClient.EnsureGeoExperienceUpgradeSupported();
 

--- a/src/Commands/Admin/SetMultiGeoExperience.cs
+++ b/src/Commands/Admin/SetMultiGeoExperience.cs
@@ -1,0 +1,34 @@
+using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Utilities.MultiGeo;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Admin
+{
+	[Cmdlet(VerbsCommon.Set, "PnPMultiGeoExperience", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
+	[RequiredApiApplicationPermissions("sharepoint/Sites.FullControl.All")]
+	[RequiredApiDelegatedPermissions("sharepoint/AllSites.FullControl")]
+	[OutputType(typeof(string))]
+	public class SetMultiGeoExperience : PnPSharePointOnlineAdminCmdlet
+	{
+		private const string UpgradeConfirmationMessage = "This operation will upgrade your instance's multi-geo experience to include SharePoint Online Multi-Geo. This upgrade action is not reversible. Confirm that you want to continue this upgrade operation.";
+		private const string UpgradeCompletedMessage = "This upgrade operation will take some time to take effect. Please run the cmdlet Get-SPOMultiGeoExperience to check the latest mode.";
+
+		[Parameter(Mandatory = false)]
+		public SwitchParameter AllInstances { get; set; }
+
+		protected override void ExecuteCmdlet()
+		{
+			var multiGeoRestApiClient = new MultiGeoRestApiClient(AdminContext);
+			multiGeoRestApiClient.EnsureGeoExperienceUpgradeSupported();
+
+			if (!ShouldContinue(UpgradeConfirmationMessage, string.Empty))
+			{
+				return;
+			}
+
+			multiGeoRestApiClient.UpgradeGeoExperience(AllInstances.ToBool());
+			WriteObject(UpgradeCompletedMessage);
+		}
+	}
+}

--- a/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
+++ b/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -28,6 +29,9 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 		private const string TenantRenameJobsPathToCancelAJob = "TenantRenameJobs/Cancel";
 		private const string GeoMoveCompatibilityChecksMinimumApiVersion = "1.3.6";
 		private const string GeoMoveCompatibilityChecksPath = "GeoMoveCompatibilityChecks";
+		private const string GeoExperienceMinimumApiVersion = "1.3.7";
+		private const string UpdateGeoExperienceModePath = "GeoExperience/UpgradeToSPOMode";
+		private const string UpdateAllInstancesExperienceModePath = "GeoExperience/UpgradeAllInstancesToSPOMode";
 		private const string AllowedDataLocationsApiVersion = "1.3.11";
 		private const string AllowedDataLocationsPath = "AllowedDataLocations";
 		private const string MultiGeoApiVersionsPath = "MultiGeoApiVersions";
@@ -145,6 +149,17 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 		internal IEnumerable<MultiGeoCompanyAllowedDataLocation> GetAllowedDataLocations()
 		{
 			return GetFeed<MultiGeoCompanyAllowedDataLocation>(AllowedDataLocationsPath, AllowedDataLocationsApiVersion);
+		}
+
+		internal void UpgradeGeoExperience(bool allInstances)
+		{
+			var apiVersion = GetGeoExperienceApiVersion();
+			PostWithEmptyBody(allInstances ? UpdateAllInstancesExperienceModePath : UpdateGeoExperienceModePath, apiVersion);
+		}
+
+		internal void EnsureGeoExperienceUpgradeSupported()
+		{
+			GetGeoExperienceApiVersion();
 		}
 
 		internal UserAndContentMoveState GetUserAndContentMoveState(string userPrincipalName)
@@ -407,6 +422,23 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 			var apiVersionIndex = Array.IndexOf(ClientSupportedApiVersions, apiVersion);
 			var minimumApiVersionIndex = Array.IndexOf(ClientSupportedApiVersions, minimumApiVersion);
 			return apiVersionIndex >= 0 && minimumApiVersionIndex >= 0 && apiVersionIndex <= minimumApiVersionIndex;
+		}
+
+		private string GetGeoExperienceApiVersion()
+		{
+			var apiVersion = GetCurrentApiVersion();
+			if (!IsSupportedApiVersion(apiVersion, GeoExperienceMinimumApiVersion))
+			{
+				throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, "The client version '{0}' is not supported. Please try to upgrade client version first.", GetApplicationVersion()));
+			}
+
+			return apiVersion;
+		}
+
+		private static string GetApplicationVersion()
+		{
+			var assembly = Assembly.GetExecutingAssembly();
+			return assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version ?? assembly.GetName().Version?.ToString();
 		}
 
 		private string Send(Func<HttpRequestMessage> requestFactory, TimeSpan? timeout, bool allowRetries)


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Adds `Set-PnPMultiGeoExperience` to upgrade the tenant multi-geo experience to include SharePoint Online Multi-Geo.

The implementation reuses the existing `MultiGeoRestApiClient` and mirrors the SharePoint Online Management Shell behavior for the `GeoExperience/UpgradeToSPOMode` and `GeoExperience/UpgradeAllInstancesToSPOMode` endpoints, minimum API version `1.3.7`, empty POST body, confirmation text, success output, and unsupported-version error message. It also adds cmdlet documentation and a changelog entry.

Validated with `dotnet build src\Commands\PnP.PowerShell.csproj --no-restore`.

### Guidance ###
N/A