### PR TITLE
Add PnP geo administrator cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added `Remove-PnPGeoAdministrator` cmdlet to remove SharePoint Online geo administrators. [#5380](https://github.com/pnp/powershell/pull/5380)
 - Added `Get-PnPGeoAdministrator` cmdlet to retrieve SharePoint Online geo administrators. [#5378](https://github.com/pnp/powershell/pull/5378)
+- Added `Add-PnPGeoAdministrator` cmdlet to add SharePoint Online multi-geo administrators. [#5381](https://github.com/pnp/powershell/pull/5381)
 - Added `Get-PnPMultiGeoExperience` cmdlet to retrieve the SharePoint Online multi-geo experience mode. [#5372](https://github.com/pnp/powershell/pull/5372)
 - Added `Set-PnPMultiGeoExperience` cmdlet to upgrade the tenant multi-geo experience to include SharePoint Online Multi-Geo. [#5369](https://github.com/pnp/powershell/pull/5369)
 - Added `Set-PnPMultiGeoCompanyAllowedDataLocation` cmdlet to start setting up a SharePoint Online multi-geo allowed data location. [#5368](https://github.com/pnp/powershell/pull/5368)

--- a/documentation/Add-PnPGeoAdministrator.md
+++ b/documentation/Add-PnPGeoAdministrator.md
@@ -1,0 +1,126 @@
+---
+Module Name: PnP.PowerShell
+title: Add-PnPGeoAdministrator
+schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/Add-PnPGeoAdministrator.html
+---
+
+# Add-PnPGeoAdministrator
+
+## SYNOPSIS
+Adds a SharePoint Online multi-geo administrator.
+
+## SYNTAX
+
+### User
+```powershell
+Add-PnPGeoAdministrator [-UserPrincipalName] <String> [-Connection <PnPConnection>]
+```
+
+### Group
+```powershell
+Add-PnPGeoAdministrator [-GroupAlias] <String> [-Connection <PnPConnection>]
+```
+
+### ObjectId
+```powershell
+Add-PnPGeoAdministrator [-ObjectId] <Guid> [-Connection <PnPConnection>]
+```
+
+## DESCRIPTION
+Adds a user or group as a SharePoint Online multi-geo administrator.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Add-PnPGeoAdministrator -UserPrincipalName user@contoso.com
+```
+
+Adds the user as a SharePoint Online multi-geo administrator.
+
+### EXAMPLE 2
+
+```powershell
+Add-PnPGeoAdministrator -GroupAlias "Geo Administrators"
+```
+
+Adds the group as a SharePoint Online multi-geo administrator.
+
+### EXAMPLE 3
+
+```powershell
+Add-PnPGeoAdministrator -ObjectId 00000000-0000-0000-0000-000000000001
+```
+
+Adds the principal with the specified object identifier as a SharePoint Online multi-geo administrator.
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by specifying `-ReturnConnection` on `Connect-PnPOnline` or by executing `Get-PnPConnection`.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -GroupAlias
+Specifies the alias of the group to add as a SharePoint Online multi-geo administrator.
+
+```yaml
+Type: String
+Parameter Sets: Group
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectId
+Specifies the object identifier of the principal to add as a SharePoint Online multi-geo administrator.
+
+```yaml
+Type: Guid
+Parameter Sets: ObjectId
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UserPrincipalName
+Specifies the user principal name of the user to add as a SharePoint Online multi-geo administrator.
+
+```yaml
+Type: String
+Parameter Sets: User
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## OUTPUTS
+
+### None
+This cmdlet does not return output.
+
+## RELATED LINKS
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/src/Commands/Admin/AddGeoAdministrator.cs
+++ b/src/Commands/Admin/AddGeoAdministrator.cs
@@ -1,0 +1,71 @@
+using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Enums;
+using PnP.PowerShell.Commands.Model;
+using PnP.PowerShell.Commands.Utilities.MultiGeo;
+using System;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Admin
+{
+	[Cmdlet(VerbsCommon.Add, "PnPGeoAdministrator", DefaultParameterSetName = UserParameterSet)]
+	[RequiredApiApplicationPermissions("sharepoint/Sites.FullControl.All")]
+	[RequiredApiDelegatedPermissions("sharepoint/AllSites.FullControl")]
+	public class AddGeoAdministrator : PnPSharePointOnlineAdminCmdlet
+	{
+		private const string UserParameterSet = "User";
+		private const string GroupParameterSet = "Group";
+		private const string ObjectIdParameterSet = "ObjectId";
+
+		[Parameter(Mandatory = true, Position = 0, ParameterSetName = GroupParameterSet)]
+		[ValidateNotNullOrEmpty]
+		public string GroupAlias { get; set; }
+
+		[Parameter(Mandatory = true, Position = 0, ParameterSetName = UserParameterSet)]
+		[ValidateNotNullOrEmpty]
+		public string UserPrincipalName { get; set; }
+
+		[Parameter(Mandatory = true, Position = 0, ParameterSetName = ObjectIdParameterSet)]
+		[ValidateNotNullOrEmpty]
+		public Guid ObjectId { get; set; }
+
+		protected override void ExecuteCmdlet()
+		{
+			var multiGeoRestApiClient = new MultiGeoRestApiClient(AdminContext);
+			switch (ParameterSetName)
+			{
+				case GroupParameterSet:
+					multiGeoRestApiClient.AddGeoAdministrator(new GeoAdministratorEntityData
+					{
+						LoginName = GroupAlias,
+						MemberType = GroupMemberType.Group
+					});
+					break;
+
+				case UserParameterSet:
+					multiGeoRestApiClient.AddGeoAdministrator(new GeoAdministratorEntityData
+					{
+						LoginName = UserPrincipalName,
+						MemberType = GroupMemberType.User
+					});
+					break;
+
+				case ObjectIdParameterSet:
+					if (ObjectId == Guid.Empty)
+					{
+						throw new PSArgumentException("ObjectId cannot be an empty GUID.", nameof(ObjectId));
+					}
+
+					multiGeoRestApiClient.EnsureGeoAdministratorObjectIdSupported();
+					multiGeoRestApiClient.AddGeoAdministrator(new GeoAdministratorEntityData
+					{
+						ObjectId = ObjectId
+					});
+					break;
+
+				default:
+					throw new ArgumentException("Parameter set cannot be resolved using the specified named parameters.");
+			}
+		}
+	}
+}

--- a/src/Commands/Model/GeoAdministratorEntityData.cs
+++ b/src/Commands/Model/GeoAdministratorEntityData.cs
@@ -1,0 +1,36 @@
+using PnP.PowerShell.Commands.Enums;
+using System;
+using System.Text.Json.Serialization;
+
+namespace PnP.PowerShell.Commands.Model
+{
+	/// <summary>
+	/// Contains the payload used to add a SharePoint Online multi-geo administrator.
+	/// </summary>
+	internal class GeoAdministratorEntityData
+	{
+		/// <summary>
+		/// The login name for the user or group principal.
+		/// </summary>
+		[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+		public string LoginName { get; set; }
+
+		/// <summary>
+		/// The display name for the principal.
+		/// </summary>
+		[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+		public string DisplayName { get; set; }
+
+		/// <summary>
+		/// The type of principal being added.
+		/// </summary>
+		[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+		public GroupMemberType MemberType { get; set; }
+
+		/// <summary>
+		/// The object identifier for the principal.
+		/// </summary>
+		[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+		public Guid ObjectId { get; set; }
+	}
+}

--- a/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
+++ b/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
@@ -183,6 +183,21 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 			return GetFeed<MultiGeoCompanyAllowedDataLocation>(AllowedDataLocationsPath, AllowedDataLocationsApiVersion);
 		}
 
+		internal GeoAdministrator AddGeoAdministrator(GeoAdministratorEntityData geoAdministrator)
+		{
+			if (geoAdministrator == null)
+			{
+				throw new ArgumentNullException(nameof(geoAdministrator));
+			}
+
+			return Post<GeoAdministrator>(GeoAdministratorsPath, geoAdministrator, apiVersion: GetGeoAdministratorsApiVersion());
+		}
+
+		internal void EnsureGeoAdministratorObjectIdSupported()
+		{
+			GetGeoAdministratorsByPrincipalApiVersion();
+		}
+
 		internal void UpgradeGeoExperience(bool allInstances)
 		{
 			var apiVersion = GetGeoExperienceApiVersion();


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Adds `Add-PnPGeoAdministrator` to mirror SharePoint Online Management Shell's `Add-SPOGeoAdministrator` for multi-geo administrators.

The cmdlet supports the same `UserPrincipalName`, `GroupAlias`, and `ObjectId` parameter sets, reuses the existing multi-geo REST client, and posts to the `GeoAdministrators` API with matching payload shape and no output. This also adds the minimal internal models, documentation, and Current nightly changelog entry.

Validation included building the project and comparing command metadata and payload serialization with the SPO module.

### Guidance ###
N/A