### PR TITLE
Add Get-PnPUserOneDriveLocation cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Current nightly]
 
 ### Added
+- Added `Get-PnPUserOneDriveLocation` cmdlet to retrieve SharePoint Online multi-geo location details for a user's OneDrive personal site.
 - Added `Remove-PnPGeoAdministrator` cmdlet to remove SharePoint Online geo administrators. [#5380](https://github.com/pnp/powershell/pull/5380)
 - Added `Get-PnPGeoAdministrator` cmdlet to retrieve SharePoint Online geo administrators. [#5378](https://github.com/pnp/powershell/pull/5378)
 - Added `Add-PnPGeoAdministrator` cmdlet to add SharePoint Online multi-geo administrators. [#5381](https://github.com/pnp/powershell/pull/5381)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Current nightly]
 
 ### Added
-- Added `Get-PnPUserOneDriveLocation` cmdlet to retrieve SharePoint Online multi-geo location details for a user's OneDrive personal site.
+- Added `Get-PnPUserOneDriveLocation` cmdlet to retrieve SharePoint Online multi-geo location details for a user's OneDrive personal site. [#5382](https://github.com/pnp/powershell/pull/5382)
 - Added `Remove-PnPGeoAdministrator` cmdlet to remove SharePoint Online geo administrators. [#5380](https://github.com/pnp/powershell/pull/5380)
 - Added `Get-PnPGeoAdministrator` cmdlet to retrieve SharePoint Online geo administrators. [#5378](https://github.com/pnp/powershell/pull/5378)
 - Added `Add-PnPGeoAdministrator` cmdlet to add SharePoint Online multi-geo administrators. [#5381](https://github.com/pnp/powershell/pull/5381)

--- a/documentation/Get-PnPUserOneDriveLocation.md
+++ b/documentation/Get-PnPUserOneDriveLocation.md
@@ -1,0 +1,73 @@
+---
+Module Name: PnP.PowerShell
+title: Get-PnPUserOneDriveLocation
+schema: 2.0.0
+applicable: SharePoint Online
+external help file: PnP.PowerShell.dll-Help.xml
+online version: https://pnp.github.io/powershell/cmdlets/Get-PnPUserOneDriveLocation.html
+---
+ 
+# Get-PnPUserOneDriveLocation
+
+## SYNOPSIS
+Returns the SharePoint Online multi-geo location details for a user's OneDrive personal site.
+
+## SYNTAX
+
+```powershell
+Get-PnPUserOneDriveLocation -UserPrincipalName <String> [-Connection <PnPConnection>]
+```
+
+## DESCRIPTION
+Returns the SharePoint Online multi-geo location, OneDrive personal site URL, site ID, and user principal name for the specified user.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Get-PnPUserOneDriveLocation -UserPrincipalName user@contoso.com
+```
+
+Returns the OneDrive personal site location details for the specified user.
+
+## PARAMETERS
+
+### -Connection
+Optional connection to be used by the cmdlet. Retrieve the value for this parameter by specifying `-ReturnConnection` on `Connect-PnPOnline` or by executing `Get-PnPConnection`.
+
+```yaml
+Type: PnPConnection
+Parameter Sets: (All)
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UserPrincipalName
+The user principal name of the user whose OneDrive personal site location details should be returned.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## OUTPUTS
+
+### PnP.PowerShell.Commands.Model.UserPersonalSiteLocation
+Returns an object with `UserPrincipalName`, `Location`, `MySiteUrl`, and `SiteId` properties.
+
+## RELATED LINKS
+
+[Get-PnPUserAndContentMoveState](Get-PnPUserAndContentMoveState.md)
+
+[Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)

--- a/src/Commands/Admin/GetUserOneDriveLocation.cs
+++ b/src/Commands/Admin/GetUserOneDriveLocation.cs
@@ -1,0 +1,24 @@
+using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Model;
+using PnP.PowerShell.Commands.Utilities.MultiGeo;
+using System.Management.Automation;
+
+namespace PnP.PowerShell.Commands.Admin
+{
+	[Cmdlet(VerbsCommon.Get, "PnPUserOneDriveLocation")]
+	[RequiredApiApplicationPermissions("sharepoint/Sites.FullControl.All")]
+	[RequiredApiDelegatedPermissions("sharepoint/AllSites.FullControl")]
+	[OutputType(typeof(UserPersonalSiteLocation))]
+	public class GetUserOneDriveLocation : PnPSharePointOnlineAdminCmdlet
+	{
+		[Parameter(Mandatory = true)]
+		public string UserPrincipalName { get; set; }
+
+		protected override void ExecuteCmdlet()
+		{
+			var multiGeoRestApiClient = new MultiGeoRestApiClient(AdminContext);
+			WriteObject(multiGeoRestApiClient.GetUserPersonalSiteLocation(UserPrincipalName));
+		}
+	}
+}

--- a/src/Commands/Admin/GetUserOneDriveLocation.cs
+++ b/src/Commands/Admin/GetUserOneDriveLocation.cs
@@ -13,6 +13,7 @@ namespace PnP.PowerShell.Commands.Admin
 	public class GetUserOneDriveLocation : PnPSharePointOnlineAdminCmdlet
 	{
 		[Parameter(Mandatory = true)]
+		[ValidateNotNullOrEmpty]
 		public string UserPrincipalName { get; set; }
 
 		protected override void ExecuteCmdlet()

--- a/src/Commands/Model/UserPersonalSiteLocation.cs
+++ b/src/Commands/Model/UserPersonalSiteLocation.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace PnP.PowerShell.Commands.Model
+{
+	/// <summary>
+	/// Contains the SharePoint Online multi-geo location details for a user's OneDrive personal site.
+	/// </summary>
+	public class UserPersonalSiteLocation
+	{
+		/// <summary>
+		/// The user principal name for the OneDrive owner.
+		/// </summary>
+		public string UserPrincipalName { get; set; }
+
+		/// <summary>
+		/// The SharePoint Online multi-geo location code for the user's OneDrive personal site.
+		/// </summary>
+		public string Location { get; set; }
+
+		/// <summary>
+		/// The URL of the user's OneDrive personal site.
+		/// </summary>
+		public string MySiteUrl { get; set; }
+
+		/// <summary>
+		/// The site collection identifier of the user's OneDrive personal site.
+		/// </summary>
+		public Guid SiteId { get; set; }
+	}
+}

--- a/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
+++ b/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
@@ -51,6 +51,8 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 		private const string MultiGeoApiVersionsPath = "MultiGeoApiVersions";
 		private const string DeleteVerbString = "DELETE";
 		private const string PatchVerbString = "PATCH";
+		private const string UserPersonalSiteLocationMinimumApiVersion = "1.0";
+		private const string UserPersonalSiteLocationPath = "UserPersonalSiteLocation('{0}')";
 		private const string UserMoveJobsMinimumApiVersion = "1.0";
 		private const string UserMoveJobsByMoveIdMinimumApiVersion = "1.2.2";
 		private const string UserMoveJobsReportMinimumApiVersion = "1.3.2";
@@ -260,6 +262,13 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 			var apiVersion = GetCurrentApiVersion(UserMoveJobsMinimumApiVersion);
 			var path = string.Format(CultureInfo.InvariantCulture, UserMoveJobPathByUpn, ProcessSpecialChars(userPrincipalName));
 			return Get<UserAndContentMoveState>(path, apiVersion);
+		}
+
+		internal UserPersonalSiteLocation GetUserPersonalSiteLocation(string userPrincipalName)
+		{
+			var apiVersion = GetCurrentApiVersion(UserPersonalSiteLocationMinimumApiVersion);
+			var path = string.Format(CultureInfo.InvariantCulture, UserPersonalSiteLocationPath, ProcessSpecialChars(userPrincipalName));
+			return Get<UserPersonalSiteLocation>(path, apiVersion);
 		}
 
 		internal UserAndContentMoveState GetUserAndContentMoveState(Guid odbMoveId)


### PR DESCRIPTION
## Summary
- Added `Get-PnPUserOneDriveLocation` using the existing SharePoint Online multi-geo REST client.
- Added the `UserPersonalSiteLocation` output model with `UserPrincipalName`, `Location`, `MySiteUrl`, and `SiteId` properties.
- Added cmdlet documentation and a Current nightly changelog entry.

## Validation
- `dotnet restore src\PnP.PowerShell.sln`
- `dotnet build src\PnP.PowerShell.sln --no-restore --verbosity minimal`
- Imported the built debug module and verified `Get-PnPUserOneDriveLocation` syntax/metadata.