### PR TITLE
Add GitLab CI/CD support to Connect-PnPOnline -FederatedIdentity

### DIFF
--- a/documentation/Connect-PnPOnline.md
+++ b/documentation/Connect-PnPOnline.md
@@ -308,6 +308,22 @@ Connect-PnPOnline -Url "https://contoso.sharepoint.com" -FederatedIdentity
 
 Connect to SharePoint/Microsoft Graph using federated identity credentials in Azure DevOps. This option is available from version 3.1.51-nightly onwards.
 
+### EXAMPLE 22
+```powershell
+Connect-PnPOnline -Url "https://contoso.sharepoint.com" -ClientId 6c5c98c7-e05a-4a0f-bcfa-0cfc65aa1f28 -Tenant 'contoso.onmicrosoft.com' -FederatedIdentity
+```
+
+Connect to SharePoint/Microsoft Graph using federated identity credentials in GitLab CI/CD. This requires the job to request an ID token named `GITLAB_OIDC_TOKEN` with audience `api://AzureADTokenExchange`, for example:
+
+```yaml
+job:
+  id_tokens:
+    GITLAB_OIDC_TOKEN:
+      aud: api://AzureADTokenExchange
+```
+
+The corresponding federated credential on the Entra ID app registration must have issuer `https://gitlab.com` (or your self-managed GitLab instance URL) and a subject matching the GitLab OIDC claim for the job, e.g. `project_path:<group>/<project>:ref_type:branch:ref:<branch>`.
+
 ## PARAMETERS
 
 ### -AccessToken
@@ -822,7 +838,7 @@ Accept wildcard characters: False
 ```
 
 ### -AzureADWorkloadIdentity
-Connects using Azure AD Workload Identity in Azure workload identity environments where `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_AUTHORITY_HOST`, and `AZURE_FEDERATED_TOKEN_FILE` are available. For GitHub Actions and Azure DevOps pipelines, use `-FederatedIdentity` instead.
+Connects using Azure AD Workload Identity in Azure workload identity environments where `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_AUTHORITY_HOST`, and `AZURE_FEDERATED_TOKEN_FILE` are available. For GitHub Actions, Azure DevOps and GitLab CI/CD pipelines, use `-FederatedIdentity` instead.
 
 ```yaml
 Type: SwitchParameter
@@ -879,7 +895,7 @@ Accept wildcard characters: False
 
 ### -FederatedIdentity
 
-Connects using Federated Identity. Use this option for GitHub Actions and Azure DevOps pipelines. For Azure workload identity environments that provide `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_AUTHORITY_HOST`, and `AZURE_FEDERATED_TOKEN_FILE`, use `-AzureADWorkloadIdentity` instead. For more information on this, you can visit [this link](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation-create-trust?pivots=identity-wif-apps-methods-rest).
+Connects using Federated Identity. Use this option for GitHub Actions, Azure DevOps and GitLab CI/CD pipelines. For Azure workload identity environments that provide `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_AUTHORITY_HOST`, and `AZURE_FEDERATED_TOKEN_FILE`, use `-AzureADWorkloadIdentity` instead. For more information on this, you can visit [this link](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation-create-trust?pivots=identity-wif-apps-methods-rest).
 
 This option is available from version 3.1.51-nightly onwards.
 

--- a/src/Commands/Base/TokenHandler.cs
+++ b/src/Commands/Base/TokenHandler.cs
@@ -346,7 +346,7 @@ namespace PnP.PowerShell.Commands.Base
         }
 
         /// <summary>
-        /// Returns an access token based on a Federated Identity. Only works within Azure components supporting federated identities like GitHub/AzureDevOps.
+        /// Returns an access token based on a Federated Identity. Only works within Azure components supporting federated identities like GitHub Actions, Azure DevOps and GitLab CI/CD.
         /// </summary>
         /// <param name="clientId">The client Id of the Federated Identity application</param>
         /// <param name="tenant">The tenant Id of the Federated Identity application</param>
