### PR TITLE
Add Get-PnPGeoStorageQuota cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added `Set-PnPMultiGeoExperience` cmdlet to upgrade the tenant multi-geo experience to include SharePoint Online Multi-Geo. [#5369](https://github.com/pnp/powershell/pull/5369)
 - Added `Set-PnPMultiGeoCompanyAllowedDataLocation` cmdlet to start setting up a SharePoint Online multi-geo allowed data location. [#5368](https://github.com/pnp/powershell/pull/5368)
+- Added `Get-PnPGeoStorageQuota` cmdlet to retrieve SharePoint Online multi-geo storage quota details. [#5371](https://github.com/pnp/powershell/pull/5371)
 - Added `Get-PnPSiteContentMoveState` cmdlet to retrieve SharePoint Online site content move states. [#5365](https://github.com/pnp/powershell/pull/5365)
 - Added `Stop-PnPSiteContentMove` cmdlet to stop SharePoint Online multi-geo site content move jobs. [#5366](https://github.com/pnp/powershell/pull/5366)
 - Added `Get-PnPUnifiedGroupMoveState` cmdlet to retrieve SharePoint Online Microsoft 365 group move states. [#5362](https://github.com/pnp/powershell/pull/5362)

--- a/documentation/Get-PnPGeoStorageQuota.md
+++ b/documentation/Get-PnPGeoStorageQuota.md
@@ -1,0 +1,81 @@
+---
+Module Name: PnP.PowerShell
+title: Get-PnPGeoStorageQuota
+schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/Get-PnPGeoStorageQuota.html
+---
+
+# Get-PnPGeoStorageQuota
+
+## SYNOPSIS
+Returns SharePoint Online storage quota details for multi-geo locations.
+
+## SYNTAX
+
+```powershell
+Get-PnPGeoStorageQuota [-AllLocations] [-Connection <PnPConnection>]
+```
+
+## DESCRIPTION
+Returns SharePoint Online storage quota details for the local geo location by default. Use `-AllLocations` to return storage quota details for all multi-geo locations.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Get-PnPGeoStorageQuota
+```
+
+Returns the storage quota details for the local geo location.
+
+### EXAMPLE 2
+
+```powershell
+Get-PnPGeoStorageQuota -AllLocations
+```
+
+Returns the storage quota details for all multi-geo locations.
+
+## PARAMETERS
+
+### -AllLocations
+Returns storage quota details for all multi-geo locations instead of only the local geo location.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by specifying `-ReturnConnection` on `Connect-PnPOnline` or by executing `Get-PnPConnection`.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## OUTPUTS
+
+### PnP.PowerShell.Commands.Model.StorageQuota
+Returns objects with `GeoLocation`, `GeoUsedStorageMB`, `GeoAvailableStorageMB`, `GeoAllocatedStorageMB`, `TenantStorageMB`, and `QuotaType` properties.
+
+## RELATED LINKS
+
+[Get-PnPMultiGeoCompanyAllowedDataLocation](Get-PnPMultiGeoCompanyAllowedDataLocation.md)
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/src/Commands/Admin/GetGeoStorageQuota.cs
+++ b/src/Commands/Admin/GetGeoStorageQuota.cs
@@ -1,0 +1,32 @@
+using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Model;
+using PnP.PowerShell.Commands.Utilities.MultiGeo;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Admin
+{
+	[Cmdlet(VerbsCommon.Get, "PnPGeoStorageQuota")]
+	[RequiredApiApplicationPermissions("sharepoint/Sites.FullControl.All")]
+	[RequiredApiDelegatedPermissions("sharepoint/AllSites.FullControl")]
+	[OutputType(typeof(StorageQuota))]
+	public class GetGeoStorageQuota : PnPSharePointOnlineAdminCmdlet
+	{
+		private const string LocalGeoLocation = "LOCAL";
+
+		[Parameter(Mandatory = false)]
+		public SwitchParameter AllLocations { get; set; }
+
+		protected override void ExecuteCmdlet()
+		{
+			var multiGeoRestApiClient = new MultiGeoRestApiClient(AdminContext);
+			if (AllLocations)
+			{
+				WriteObject(multiGeoRestApiClient.GetStorageQuotas(), true);
+				return;
+			}
+
+			WriteObject(multiGeoRestApiClient.GetStorageQuotaByLocation(LocalGeoLocation));
+		}
+	}
+}

--- a/src/Commands/Enums/QuotaType.cs
+++ b/src/Commands/Enums/QuotaType.cs
@@ -1,0 +1,18 @@
+namespace PnP.PowerShell.Commands.Enums
+{
+	/// <summary>
+	/// Specifies how SharePoint Online allocates storage quota for a multi-geo location.
+	/// </summary>
+	public enum QuotaType
+	{
+		/// <summary>
+		/// Storage quota is allocated directly to the geo location.
+		/// </summary>
+		Allocated = 0,
+
+		/// <summary>
+		/// Storage quota is shared across geo locations.
+		/// </summary>
+		CrossGeoShared = 1
+	}
+}

--- a/src/Commands/Model/StorageQuota.cs
+++ b/src/Commands/Model/StorageQuota.cs
@@ -1,0 +1,42 @@
+using PnP.PowerShell.Commands.Enums;
+using System.Text.Json.Serialization;
+
+namespace PnP.PowerShell.Commands.Model
+{
+	/// <summary>
+	/// Contains SharePoint Online storage quota details for a multi-geo location.
+	/// </summary>
+	public class StorageQuota
+	{
+		/// <summary>
+		/// The geo location code.
+		/// </summary>
+		public string GeoLocation { get; set; }
+
+		/// <summary>
+		/// The storage used by the geo location, in megabytes.
+		/// </summary>
+		public long GeoUsedStorageMB { get; set; }
+
+		/// <summary>
+		/// The storage available to the geo location, in megabytes.
+		/// </summary>
+		public long GeoAvailableStorageMB { get; set; }
+
+		/// <summary>
+		/// The storage allocated to the geo location, in megabytes.
+		/// </summary>
+		public long GeoAllocatedStorageMB { get; set; }
+
+		/// <summary>
+		/// The total tenant storage, in megabytes.
+		/// </summary>
+		public long TenantStorageMB { get; set; }
+
+		/// <summary>
+		/// The storage quota type.
+		/// </summary>
+		[JsonConverter(typeof(JsonStringEnumConverter))]
+		public QuotaType QuotaType { get; set; }
+	}
+}

--- a/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
+++ b/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
@@ -35,6 +35,9 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 		private const string UpdateAllInstancesExperienceModePath = "GeoExperience/UpgradeAllInstancesToSPOMode";
 		private const string AllowedDataLocationsApiVersion = "1.3.11";
 		private const string AllowedDataLocationsPath = "AllowedDataLocations";
+		private const string StorageQuotasMinimumApiVersion = "1.3.1";
+		private const string StorageQuotasPath = "StorageQuotas";
+		private const string StorageQuotaByLocationPath = "StorageQuotas(geoLocation='{0}')";
 		private const string MultiGeoApiVersionsPath = "MultiGeoApiVersions";
 		private const string UserMoveJobsMinimumApiVersion = "1.0";
 		private const string UserMoveJobsByMoveIdMinimumApiVersion = "1.2.2";
@@ -177,6 +180,18 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 			}
 
 			PostWithoutResponse(AllowedDataLocationsPath, allowedDataLocation, apiVersion);
+		}
+
+		internal IEnumerable<StorageQuota> GetStorageQuotas()
+		{
+			return GetFeed<StorageQuota>(StorageQuotasPath, GetStorageQuotasApiVersion());
+		}
+
+		internal StorageQuota GetStorageQuotaByLocation(string geoLocation)
+		{
+			var apiVersion = GetStorageQuotasApiVersion();
+			var path = string.Format(CultureInfo.InvariantCulture, StorageQuotaByLocationPath, geoLocation);
+			return Get<StorageQuota>(path, apiVersion);
 		}
 
 		internal UserAndContentMoveState GetUserAndContentMoveState(string userPrincipalName)
@@ -445,6 +460,17 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 			var apiVersionIndex = Array.IndexOf(ClientSupportedApiVersions, apiVersion);
 			var minimumApiVersionIndex = Array.IndexOf(ClientSupportedApiVersions, minimumApiVersion);
 			return apiVersionIndex >= 0 && minimumApiVersionIndex >= 0 && apiVersionIndex <= minimumApiVersionIndex;
+		}
+
+		private string GetStorageQuotasApiVersion()
+		{
+			var apiVersion = GetCurrentApiVersion();
+			if (!IsSupportedApiVersion(apiVersion, StorageQuotasMinimumApiVersion))
+			{
+				throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, CommandResources.CrossGeoInvalidVersion, GetApplicationVersion()));
+			}
+
+			return apiVersion;
 		}
 
 		private string GetGeoExperienceApiVersion()


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Adds `Get-PnPGeoStorageQuota` so PnP PowerShell can retrieve SharePoint Online multi-geo storage quota details using the same REST endpoints as SPO Management Shell.

The cmdlet reuses the existing multi-geo REST client and mirrors the SPO behavior: default lookup calls `StorageQuotas(geoLocation='LOCAL')`, `-AllLocations` calls `StorageQuotas`, and the minimum multi-geo API version is `1.3.1`. It also adds the matching output model, `QuotaType` enum, cmdlet documentation, and changelog entry.

### Guidance ###
N/A