### PR TITLE
Add Get-PnPGeoAdministrator cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Current nightly]
 
 ### Added
+- Added `Get-PnPGeoAdministrator` cmdlet to retrieve SharePoint Online geo administrators.
 - Added `Get-PnPMultiGeoExperience` cmdlet to retrieve the SharePoint Online multi-geo experience mode. [#5372](https://github.com/pnp/powershell/pull/5372)
 - Added `Set-PnPMultiGeoExperience` cmdlet to upgrade the tenant multi-geo experience to include SharePoint Online Multi-Geo. [#5369](https://github.com/pnp/powershell/pull/5369)
 - Added `Set-PnPMultiGeoCompanyAllowedDataLocation` cmdlet to start setting up a SharePoint Online multi-geo allowed data location. [#5368](https://github.com/pnp/powershell/pull/5368)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Current nightly]
 
 ### Added
-- Added `Get-PnPGeoAdministrator` cmdlet to retrieve SharePoint Online geo administrators.
+- Added `Get-PnPGeoAdministrator` cmdlet to retrieve SharePoint Online geo administrators. [#5378](https://github.com/pnp/powershell/pull/5378)
 - Added `Get-PnPMultiGeoExperience` cmdlet to retrieve the SharePoint Online multi-geo experience mode. [#5372](https://github.com/pnp/powershell/pull/5372)
 - Added `Set-PnPMultiGeoExperience` cmdlet to upgrade the tenant multi-geo experience to include SharePoint Online Multi-Geo. [#5369](https://github.com/pnp/powershell/pull/5369)
 - Added `Set-PnPMultiGeoCompanyAllowedDataLocation` cmdlet to start setting up a SharePoint Online multi-geo allowed data location. [#5368](https://github.com/pnp/powershell/pull/5368)

--- a/documentation/Get-PnPGeoAdministrator.md
+++ b/documentation/Get-PnPGeoAdministrator.md
@@ -1,0 +1,59 @@
+---
+Module Name: PnP.PowerShell
+title: Get-PnPGeoAdministrator
+schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/Get-PnPGeoAdministrator.html
+---
+
+# Get-PnPGeoAdministrator
+
+## SYNOPSIS
+Returns SharePoint Online geo administrators.
+
+## SYNTAX
+
+```powershell
+Get-PnPGeoAdministrator [-Connection <PnPConnection>]
+```
+
+## DESCRIPTION
+Returns the SharePoint Online geo administrators configured for the tenant.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Get-PnPGeoAdministrator
+```
+
+Returns all SharePoint Online geo administrators.
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by specifying `-ReturnConnection` on `Connect-PnPOnline` or by executing `Get-PnPConnection`.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## OUTPUTS
+
+### PnP.PowerShell.Commands.Model.GeoAdministrator
+Returns objects with `DisplayName`, `LoginName`, `MemberType`, `ObjectId`, and `GeoLocation` properties.
+
+## RELATED LINKS
+
+[Get-PnPMultiGeoCompanyAllowedDataLocation](Get-PnPMultiGeoCompanyAllowedDataLocation.md)
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/src/Commands/Admin/GetGeoAdministrator.cs
+++ b/src/Commands/Admin/GetGeoAdministrator.cs
@@ -1,0 +1,21 @@
+using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Model;
+using PnP.PowerShell.Commands.Utilities.MultiGeo;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Admin
+{
+	[Cmdlet(VerbsCommon.Get, "PnPGeoAdministrator")]
+	[RequiredApiApplicationPermissions("sharepoint/Sites.FullControl.All")]
+	[RequiredApiDelegatedPermissions("sharepoint/AllSites.FullControl")]
+	[OutputType(typeof(GeoAdministrator))]
+	public class GetGeoAdministrator : PnPSharePointOnlineAdminCmdlet
+	{
+		protected override void ExecuteCmdlet()
+		{
+			var multiGeoRestApiClient = new MultiGeoRestApiClient(AdminContext);
+			WriteObject(multiGeoRestApiClient.GetGeoAdministrators().GeoAdministrators, true);
+		}
+	}
+}

--- a/src/Commands/Enums/GroupMemberType.cs
+++ b/src/Commands/Enums/GroupMemberType.cs
@@ -1,0 +1,23 @@
+namespace PnP.PowerShell.Commands.Enums
+{
+	/// <summary>
+	/// Specifies the member type for a SharePoint Online geo administrator.
+	/// </summary>
+	public enum GroupMemberType
+	{
+		/// <summary>
+		/// The member type is unknown.
+		/// </summary>
+		Unknown = 0,
+
+		/// <summary>
+		/// The member is a user.
+		/// </summary>
+		User = 1,
+
+		/// <summary>
+		/// The member is a group.
+		/// </summary>
+		Group = 2
+	}
+}

--- a/src/Commands/Model/GeoAdministrator.cs
+++ b/src/Commands/Model/GeoAdministrator.cs
@@ -1,0 +1,36 @@
+using PnP.PowerShell.Commands.Enums;
+using System;
+
+namespace PnP.PowerShell.Commands.Model
+{
+	/// <summary>
+	/// Contains a SharePoint Online geo administrator.
+	/// </summary>
+	public class GeoAdministrator
+	{
+		/// <summary>
+		/// The display name of the geo administrator.
+		/// </summary>
+		public string DisplayName { get; set; }
+
+		/// <summary>
+		/// The login name of the geo administrator.
+		/// </summary>
+		public string LoginName { get; set; }
+
+		/// <summary>
+		/// The member type of the geo administrator.
+		/// </summary>
+		public GroupMemberType MemberType { get; set; }
+
+		/// <summary>
+		/// The object identifier of the geo administrator.
+		/// </summary>
+		public Guid ObjectId { get; set; }
+
+		/// <summary>
+		/// The geo location administered by the geo administrator.
+		/// </summary>
+		public string GeoLocation { get; set; }
+	}
+}

--- a/src/Commands/Model/GeoAdministratorCollection.cs
+++ b/src/Commands/Model/GeoAdministratorCollection.cs
@@ -1,0 +1,13 @@
+namespace PnP.PowerShell.Commands.Model
+{
+	/// <summary>
+	/// Contains SharePoint Online geo administrators returned by the multi-geo REST API.
+	/// </summary>
+	internal class GeoAdministratorCollection
+	{
+		/// <summary>
+		/// The SharePoint Online geo administrators.
+		/// </summary>
+		public GeoAdministrator[] GeoAdministrators { get; set; }
+	}
+}

--- a/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
+++ b/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
@@ -31,6 +31,8 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 		private const string TenantRenameJobsPathToCancelAJob = "TenantRenameJobs/Cancel";
 		private const string GeoMoveCompatibilityChecksMinimumApiVersion = "1.3.6";
 		private const string GeoMoveCompatibilityChecksPath = "GeoMoveCompatibilityChecks";
+		private const string GeoAdministratorsMinimumApiVersion = "1.2-beta";
+		private const string GeoAdministratorsPath = "GeoAdministrators";
 		private const string GeoExperienceMinimumApiVersion = "1.3.7";
 		private const string GeoExperiencePath = "GeoExperience";
 		private const string UpdateGeoExperienceModePath = "GeoExperience/UpgradeToSPOMode";
@@ -156,6 +158,11 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 		internal IEnumerable<GeoMoveTenantCompatibilityCheck> GetGeoMoveCompatibilityChecks()
 		{
 			return GetFeed<GeoMoveTenantCompatibilityCheck>(GeoMoveCompatibilityChecksPath, GetCurrentApiVersion(GeoMoveCompatibilityChecksMinimumApiVersion));
+		}
+
+		internal GeoAdministratorCollection GetGeoAdministrators()
+		{
+			return Get<GeoAdministratorCollection>(GeoAdministratorsPath, GetGeoAdministratorsApiVersion());
 		}
 
 		internal MultiGeoExperience GetGeoExperience()
@@ -532,6 +539,17 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 		{
 			var apiVersion = GetCurrentApiVersion();
 			if (!IsSupportedApiVersion(apiVersion, StorageQuotasMinimumApiVersion))
+			{
+				throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, CommandResources.CrossGeoInvalidVersion, GetApplicationVersion()));
+			}
+
+			return apiVersion;
+		}
+
+		private string GetGeoAdministratorsApiVersion()
+		{
+			var apiVersion = GetCurrentApiVersion();
+			if (!IsSupportedApiVersion(apiVersion, GeoAdministratorsMinimumApiVersion))
 			{
 				throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, CommandResources.CrossGeoInvalidVersion, GetApplicationVersion()));
 			}


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Adds `Get-PnPGeoAdministrator` to retrieve SharePoint Online geo administrators using the same MultiGeo REST endpoint as the SPO Management Shell cmdlet.

The implementation reuses the existing `MultiGeoRestApiClient`, adds the `GeoAdministrators` API call with the SPO minimum API version `1.2-beta`, and returns output objects matching the SPO response shape: `DisplayName`, `LoginName`, `MemberType`, `ObjectId`, and `GeoLocation`. Documentation and the current nightly changelog are included.

### Guidance ###
N/A