### PR TITLE
Add Get-PnPMultiGeoExperience cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Current nightly]
 
 ### Added
-- Added `Get-PnPMultiGeoExperience` cmdlet to retrieve the SharePoint Online multi-geo experience mode.
+- Added `Get-PnPMultiGeoExperience` cmdlet to retrieve the SharePoint Online multi-geo experience mode. [#5372](https://github.com/pnp/powershell/pull/5372)
 - Added `Set-PnPMultiGeoExperience` cmdlet to upgrade the tenant multi-geo experience to include SharePoint Online Multi-Geo. [#5369](https://github.com/pnp/powershell/pull/5369)
 - Added `Set-PnPMultiGeoCompanyAllowedDataLocation` cmdlet to start setting up a SharePoint Online multi-geo allowed data location. [#5368](https://github.com/pnp/powershell/pull/5368)
 - Added `Get-PnPGeoStorageQuota` cmdlet to retrieve SharePoint Online multi-geo storage quota details. [#5371](https://github.com/pnp/powershell/pull/5371)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Current nightly]
 
 ### Added
+- Added `Get-PnPMultiGeoExperience` cmdlet to retrieve the SharePoint Online multi-geo experience mode.
 - Added `Set-PnPMultiGeoExperience` cmdlet to upgrade the tenant multi-geo experience to include SharePoint Online Multi-Geo. [#5369](https://github.com/pnp/powershell/pull/5369)
 - Added `Set-PnPMultiGeoCompanyAllowedDataLocation` cmdlet to start setting up a SharePoint Online multi-geo allowed data location. [#5368](https://github.com/pnp/powershell/pull/5368)
 - Added `Get-PnPGeoStorageQuota` cmdlet to retrieve SharePoint Online multi-geo storage quota details. [#5371](https://github.com/pnp/powershell/pull/5371)

--- a/documentation/Get-PnPMultiGeoExperience.md
+++ b/documentation/Get-PnPMultiGeoExperience.md
@@ -1,0 +1,59 @@
+---
+Module Name: PnP.PowerShell
+title: Get-PnPMultiGeoExperience
+schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/Get-PnPMultiGeoExperience.html
+---
+ 
+# Get-PnPMultiGeoExperience
+
+## SYNOPSIS
+Returns the SharePoint Online multi-geo experience mode.
+
+## SYNTAX
+
+```powershell
+Get-PnPMultiGeoExperience [-Connection <PnPConnection>]
+```
+
+## DESCRIPTION
+Returns the SharePoint Online multi-geo experience mode for the current geo location.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Get-PnPMultiGeoExperience
+```
+
+Returns the SharePoint Online multi-geo experience mode for the current geo location.
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by specifying `-ReturnConnection` on `Connect-PnPOnline` or by executing `Get-PnPConnection`.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## OUTPUTS
+
+### PnP.PowerShell.Commands.Model.MultiGeoExperience
+Returns an object with `GeoLocation` and `MultiGeoExperienceMode` properties.
+
+## RELATED LINKS
+
+[Set-PnPMultiGeoExperience](Set-PnPMultiGeoExperience.md)
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/documentation/Set-PnPMultiGeoExperience.md
+++ b/documentation/Set-PnPMultiGeoExperience.md
@@ -108,4 +108,6 @@ Returns the SharePoint Online Management Shell completion message: `This upgrade
 
 ## RELATED LINKS
 
+[Get-PnPMultiGeoExperience](Get-PnPMultiGeoExperience.md)
+
 [Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/src/Commands/Admin/GetMultiGeoExperience.cs
+++ b/src/Commands/Admin/GetMultiGeoExperience.cs
@@ -1,0 +1,21 @@
+using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Model;
+using PnP.PowerShell.Commands.Utilities.MultiGeo;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Admin
+{
+	[Cmdlet(VerbsCommon.Get, "PnPMultiGeoExperience")]
+	[RequiredApiApplicationPermissions("sharepoint/Sites.FullControl.All")]
+	[RequiredApiDelegatedPermissions("sharepoint/AllSites.FullControl")]
+	[OutputType(typeof(MultiGeoExperience))]
+	public class GetMultiGeoExperience : PnPSharePointOnlineAdminCmdlet
+	{
+		protected override void ExecuteCmdlet()
+		{
+			var multiGeoRestApiClient = new MultiGeoRestApiClient(AdminContext);
+			WriteObject(multiGeoRestApiClient.GetGeoExperience());
+		}
+	}
+}

--- a/src/Commands/Enums/MultiGeoExperienceMode.cs
+++ b/src/Commands/Enums/MultiGeoExperienceMode.cs
@@ -1,0 +1,18 @@
+namespace PnP.PowerShell.Commands.Enums
+{
+	/// <summary>
+	/// Specifies the SharePoint Online multi-geo experience mode.
+	/// </summary>
+	public enum MultiGeoExperienceMode
+	{
+		/// <summary>
+		/// SharePoint Online Multi-Geo experience mode.
+		/// </summary>
+		SPO = 0,
+
+		/// <summary>
+		/// OneDrive Multi-Geo experience mode.
+		/// </summary>
+		ODB = 1
+	}
+}

--- a/src/Commands/Model/MultiGeoExperience.cs
+++ b/src/Commands/Model/MultiGeoExperience.cs
@@ -1,0 +1,22 @@
+using PnP.PowerShell.Commands.Enums;
+using System.Text.Json.Serialization;
+
+namespace PnP.PowerShell.Commands.Model
+{
+	/// <summary>
+	/// Contains the SharePoint Online multi-geo experience mode for a geo location.
+	/// </summary>
+	public class MultiGeoExperience
+	{
+		/// <summary>
+		/// The geo location code.
+		/// </summary>
+		public string GeoLocation { get; set; }
+
+		/// <summary>
+		/// The SharePoint Online multi-geo experience mode.
+		/// </summary>
+		[JsonConverter(typeof(JsonStringEnumConverter))]
+		public MultiGeoExperienceMode MultiGeoExperienceMode { get; set; }
+	}
+}

--- a/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
+++ b/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
@@ -31,6 +31,7 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 		private const string GeoMoveCompatibilityChecksMinimumApiVersion = "1.3.6";
 		private const string GeoMoveCompatibilityChecksPath = "GeoMoveCompatibilityChecks";
 		private const string GeoExperienceMinimumApiVersion = "1.3.7";
+		private const string GeoExperiencePath = "GeoExperience";
 		private const string UpdateGeoExperienceModePath = "GeoExperience/UpgradeToSPOMode";
 		private const string UpdateAllInstancesExperienceModePath = "GeoExperience/UpgradeAllInstancesToSPOMode";
 		private const string AllowedDataLocationsApiVersion = "1.3.11";
@@ -149,6 +150,11 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 		internal IEnumerable<GeoMoveTenantCompatibilityCheck> GetGeoMoveCompatibilityChecks()
 		{
 			return GetFeed<GeoMoveTenantCompatibilityCheck>(GeoMoveCompatibilityChecksPath, GetCurrentApiVersion(GeoMoveCompatibilityChecksMinimumApiVersion));
+		}
+
+		internal MultiGeoExperience GetGeoExperience()
+		{
+			return Get<MultiGeoExperience>(GeoExperiencePath, GetGeoExperienceApiVersion());
 		}
 
 		internal IEnumerable<MultiGeoCompanyAllowedDataLocation> GetAllowedDataLocations()


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Adds `Get-PnPMultiGeoExperience` so PnP PowerShell can retrieve the SharePoint Online multi-geo experience mode without requiring the SPO Management Shell cmdlet.

The implementation reuses the existing multi-geo REST client and calls the same `GeoExperience` endpoint with the existing API version negotiation used by `Set-PnPMultiGeoExperience`. It adds the matching response model and `MultiGeoExperienceMode` enum shape, plus cmdlet documentation, a related link from `Set-PnPMultiGeoExperience`, and a changelog entry.

### Guidance ###
N/A