@@ -363,6 +363,8 @@ namespace PnP.PowerShell.Commands.Base
             var actionsIdTokenRequestUrl = Environment.GetEnvironmentVariable("ACTIONS_ID_TOKEN_REQUEST_URL");
             var actionsIdTokenRequestToken = Environment.GetEnvironmentVariable("ACTIONS_ID_TOKEN_REQUEST_TOKEN");
             var systemOidcRequestUri = Environment.GetEnvironmentVariable("SYSTEM_OIDCREQUESTURI");
+            var gitlabCi = Environment.GetEnvironmentVariable("GITLAB_CI");
+            var gitlabOidcToken = Environment.GetEnvironmentVariable("GITLAB_OIDC_TOKEN");
 
             if (!string.IsNullOrWhiteSpace(actionsIdTokenRequestUrl) && !string.IsNullOrWhiteSpace(actionsIdTokenRequestToken))
             {
@@ -403,9 +405,22 @@ namespace PnP.PowerShell.Commands.Base
                 var federationToken = await GetFederationTokenFromAzureDevOpsAsync(systemOidcRequestUri, systemAccessToken, serviceConnectionId);
                 return await GetAccessTokenWithFederatedTokenAsync(serviceConnectionAppId, serviceConnectionTenantId, requiredScope, federationToken);
             }
+            else if (!string.IsNullOrWhiteSpace(gitlabCi) && !string.IsNullOrWhiteSpace(gitlabOidcToken))
+            {
+                if (string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(tenant))
+                {
+                    throw new PSInvalidOperationException("ClientId and Tenant must be provided when using Federated Identity in GitLab CI/CD.");
+                }
+
+                Framework.Diagnostics.Log.Debug("TokenHandler", "GITLAB_CI and GITLAB_OIDC_TOKEN env variables found. The context is GitLab CI/CD...");
+
+                // GitLab's id_tokens feature mints the OIDC JWT directly into the configured job variable, so no
+                // separate request to GitLab is needed to obtain the federation token before exchanging it with Entra ID.
+                return await GetAccessTokenWithFederatedTokenAsync(clientId, tenant, requiredScope, gitlabOidcToken);
+            }
             else
             {
-                throw new PSInvalidOperationException("Federated identity is currently only supported in GitHub Actions and Azure DevOps.");
+                throw new PSInvalidOperationException("Federated identity is currently only supported in GitHub Actions, Azure DevOps and GitLab CI/CD.");
             }
         }
 


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [x] New Feature
- [ ] Sample

## Summary

Extends `Connect-PnPOnline -FederatedIdentity` to support GitLab CI/CD pipelines, alongside the existing GitHub Actions and Azure DevOps support. This lets users authenticate to SharePoint/Microsoft Graph from a GitLab pipeline using GitLab's OIDC `id_tokens` feature and a federated credential trust on the Entra ID app registration, without needing to store a client secret or certificate in GitLab.

## Modified cmdlets

- **Connect-PnPOnline** — no parameter changes. The existing `-FederatedIdentity` switch parameter set now also recognizes a GitLab CI/CD context. As with GitHub Actions, `-ClientId` and `-Tenant` must be supplied explicitly (GitLab has no equivalent of Azure DevOps' service-connection auto-lookup).

## Implementation notes

- `TokenHandler.GetFederatedIdentityTokenAsync` gains a third detection branch, alongside the existing GitHub Actions (`ACTIONS_ID_TOKEN_REQUEST_URL`/`ACTIONS_ID_TOKEN_REQUEST_TOKEN`) and Azure DevOps (`SYSTEM_OIDCREQUESTURI`) branches. GitLab CI is detected via the `GITLAB_CI` environment variable combined with the presence of `GITLAB_OIDC_TOKEN`.
- Unlike GitHub Actions and Azure DevOps, no HTTP round-trip is required to obtain GitLab's own OIDC token: GitLab's `id_tokens` pipeline feature mints the JWT directly into the configured job variable at job start. The pipeline must define it under that exact name:
  ```yaml
  id_tokens:
    GITLAB_OIDC_TOKEN:
      aud: api://AzureADTokenExchange
- Documentation included
- Developed with AI assistance
- Tested in GitLab CI
