### PR TITLE
Add Remove-PnPMultiGeoCompanyAllowedDataLocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `Get-PnPMultiGeoExperience` cmdlet to retrieve the SharePoint Online multi-geo experience mode. [#5372](https://github.com/pnp/powershell/pull/5372)
 - Added `Set-PnPMultiGeoExperience` cmdlet to upgrade the tenant multi-geo experience to include SharePoint Online Multi-Geo. [#5369](https://github.com/pnp/powershell/pull/5369)
 - Added `Set-PnPMultiGeoCompanyAllowedDataLocation` cmdlet to start setting up a SharePoint Online multi-geo allowed data location. [#5368](https://github.com/pnp/powershell/pull/5368)
+- Added `Remove-PnPMultiGeoCompanyAllowedDataLocation` cmdlet to delete a SharePoint Online multi-geo allowed data location.
 - Added `Get-PnPGeoStorageQuota` cmdlet to retrieve SharePoint Online multi-geo storage quota details. [#5371](https://github.com/pnp/powershell/pull/5371)
 - Added `Set-PnPGeoStorageQuota` cmdlet to set SharePoint Online multi-geo storage quotas. [#5370](https://github.com/pnp/powershell/pull/5370)
 - Added `Get-PnPSiteContentMoveState` cmdlet to retrieve SharePoint Online site content move states. [#5365](https://github.com/pnp/powershell/pull/5365)

--- a/documentation/Get-PnPMultiGeoCompanyAllowedDataLocation.md
+++ b/documentation/Get-PnPMultiGeoCompanyAllowedDataLocation.md
@@ -56,4 +56,6 @@ Returns objects with `Location`, `Domain`, and `IsDefault` properties.
 
 [Set-PnPMultiGeoCompanyAllowedDataLocation](Set-PnPMultiGeoCompanyAllowedDataLocation.md)
 
+[Remove-PnPMultiGeoCompanyAllowedDataLocation](Remove-PnPMultiGeoCompanyAllowedDataLocation.md)
+
 [Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/documentation/Remove-PnPMultiGeoCompanyAllowedDataLocation.md
+++ b/documentation/Remove-PnPMultiGeoCompanyAllowedDataLocation.md
@@ -1,35 +1,35 @@
 ---
 Module Name: PnP.PowerShell
-title: Set-PnPMultiGeoCompanyAllowedDataLocation
+title: Remove-PnPMultiGeoCompanyAllowedDataLocation
 schema: 2.0.0
 applicable: SharePoint Online
 external help file: PnP.PowerShell.dll-Help.xml
-online version: https://pnp.github.io/powershell/cmdlets/Set-PnPMultiGeoCompanyAllowedDataLocation.html
+online version: https://pnp.github.io/powershell/cmdlets/Remove-PnPMultiGeoCompanyAllowedDataLocation.html
 ---
  
-# Set-PnPMultiGeoCompanyAllowedDataLocation
+# Remove-PnPMultiGeoCompanyAllowedDataLocation
 
 ## SYNOPSIS
-Starts setting up a multi-geo data location for the SharePoint Online tenant.
+Deletes a SharePoint Online multi-geo data location from the tenant.
 
 ## SYNTAX
 
 ```powershell
-Set-PnPMultiGeoCompanyAllowedDataLocation [-Location] <String> [-InitialDomain] <String> [-Connection <PnPConnection>] [-WhatIf] [-Confirm]
+Remove-PnPMultiGeoCompanyAllowedDataLocation [-Location] <String> [-Connection <PnPConnection>] [-WhatIf] [-Confirm]
 ```
 
 ## DESCRIPTION
-Starts setting up an allowed SharePoint Online multi-geo data location for the tenant.
+Deletes an allowed SharePoint Online multi-geo data location from the tenant. Any remaining user data in the location will be permanently deleted.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 
 ```powershell
-Set-PnPMultiGeoCompanyAllowedDataLocation -Location EUR -InitialDomain contoso.onmicrosoft.com
+Remove-PnPMultiGeoCompanyAllowedDataLocation -Location EUR
 ```
 
-Starts setting up the EUR multi-geo data location for the tenant with the initial domain `contoso.onmicrosoft.com`.
+Deletes the EUR multi-geo data location from the tenant.
 
 ## PARAMETERS
 
@@ -61,22 +61,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -InitialDomain
-Specifies the initial SharePoint Online domain for the data location.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-
-Required: True
-Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Location
-Specifies the multi-geo location code to set up.
+Specifies the multi-geo location code to delete.
 
 ```yaml
 Type: String
@@ -105,13 +91,13 @@ Accept wildcard characters: False
 
 ## OUTPUTS
 
-### System.String
-Returns a message indicating that setting up the new location has started.
+### System.Object
+Writes the SharePoint Online Management Shell cancellation message if the delete operation is canceled. On success, writes a warning that deleting the location might take a few hours.
 
 ## RELATED LINKS
 
 [Get-PnPMultiGeoCompanyAllowedDataLocation](Get-PnPMultiGeoCompanyAllowedDataLocation.md)
 
-[Remove-PnPMultiGeoCompanyAllowedDataLocation](Remove-PnPMultiGeoCompanyAllowedDataLocation.md)
+[Set-PnPMultiGeoCompanyAllowedDataLocation](Set-PnPMultiGeoCompanyAllowedDataLocation.md)
 
 [Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/src/Commands/Admin/RemoveMultiGeoCompanyAllowedDataLocation.cs
+++ b/src/Commands/Admin/RemoveMultiGeoCompanyAllowedDataLocation.cs
@@ -1,0 +1,47 @@
+using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Properties;
+using PnP.PowerShell.Commands.Utilities.MultiGeo;
+using System.Globalization;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Admin
+{
+	[Cmdlet(VerbsCommon.Remove, "PnPMultiGeoCompanyAllowedDataLocation", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
+	[RequiredApiApplicationPermissions("sharepoint/Sites.FullControl.All")]
+	[RequiredApiDelegatedPermissions("sharepoint/AllSites.FullControl")]
+	public class RemoveMultiGeoCompanyAllowedDataLocation : PnPSharePointOnlineAdminCmdlet
+	{
+		[Parameter(Mandatory = true, Position = 0)]
+		[ValidateNotNullOrEmpty]
+		public string Location { get; set; }
+
+		protected override void ExecuteCmdlet()
+		{
+			if (!ShouldProcess(Resources.CrossGeoWarningRemoveAdl, Resources.CrossGeoWarningRemoveAdl, string.Format(CultureInfo.InvariantCulture, Resources.CrossGeoWarningRemoveAdlQuery, Location)))
+			{
+				if (!IsWhatIf())
+				{
+					WriteObject(Resources.CrossGeoWarningRemoveAdlCancelMessage);
+				}
+
+				return;
+			}
+
+			if (!ShouldProcess(Resources.CrossGeoWarning2RemoveAdl, Resources.CrossGeoWarning2RemoveAdl, Resources.CrossGeoWarning2RemoveAdlQuery))
+			{
+				WriteObject(Resources.CrossGeoWarningRemoveAdlCancelMessage);
+				return;
+			}
+
+			var multiGeoRestApiClient = new MultiGeoRestApiClient(AdminContext);
+			multiGeoRestApiClient.RemoveAllowedDataLocation(Location);
+			WriteWarning(Resources.CrossGeoWarningRemoveAdlSuccessMessage);
+		}
+
+		private bool IsWhatIf()
+		{
+			return MyInvocation.BoundParameters.TryGetValue("WhatIf", out var whatIfValue) && whatIfValue is SwitchParameter whatIf && whatIf.ToBool();
+		}
+	}
+}

--- a/src/Commands/Properties/Resources.Designer.cs
+++ b/src/Commands/Properties/Resources.Designer.cs
@@ -273,6 +273,63 @@ namespace PnP.PowerShell.Commands.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Any remaining user data in this location will be permanently deleted. This includes all OneDrive for Business data, SharePoint sites and Group sites. Make sure all data is moved to another location before continuing.
+        ///
+        ///If you delete this location, you won&apos;t be able to restore it.
+        ///.
+        /// </summary>
+        internal static string CrossGeoWarningRemoveAdl {
+            get {
+                return ResourceManager.GetString("CrossGeoWarningRemoveAdl", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Do you want to permanently delete this location and all its data: {0}?.
+        /// </summary>
+        internal static string CrossGeoWarningRemoveAdlQuery {
+            get {
+                return ResourceManager.GetString("CrossGeoWarningRemoveAdlQuery", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to I acknowledge that I am responsible for copying or moving the data from this location before I delete the location..
+        /// </summary>
+        internal static string CrossGeoWarning2RemoveAdl {
+            get {
+                return ResourceManager.GetString("CrossGeoWarning2RemoveAdl", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Did you move all data from this location?.
+        /// </summary>
+        internal static string CrossGeoWarning2RemoveAdlQuery {
+            get {
+                return ResourceManager.GetString("CrossGeoWarning2RemoveAdlQuery", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The delete operation was canceled..
+        /// </summary>
+        internal static string CrossGeoWarningRemoveAdlCancelMessage {
+            get {
+                return ResourceManager.GetString("CrossGeoWarningRemoveAdlCancelMessage", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Deleting the location might take a few hours. After the location is deleted, you&apos;ll be disconnected from the SharePoint Online Administration center in this location..
+        /// </summary>
+        internal static string CrossGeoWarningRemoveAdlSuccessMessage {
+            get {
+                return ResourceManager.GetString("CrossGeoWarningRemoveAdlSuccessMessage", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Current site is not a tenant administration site.
         /// </summary>
         internal static string CurrentSiteIsNoTenantAdminSite {

--- a/src/Commands/Properties/Resources.resx
+++ b/src/Commands/Properties/Resources.resx
@@ -147,6 +147,24 @@
   <data name="CrossGeoWarningAddAdlSuccessMessage" xml:space="preserve">
     <value>Successfully started setting up the new location. You will receive a notification when the process completes. You can check status using the following command: Get-PnPMultiGeoCompanyAllowedDataLocation.</value>
   </data>
+  <data name="CrossGeoWarningRemoveAdl" xml:space="preserve">
+    <value>Any remaining user data in this location will be permanently deleted. This includes all OneDrive for Business data, SharePoint sites and Group sites. Make sure all data is moved to another location before continuing.&#xD;&#xA;&#xD;&#xA;If you delete this location, you won't be able to restore it.&#xD;&#xA;</value>
+  </data>
+  <data name="CrossGeoWarningRemoveAdlQuery" xml:space="preserve">
+    <value>Do you want to permanently delete this location and all its data: {0}?</value>
+  </data>
+  <data name="CrossGeoWarning2RemoveAdl" xml:space="preserve">
+    <value>I acknowledge that I am responsible for copying or moving the data from this location before I delete the location.</value>
+  </data>
+  <data name="CrossGeoWarning2RemoveAdlQuery" xml:space="preserve">
+    <value>Did you move all data from this location?</value>
+  </data>
+  <data name="CrossGeoWarningRemoveAdlCancelMessage" xml:space="preserve">
+    <value>The delete operation was canceled.</value>
+  </data>
+  <data name="CrossGeoWarningRemoveAdlSuccessMessage" xml:space="preserve">
+    <value>Deleting the location might take a few hours. After the location is deleted, you'll be disconnected from the SharePoint Online Administration center in this location.</value>
+  </data>
   <data name="CurrentSiteIsNoTenantAdminSite" xml:space="preserve">
     <value>Current site is not a tenant administration site</value>
   </data>

--- a/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
+++ b/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
@@ -37,11 +37,13 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 		private const string UpdateAllInstancesExperienceModePath = "GeoExperience/UpgradeAllInstancesToSPOMode";
 		private const string AllowedDataLocationsApiVersion = "1.3.11";
 		private const string AllowedDataLocationsPath = "AllowedDataLocations";
+		private const string AllowedDataLocationByLocationPath = "AllowedDataLocations(location='{0}')";
 		private const string StorageQuotasMinimumApiVersion = "1.3.1";
 		private const string StorageQuotasPath = "StorageQuotas";
 		private const string StorageQuotaByLocationPath = "StorageQuotas(geoLocation='{0}')";
 		private const string MultiGeoApiVersionsPath = "MultiGeoApiVersions";
 		private const string PatchVerbString = "PATCH";
+		private const string DeleteVerbString = "DELETE";
 		private const string UserMoveJobsMinimumApiVersion = "1.0";
 		private const string UserMoveJobsByMoveIdMinimumApiVersion = "1.2.2";
 		private const string UserMoveJobsReportMinimumApiVersion = "1.3.2";
@@ -193,6 +195,18 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 			}
 
 			PostWithoutResponse(AllowedDataLocationsPath, allowedDataLocation, apiVersion);
+		}
+
+		internal void RemoveAllowedDataLocation(string location)
+		{
+			var apiVersion = GetCurrentApiVersion();
+			if (!IsSupportedApiVersion(apiVersion, AllowedDataLocationsApiVersion))
+			{
+				throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, CommandResources.CrossGeoInvalidVersion, GetApplicationVersion()));
+			}
+
+			var path = string.Format(CultureInfo.InvariantCulture, AllowedDataLocationByLocationPath, ProcessSpecialChars(location));
+			PostWithEmptyBodyMethodOverride(path, DeleteVerbString, apiVersion);
 		}
 
 		internal IEnumerable<StorageQuota> GetStorageQuotas()
@@ -425,6 +439,21 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 			Send(() =>
 			{
 				var request = CreateRequest(HttpMethod.Post, path, apiVersion, jsonPayload);
+				request.Headers.TryAddWithoutValidation("X-HTTP-Method", methodOverride);
+				if (request.Content != null)
+				{
+					request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json;charset=UTF-8");
+				}
+
+				return request;
+			}, timeout: null, allowRetries: false);
+		}
+
+		private void PostWithEmptyBodyMethodOverride(string path, string methodOverride, string apiVersion)
+		{
+			Send(() =>
+			{
+				var request = CreateRequest(HttpMethod.Post, path, apiVersion, string.Empty);
 				request.Headers.TryAddWithoutValidation("X-HTTP-Method", methodOverride);
 				if (request.Content != null)
 				{


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Adds `Remove-PnPMultiGeoCompanyAllowedDataLocation` so PnP PowerShell can delete a SharePoint Online multi-geo allowed data location using the same behavior as the SPO Management Shell cmdlet.

The cmdlet mirrors the SPO command shape and UX, including the mandatory `-Location` parameter, `SupportsShouldProcess`, high confirm impact, two confirmation prompts, the cancel output, and the success warning. The MultiGeo REST client reuses the existing API version negotiation and sends the same request pattern: POST with an empty body and `X-HTTP-Method: DELETE` to `AllowedDataLocations(location='{escapedLocation}')`.

Documentation, related links, resource strings, and the Current nightly changelog were updated for the new cmdlet.

### Guidance ###
N/A