### PR TITLE
Cross-reference the minimal-permissions page migration guide

### DIFF
--- a/documentation/ConvertTo-PnPPage.md
+++ b/documentation/ConvertTo-PnPPage.md
@@ -709,4 +709,4 @@ Accept pipeline input: False
 
 [Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp)
 
-
+[Migrate classic pages to modern with the least permission possible](https://pnp.github.io/pnpassessment/classic/migrate-minimal-permissions.html)


### PR DESCRIPTION
## Summary

Adds one entry to the **RELATED LINKS** section of the `ConvertTo-PnPPage` cmdlet reference, pointing to the new guide:

- [Migrate classic SharePoint pages to modern — with the least permission possible](https://pnp.github.io/pnpassessment/classic/migrate-minimal-permissions.html)

`ConvertTo-PnPPage` is the cmdlet that guide is built around. The guide covers requesting the smallest Entra app permission that works (`AllSites.Manage`, escalating to `AllSites.FullControl` only when a page's item-level unique permissions must be preserved) and the user-consent vs. admin-consent paths — the permission/consent angle that the reference page itself doesn't cover.

## Change

- One link added under `## RELATED LINKS`, blank-line separated to match the existing style used across the cmdlet docs. LF line endings preserved; no generated content touched.