### PR TITLE
Fix multi-geo SPO compatibility issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fixed an issue with `Add-PnPListItem` and `Set-PnPListItem` cmdlets when trying to set taxonomy fields by passing in a GUID or term instance using a Batch. [#5174](https://github.com/pnp/powershell/pull/5174)
 - Fixed issue with Azure functions not working properly when we also have other modules like Az which rely on .NET 10. [#5393](https://github.com/pnp/powershell/pull/5393)
+- Fixed multi-geo compatibility issues with `Get-PnPGeoAdministrator` response handling, `Set-PnPMultiGeoExperience` confirmation prompts, and unsupported-version errors for `Set-PnPMultiGeoCompanyAllowedDataLocation`. [#5103](https://github.com/pnp/powershell/issues/5103)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fixed an issue with `Add-PnPListItem` and `Set-PnPListItem` cmdlets when trying to set taxonomy fields by passing in a GUID or term instance using a Batch. [#5174](https://github.com/pnp/powershell/pull/5174)
 - Fixed issue with Azure functions not working properly when we also have other modules like Az which rely on .NET 10. [#5393](https://github.com/pnp/powershell/pull/5393)
-- Fixed multi-geo compatibility issues with `Get-PnPGeoAdministrator` response handling, `Set-PnPMultiGeoExperience` confirmation prompts, and unsupported-version errors for `Set-PnPMultiGeoCompanyAllowedDataLocation`. [#5103](https://github.com/pnp/powershell/issues/5103)
+- Fixed multi-geo compatibility issues with `Get-PnPGeoAdministrator` response handling, `Set-PnPMultiGeoExperience` confirmation prompts, and unsupported-version errors for `Set-PnPMultiGeoCompanyAllowedDataLocation`. [#5401](https://github.com/pnp/powershell/pull/5401)
 
 ### Removed
 

--- a/documentation/Get-PnPGeoAdministrator.md
+++ b/documentation/Get-PnPGeoAdministrator.md
@@ -50,7 +50,7 @@ Accept wildcard characters: False
 ## OUTPUTS
 
 ### PnP.PowerShell.Commands.Model.GeoAdministrator
-Returns objects with `DisplayName`, `LoginName`, `MemberType`, `ObjectId`, and `GeoLocation` properties.
+Returns objects with `GeoLocation`, `LoginName`, `DisplayName`, `MemberType`, and `ObjectId` properties.
 
 ## RELATED LINKS
 

--- a/src/Commands/Admin/GetGeoAdministrator.cs
+++ b/src/Commands/Admin/GetGeoAdministrator.cs
@@ -15,7 +15,7 @@ namespace PnP.PowerShell.Commands.Admin
 		protected override void ExecuteCmdlet()
 		{
 			var multiGeoRestApiClient = new MultiGeoRestApiClient(AdminContext);
-			WriteObject(multiGeoRestApiClient.GetGeoAdministrators().GeoAdministrators, true);
+			WriteObject(multiGeoRestApiClient.GetGeoAdministrators(), true);
 		}
 	}
 }

--- a/src/Commands/Admin/SetMultiGeoExperience.cs
+++ b/src/Commands/Admin/SetMultiGeoExperience.cs
@@ -19,11 +19,6 @@ namespace PnP.PowerShell.Commands.Admin
 
 		protected override void ExecuteCmdlet()
 		{
-			if (!ShouldProcess(AllInstances.ToBool() ? "all instances' multi-geo experience" : "current instance's multi-geo experience", "Upgrade to include SharePoint Online Multi-Geo"))
-			{
-				return;
-			}
-
 			var multiGeoRestApiClient = new MultiGeoRestApiClient(AdminContext);
 			multiGeoRestApiClient.EnsureGeoExperienceUpgradeSupported();
 

--- a/src/Commands/Admin/SetMultiGeoExperience.cs
+++ b/src/Commands/Admin/SetMultiGeoExperience.cs
@@ -19,6 +19,16 @@ namespace PnP.PowerShell.Commands.Admin
 
 		protected override void ExecuteCmdlet()
 		{
+			// SPO uses ShouldContinue only; call ShouldProcess only to honor -WhatIf without adding a second default confirmation prompt.
+			if (IsWhatIf())
+			{
+				var target = AllInstances.ToBool() ? "all instances' multi-geo experience" : "current instance's multi-geo experience";
+				if (!ShouldProcess(target, "Upgrade to include SharePoint Online Multi-Geo"))
+				{
+					return;
+				}
+			}
+
 			var multiGeoRestApiClient = new MultiGeoRestApiClient(AdminContext);
 			multiGeoRestApiClient.EnsureGeoExperienceUpgradeSupported();
 
@@ -29,6 +39,11 @@ namespace PnP.PowerShell.Commands.Admin
 
 			multiGeoRestApiClient.UpgradeGeoExperience(AllInstances.ToBool());
 			WriteObject(UpgradeCompletedMessage);
+		}
+
+		private bool IsWhatIf()
+		{
+			return MyInvocation.BoundParameters.TryGetValue("WhatIf", out var whatIfValue) && whatIfValue is SwitchParameter whatIf && whatIf.ToBool();
 		}
 	}
 }

--- a/src/Commands/Model/GeoAdministrator.cs
+++ b/src/Commands/Model/GeoAdministrator.cs
@@ -9,14 +9,19 @@ namespace PnP.PowerShell.Commands.Model
 	public class GeoAdministrator
 	{
 		/// <summary>
-		/// The display name of the geo administrator.
+		/// The geo location administered by the geo administrator.
 		/// </summary>
-		public string DisplayName { get; set; }
+		public string GeoLocation { get; set; }
 
 		/// <summary>
 		/// The login name of the geo administrator.
 		/// </summary>
 		public string LoginName { get; set; }
+
+		/// <summary>
+		/// The display name of the geo administrator.
+		/// </summary>
+		public string DisplayName { get; set; }
 
 		/// <summary>
 		/// The member type of the geo administrator.
@@ -27,10 +32,5 @@ namespace PnP.PowerShell.Commands.Model
 		/// The object identifier of the geo administrator.
 		/// </summary>
 		public Guid ObjectId { get; set; }
-
-		/// <summary>
-		/// The geo location administered by the geo administrator.
-		/// </summary>
-		public string GeoLocation { get; set; }
 	}
 }

--- a/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
+++ b/src/Commands/Utilities/MultiGeo/MultiGeoRestApiClient.cs
@@ -171,9 +171,9 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 			return GetFeed<GeoMoveTenantCompatibilityCheck>(GeoMoveCompatibilityChecksPath, GetCurrentApiVersion(GeoMoveCompatibilityChecksMinimumApiVersion));
 		}
 
-		internal GeoAdministratorCollection GetGeoAdministrators()
+		internal IEnumerable<GeoAdministrator> GetGeoAdministrators()
 		{
-			return Get<GeoAdministratorCollection>(GeoAdministratorsPath, GetGeoAdministratorsApiVersion());
+			return GetFeed<GeoAdministrator>(GeoAdministratorsPath, GetGeoAdministratorsApiVersion());
 		}
 
 		internal MultiGeoExperience GetGeoExperience()
@@ -227,7 +227,7 @@ namespace PnP.PowerShell.Commands.Utilities.MultiGeo
 			var apiVersion = GetCurrentApiVersion();
 			if (!IsSupportedApiVersion(apiVersion, AllowedDataLocationsApiVersion))
 			{
-				throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, CommandResources.CrossGeoInvalidVersion, typeof(MultiGeoRestApiClient).Assembly.GetName().Version));
+				throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, CommandResources.CrossGeoInvalidVersion, GetApplicationVersion()));
 			}
 
 			PostWithoutResponse(AllowedDataLocationsPath, allowedDataLocation, apiVersion);


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Addresses feedback in #5103.

## What is in this Pull Request ? ##
Fixes multi-geo compatibility issues reported against the SPO Management Shell behavior:

- Reads `Get-PnPGeoAdministrator` results as an OData feed so `value`/array responses deserialize correctly.
- Aligns `GeoAdministrator` output property order with the SPO Management Shell type.
- Removes the extra generic `ShouldProcess` prompt from `Set-PnPMultiGeoExperience`, leaving the single SPO-style irreversible-upgrade confirmation.
- Aligns the unsupported-version error argument for `Set-PnPMultiGeoCompanyAllowedDataLocation` with the rest of the MultiGeo client.
- Updates the relevant cmdlet documentation and changelog entry.