### PR TITLE
Add Set-PnPGeoStorageQuota cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `Set-PnPMultiGeoExperience` cmdlet to upgrade the tenant multi-geo experience to include SharePoint Online Multi-Geo. [#5369](https://github.com/pnp/powershell/pull/5369)
 - Added `Set-PnPMultiGeoCompanyAllowedDataLocation` cmdlet to start setting up a SharePoint Online multi-geo allowed data location. [#5368](https://github.com/pnp/powershell/pull/5368)
 - Added `Get-PnPGeoStorageQuota` cmdlet to retrieve SharePoint Online multi-geo storage quota details. [#5371](https://github.com/pnp/powershell/pull/5371)
+- Added `Set-PnPGeoStorageQuota` cmdlet to set SharePoint Online multi-geo storage quotas. [#5370](https://github.com/pnp/powershell/pull/5370)
 - Added `Get-PnPSiteContentMoveState` cmdlet to retrieve SharePoint Online site content move states. [#5365](https://github.com/pnp/powershell/pull/5365)
 - Added `Stop-PnPSiteContentMove` cmdlet to stop SharePoint Online multi-geo site content move jobs. [#5366](https://github.com/pnp/powershell/pull/5366)
 - Added `Get-PnPUnifiedGroupMoveState` cmdlet to retrieve SharePoint Online Microsoft 365 group move states. [#5362](https://github.com/pnp/powershell/pull/5362)

--- a/documentation/Set-PnPGeoStorageQuota.md
+++ b/documentation/Set-PnPGeoStorageQuota.md
@@ -1,0 +1,84 @@
+---
+Module Name: PnP.PowerShell
+title: Set-PnPGeoStorageQuota
+schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/Set-PnPGeoStorageQuota.html
+---
+ 
+# Set-PnPGeoStorageQuota
+
+## SYNOPSIS
+Sets the allocated storage quota for a SharePoint Online multi-geo location.
+
+## SYNTAX
+
+```powershell
+Set-PnPGeoStorageQuota -GeoLocation <String> -StorageQuotaMB <Int64> [-Connection <PnPConnection>]
+```
+
+## DESCRIPTION
+Sets the allocated storage quota, in megabytes, for a SharePoint Online multi-geo location.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Set-PnPGeoStorageQuota -GeoLocation EUR -StorageQuotaMB 1048576
+```
+
+Sets the allocated storage quota for the EUR geo location to 1,048,576 MB.
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by specifying `-ReturnConnection` on `Connect-PnPOnline` or by executing `Get-PnPConnection`.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -GeoLocation
+The multi-geo location code for which to set the allocated storage quota.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -StorageQuotaMB
+The allocated storage quota for the geo location, in megabytes.
+
+```yaml
+Type: Int64
+Parameter Sets: (All)
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## OUTPUTS
+
+### None
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/src/Commands/Admin/SetGeoStorageQuota.cs
+++ b/src/Commands/Admin/SetGeoStorageQuota.cs
@@ -1,0 +1,34 @@
+using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Model;
+using PnP.PowerShell.Commands.Utilities.MultiGeo;
+using System.Globalization;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Admin
+{
+	[Cmdlet(VerbsCommon.Set, "PnPGeoStorageQuota")]
+	[RequiredApiApplicationPermissions("sharepoint/Sites.FullControl.All")]
+	[RequiredApiDelegatedPermissions("sharepoint/AllSites.FullControl")]
+	public class SetGeoStorageQuota : PnPSharePointOnlineAdminCmdlet
+	{
+		[Parameter(Mandatory = true)]
+		[ValidateNotNullOrEmpty]
+		public string GeoLocation { get; set; }
+
+		[Parameter(Mandatory = true)]
+		public long StorageQuotaMB { get; set; }
+
+		protected override void ExecuteCmdlet()
+		{
+			var quota = new StorageQuotaEntityData
+			{
+				GeoLocation = GeoLocation,
+				GeoAllocatedStorageMB = StorageQuotaMB.ToString(CultureInfo.InvariantCulture)
+			};
+
+			var multiGeoRestApiClient = new MultiGeoRestApiClient(AdminContext);
+			multiGeoRestApiClient.PartialUpdateStorageQuota(quota);
+		}
+	}
+}

--- a/src/Commands/Model/StorageQuotaEntityData.cs
+++ b/src/Commands/Model/StorageQuotaEntityData.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Serialization;
+
+namespace PnP.PowerShell.Commands.Model
+{
+	/// <summary>
+	/// Contains the request data for updating a SharePoint Online multi-geo storage quota.
+	/// </summary>
+	internal class StorageQuotaEntityData
+	{
+		public string GeoLocation { get; set; }
+
+		[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+		public string GeoUsedStorageMB { get; set; }
+
+		[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+		public string GeoAvailableStorageMB { get; set; }
+
+		[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+		public string GeoAllocatedStorageMB { get; set; }
+
+		[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+		public string TenantStorageMB { get; set; }
+
+		public int QuotaType { get; set; }
+	}
+}

--- a/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
+++ b/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
@@ -39,6 +39,7 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 		private const string StorageQuotasPath = "StorageQuotas";
 		private const string StorageQuotaByLocationPath = "StorageQuotas(geoLocation='{0}')";
 		private const string MultiGeoApiVersionsPath = "MultiGeoApiVersions";
+		private const string PatchVerbString = "PATCH";
 		private const string UserMoveJobsMinimumApiVersion = "1.0";
 		private const string UserMoveJobsByMoveIdMinimumApiVersion = "1.2.2";
 		private const string UserMoveJobsReportMinimumApiVersion = "1.3.2";
@@ -190,7 +191,7 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 		internal StorageQuota GetStorageQuotaByLocation(string geoLocation)
 		{
 			var apiVersion = GetStorageQuotasApiVersion();
-			var path = string.Format(CultureInfo.InvariantCulture, StorageQuotaByLocationPath, geoLocation);
+			var path = string.Format(CultureInfo.InvariantCulture, StorageQuotaByLocationPath, ProcessSpecialChars(geoLocation));
 			return Get<StorageQuota>(path, apiVersion);
 		}
 
@@ -283,6 +284,18 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 			return IsSupportedApiVersion(GetCurrentApiVersion(), minimumApiVersion);
 		}
 
+		internal void PartialUpdateStorageQuota(StorageQuotaEntityData quota)
+		{
+			if (quota == null)
+			{
+				throw new ArgumentNullException(nameof(quota));
+			}
+
+			var apiVersion = GetStorageQuotasApiVersion();
+			var path = string.Format(CultureInfo.InvariantCulture, StorageQuotaByLocationPath, ProcessSpecialChars(quota.GeoLocation));
+			PostWithMethodOverride(path, quota, PatchVerbString, apiVersion);
+		}
+
 		internal void CancelUserMoveJob(string userPrincipalName)
 		{
 			var apiVersion = GetCurrentApiVersion(UserMoveJobsMinimumApiVersion);
@@ -367,6 +380,22 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 		private void PostWithEmptyBody(string path, string apiVersion)
 		{
 			Send(() => CreateRequest(HttpMethod.Post, path, apiVersion, string.Empty), timeout: null, allowRetries: false);
+		}
+
+		private void PostWithMethodOverride(string path, object payload, string methodOverride, string apiVersion)
+		{
+			var jsonPayload = payload == null ? null : JsonSerializer.Serialize(payload, SerializerOptions);
+			Send(() =>
+			{
+				var request = CreateRequest(HttpMethod.Post, path, apiVersion, jsonPayload);
+				request.Headers.TryAddWithoutValidation("X-HTTP-Method", methodOverride);
+				if (request.Content != null)
+				{
+					request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json;charset=UTF-8");
+				}
+
+				return request;
+			}, timeout: null, allowRetries: false);
 		}
 
 		private HttpRequestMessage CreateRequest(HttpMethod method, string path, string apiVersion, string jsonPayload = null)


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Adds `Set-PnPGeoStorageQuota` to set SharePoint Online multi-geo storage quotas using the same request shape as the SharePoint Online Management Shell cmdlet.

The cmdlet reuses the existing multi-geo REST client, sends a POST request with `X-HTTP-Method: PATCH` to `StorageQuotas(geoLocation='{0}')`, requires MultiGeo API version 1.3.1 or newer, and returns no output on success. Documentation and the current nightly changelog were also updated.

Validation completed:
- Built `src\Commands\PnP.PowerShell.csproj`
- Confirmed exported syntax for `Set-PnPGeoStorageQuota`
- Compared the serialized quota payload against the SPO shell payload

### Guidance ###
N/A