### PR TITLE
Fix Power Apps endpoints for government clouds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed an issue with `Add-PnPListItem` and `Set-PnPListItem` cmdlets when trying to set taxonomy fields by passing in a GUID or term instance using a Batch. [#5174](https://github.com/pnp/powershell/pull/5174)
 - Fixed issue with Azure functions not working properly when we also have other modules like Az which rely on .NET 10. [#5393](https://github.com/pnp/powershell/pull/5393)
 - Fixed multi-geo compatibility issues with `Get-PnPGeoAdministrator` response handling, `Set-PnPMultiGeoExperience` confirmation prompts, and unsupported-version errors for `Set-PnPMultiGeoCompanyAllowedDataLocation`. [#5401](https://github.com/pnp/powershell/pull/5401)
-- Fixed Power Apps cmdlets to use cloud-specific Power Apps service audiences and endpoints for government clouds. [#5400](https://github.com/pnp/powershell/issues/5400)
+- Fixed Power Apps cmdlets to use cloud-specific Power Apps service audiences and endpoints for government clouds. [#5404](https://github.com/pnp/powershell/pull/5404)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed an issue with `Add-PnPListItem` and `Set-PnPListItem` cmdlets when trying to set taxonomy fields by passing in a GUID or term instance using a Batch. [#5174](https://github.com/pnp/powershell/pull/5174)
 - Fixed issue with Azure functions not working properly when we also have other modules like Az which rely on .NET 10. [#5393](https://github.com/pnp/powershell/pull/5393)
 - Fixed multi-geo compatibility issues with `Get-PnPGeoAdministrator` response handling, `Set-PnPMultiGeoExperience` confirmation prompts, and unsupported-version errors for `Set-PnPMultiGeoCompanyAllowedDataLocation`. [#5401](https://github.com/pnp/powershell/pull/5401)
+- Fixed Power Apps cmdlets to use cloud-specific Power Apps service audiences and endpoints for government clouds. [#5400](https://github.com/pnp/powershell/issues/5400)
 
 ### Removed
 

--- a/documentation/Get-PnPPowerApp.md
+++ b/documentation/Get-PnPPowerApp.md
@@ -14,6 +14,7 @@ title: Get-PnPPowerApp
 **Required Permissions**
 
 * Azure: management.azure.com
+* PowerApps: service.powerapps.com
 
 Returns the Power Apps for a given environment
 

--- a/documentation/Set-PnPPowerAppByPassConsent.md
+++ b/documentation/Set-PnPPowerAppByPassConsent.md
@@ -14,6 +14,7 @@ title: Set-PnPPowerAppByPassConsent
 **Required Permissions**
 
 * Azure: management.azure.com
+* PowerApps: service.powerapps.com
 
 Sets the consent bypass flag of a Power Apps for a given environment
 

--- a/src/Commands/Base/PnPAzureManagementApiCmdlet.cs
+++ b/src/Commands/Base/PnPAzureManagementApiCmdlet.cs
@@ -1,5 +1,6 @@
 ﻿using System.Management.Automation;
 using Microsoft.SharePoint.Client;
+using PnP.PowerShell.Commands.Utilities;
 using PnP.PowerShell.Commands.Utilities.Auth;
 using PnP.PowerShell.Commands.Utilities.REST;
 
@@ -18,7 +19,7 @@ namespace PnP.PowerShell.Commands.Base
         /// <summary>
         /// The default audience to target PowerApps APIs
         /// </summary>
-        public string PowerAppDefaultAudience => "https://service.powerapps.com/.default";
+        public string PowerAppDefaultAudience => $"{PowerPlatformUtility.GetPowerAppsServiceEndpoint(Connection.AzureEnvironment)}/.default";
 
         /// <summary>
         /// Returns an Access Token for the Microsoft Office Management API, if available, otherwise NULL

--- a/src/Commands/Base/TokenHandler.cs
+++ b/src/Commands/Base/TokenHandler.cs
@@ -125,7 +125,17 @@ namespace PnP.PowerShell.Commands.Base
                 "azure" or "management.azure.com" or "management.chinacloudapi.cn" or "management.usgovcloudapi.net" => Enums.ResourceTypeName.AzureManagementApi,
                 "exchangeonline" or "outlook.office.com" or "outlook.office365.com" => Enums.ResourceTypeName.ExchangeOnline,
                 "flow" or "service.flow.microsoft.com" => Enums.ResourceTypeName.PowerAutomate,
-                "powerapps" or "api.powerapps.com" => Enums.ResourceTypeName.PowerApps,
+                "powerapps"
+                    or "api.powerapps.com"
+                    or "service.powerapps.com"
+                    or "api.powerapps.cn"
+                    or "service.powerapps.cn"
+                    or "gov.api.powerapps.us"
+                    or "gov.service.powerapps.us"
+                    or "high.api.powerapps.us"
+                    or "high.service.powerapps.us"
+                    or "api.apps.appsplatform.us"
+                    or "service.apps.appsplatform.us" => Enums.ResourceTypeName.PowerApps,
                 "dynamics" or "admin.services.crm.dynamics.com" or "api.crm.dynamics.com" => Enums.ResourceTypeName.DynamicsCRM,
                 "gcs" or "gcs.office.com" => Enums.ResourceTypeName.Gcs,
 

--- a/src/Commands/PowerPlatform/PowerApps/GetPowerApp.cs
+++ b/src/Commands/PowerPlatform/PowerApps/GetPowerApp.cs
@@ -40,7 +40,10 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerApps
             {
                 LogDebug($"Retrieving all PowerApps within environment '{environmentName}'");
 
-                var apps = PowerAppsRequestHelper.GetResultCollection<Model.PowerPlatform.PowerApp.PowerApp>($"{powerAppsUrl}/providers/Microsoft.PowerApps/apps?api-version=2016-11-01&$filter=environment eq '{environmentName}'");
+                var requestUrl = AsAdmin
+                    ? $"{powerAppsUrl}/providers/Microsoft.PowerApps/scopes/admin/environments/{environmentName}/apps?api-version=2016-11-01"
+                    : $"{powerAppsUrl}/providers/Microsoft.PowerApps/apps?api-version=2016-11-01&$filter=environment eq '{environmentName}'";
+                var apps = PowerAppsRequestHelper.GetResultCollection<Model.PowerPlatform.PowerApp.PowerApp>(requestUrl);
                 WriteObject(apps, true);
             }
         }

--- a/src/Commands/Utilities/PowerPlatformUtility.cs
+++ b/src/Commands/Utilities/PowerPlatformUtility.cs
@@ -1,4 +1,5 @@
-﻿using PnP.Framework;
+﻿using System;
+using PnP.Framework;
 using PnP.PowerShell.Commands.Utilities.REST;
 using System.Linq;
 using PnP.Framework.Diagnostics;
@@ -26,6 +27,7 @@ namespace PnP.PowerShell.Commands.Utilities
                 AzureEnvironment.USGovernmentHigh => "https://high.api.flow.microsoft.us",
                 AzureEnvironment.USGovernmentDoD => "https://api.flow.appsplatform.us",
                 AzureEnvironment.PPE => "https://api.flow.microsoft.com",
+                AzureEnvironment.BleuCloud or AzureEnvironment.DelosCloud or AzureEnvironment.GovSGCloud => throw GetUnsupportedPowerPlatformCloudException(environment),
                 _ => "https://api.flow.microsoft.com"
             };
         }
@@ -41,12 +43,34 @@ namespace PnP.PowerShell.Commands.Utilities
             {
                 AzureEnvironment.Production => "https://api.powerapps.com",
                 AzureEnvironment.Germany => "https://api.powerapps.com",
-                AzureEnvironment.China => "https://api.powerautomate.cn",
+                AzureEnvironment.China => "https://api.powerapps.cn",
                 AzureEnvironment.USGovernment => "https://gov.api.powerapps.us",
                 AzureEnvironment.USGovernmentHigh => "https://high.api.powerapps.us",
                 AzureEnvironment.USGovernmentDoD => "https://api.apps.appsplatform.us",
                 AzureEnvironment.PPE => "https://api.powerapps.com",
+                AzureEnvironment.BleuCloud or AzureEnvironment.DelosCloud or AzureEnvironment.GovSGCloud => throw GetUnsupportedPowerPlatformCloudException(environment),
                 _ => "https://api.powerapps.com"
+            };
+        }
+
+        /// <summary>
+        /// Returns the audience URL for acquiring tokens for Power Apps APIs based on the Azure Environment
+        /// </summary>
+        /// <param name="environment">Azure Environment to indicate the type of cloud to target</param>
+        /// <returns>Audience URL for acquiring tokens for Power Apps APIs</returns>
+        public static string GetPowerAppsServiceEndpoint(AzureEnvironment environment)
+        {
+            return environment switch
+            {
+                AzureEnvironment.Production => "https://service.powerapps.com",
+                AzureEnvironment.Germany => "https://service.powerapps.com",
+                AzureEnvironment.China => "https://service.powerapps.cn",
+                AzureEnvironment.USGovernment => "https://gov.service.powerapps.us",
+                AzureEnvironment.USGovernmentHigh => "https://high.service.powerapps.us",
+                AzureEnvironment.USGovernmentDoD => "https://service.apps.appsplatform.us",
+                AzureEnvironment.PPE => "https://service.powerapps.com",
+                AzureEnvironment.BleuCloud or AzureEnvironment.DelosCloud or AzureEnvironment.GovSGCloud => throw GetUnsupportedPowerPlatformCloudException(environment),
+                _ => "https://service.powerapps.com"
             };
         }
 
@@ -66,8 +90,14 @@ namespace PnP.PowerShell.Commands.Utilities
                 AzureEnvironment.USGovernmentHigh => "https://high.api.bap.microsoft.us",
                 AzureEnvironment.USGovernmentDoD => "https://api.bap.appsplatform.us",
                 AzureEnvironment.PPE => "https://api.bap.microsoft.com",
+                AzureEnvironment.BleuCloud or AzureEnvironment.DelosCloud or AzureEnvironment.GovSGCloud => throw GetUnsupportedPowerPlatformCloudException(environment),
                 _ => "https://api.bap.microsoft.com"
             };
+        }
+
+        private static NotSupportedException GetUnsupportedPowerPlatformCloudException(AzureEnvironment environment)
+        {
+            return new NotSupportedException($"Power Platform endpoints for AzureEnvironment '{environment}' are not currently documented or supported.");
         }
 
         /// <summary>


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #5400

## What is in this Pull Request ? ##
This PR fixes Power Apps cmdlets in government cloud connections by using cloud-specific Power Apps service audiences when acquiring tokens while keeping REST calls on the matching cloud-specific API endpoint.

It also updates `Get-PnPPowerApp -AsAdmin` list calls to use the admin-scoped Power Apps endpoint, corrects the China Power Apps API endpoint, documents the additional Power Apps permission requirement for affected cmdlets, and prevents unsupported sovereign cloud values from silently falling back to public Power Platform endpoints when Microsoft has not documented Power Platform endpoint support for those clouds.
