### PR TITLE
Fix Power Apps package exports in sovereign clouds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed issue with Azure functions not working properly when we also have other modules like Az which rely on .NET 10. [#5393](https://github.com/pnp/powershell/pull/5393)
 - Fixed multi-geo compatibility issues with `Get-PnPGeoAdministrator` response handling, `Set-PnPMultiGeoExperience` confirmation prompts, and unsupported-version errors for `Set-PnPMultiGeoCompanyAllowedDataLocation`. [#5401](https://github.com/pnp/powershell/pull/5401)
 - Fixed Power Apps cmdlets to use cloud-specific Power Apps service audiences and endpoints for government clouds. [#5404](https://github.com/pnp/powershell/pull/5404)
+- Fixed `Export-PnPPowerApp`, `Get-PnPPowerPlatformCustomConnector`, `Export-PnPFlow -AsZipPackage`, and `Import-PnPFlow` to use the Power Apps service audience when calling Power Apps and Business Applications endpoints in sovereign clouds.
 
 ### Removed
 

--- a/documentation/Export-PnPFlow.md
+++ b/documentation/Export-PnPFlow.md
@@ -14,6 +14,7 @@ title: Export-PnPFlow
 **Required Permissions**
 
 * Azure: management.azure.com
+* PowerApps: service.powerapps.com (when exporting as a ZIP package)
 
 Exports a Microsoft Power Automate Flow
 

--- a/documentation/Export-PnPPowerApp.md
+++ b/documentation/Export-PnPPowerApp.md
@@ -14,6 +14,7 @@ title: Export-PnPPowerApp
 **Required Permissions**
 
 * Azure: management.azure.com
+* PowerApps: service.powerapps.com
 
 Exports a Microsoft Power App
 

--- a/documentation/Get-PnPPowerPlatformCustomConnector.md
+++ b/documentation/Get-PnPPowerPlatformCustomConnector.md
@@ -14,6 +14,7 @@ title: Get-PnPPowerPlatformCustomConnector
 **Required Permissions**
 
 * Azure: management.azure.com
+* PowerApps: service.powerapps.com
 
 Returns the custom Power Platform Connectors for a given environment
 

--- a/documentation/Import-PnPFlow.md
+++ b/documentation/Import-PnPFlow.md
@@ -14,6 +14,7 @@ title: Import-PnPFlow
 **Required Permissions**
 
 * Azure: management.azure.com
+* PowerApps: service.powerapps.com
 
 Imports a Microsoft Power Automate Flow.
 

--- a/src/Commands/PowerPlatform/Environment/GetPowerPlatformCustomConnector.cs
+++ b/src/Commands/PowerPlatform/Environment/GetPowerPlatformCustomConnector.cs
@@ -1,4 +1,5 @@
 ﻿using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Attributes;
 using System.Management.Automation;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 using PnP.PowerShell.Commands.Utilities;
@@ -6,6 +7,7 @@ using PnP.PowerShell.Commands.Utilities;
 namespace PnP.PowerShell.Commands.PowerPlatform.Environment
 {
     [Cmdlet(VerbsCommon.Get, "PnPPowerPlatformCustomConnector")]
+    [RequiredApiApplicationPermissions("https://management.azure.com/user_impersonation", "https://service.powerapps.com/user")]
     public class GetPowerPlatformCustomConnector : PnPAzureManagementApiCmdlet
     {
         [Parameter(Mandatory = false, ValueFromPipeline = true)]
@@ -28,14 +30,17 @@ namespace PnP.PowerShell.Commands.PowerPlatform.Environment
 
                 LogDebug($"Retrieving specific Custom Connector with the provided name '{appName}' within the environment '{environmentName}'");
 
-                var result = ArmRequestHelper.Get<Model.PowerPlatform.Environment.PowerPlatformConnector>( $"{powerAppsUrl}/providers/Microsoft.PowerApps{(AsAdmin ? "/scopes/admin/environments/" + environmentName : "")}/apis/{appName}?api-version=2016-11-01&$filter=environment eq '{environmentName}' and isCustomApi eq 'True'");
+                var result = PowerAppsRequestHelper.Get<Model.PowerPlatform.Environment.PowerPlatformConnector>( $"{powerAppsUrl}/providers/Microsoft.PowerApps{(AsAdmin ? "/scopes/admin/environments/" + environmentName : "")}/apis/{appName}?api-version=2016-11-01&$filter=environment eq '{environmentName}' and isCustomApi eq 'True'");
                 WriteObject(result, false);
             }
             else
             {
                 LogDebug($"Retrieving all Connectors within environment '{environmentName}'");
 
-                var connectors = ArmRequestHelper.GetResultCollection<Model.PowerPlatform.Environment.PowerPlatformConnector>( $"{powerAppsUrl}/providers/Microsoft.PowerApps/apis?api-version=2016-11-01&$filter=environment eq '{environmentName}' and isCustomApi eq 'True'");
+                var requestUrl = AsAdmin
+                    ? $"{powerAppsUrl}/providers/Microsoft.PowerApps/scopes/admin/environments/{environmentName}/apis?api-version=2016-11-01&$filter=isCustomApi eq 'True'"
+                    : $"{powerAppsUrl}/providers/Microsoft.PowerApps/apis?api-version=2016-11-01&$filter=environment eq '{environmentName}' and isCustomApi eq 'True'";
+                var connectors = PowerAppsRequestHelper.GetResultCollection<Model.PowerPlatform.Environment.PowerPlatformConnector>(requestUrl);
                 WriteObject(connectors, true);
             }
         }

--- a/src/Commands/PowerPlatform/PowerApps/ExportPowerApp.cs
+++ b/src/Commands/PowerPlatform/PowerApps/ExportPowerApp.cs
@@ -8,7 +8,7 @@ using System.Management.Automation;
 namespace PnP.PowerShell.Commands.PowerPlatform.PowerApps
 {
     [Cmdlet(VerbsData.Export, "PnPPowerApp")]
-    [RequiredApiApplicationPermissions("https://management.azure.com/.default")]
+    [RequiredApiApplicationPermissions("https://management.azure.com/user_impersonation", "https://service.powerapps.com/user")]
     public class ExportPowerApp : PnPAzureManagementApiCmdlet
     {
         [Parameter(Mandatory = false)]
@@ -59,8 +59,9 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerApps
 
             var environmentName = ParameterSpecified(nameof(Environment)) ? Environment.GetName() : PowerPlatformUtility.GetDefaultEnvironment(ArmRequestHelper, Connection.AzureEnvironment)?.Name;
             var appName = Identity.GetName();
+            var powerAppsServiceAccessToken = PowerAppsServiceAccessToken;
 
-            var wrapper = PowerAppsUtility.GetWrapper(Connection.HttpClient, environmentName, AccessToken, appName, Connection.AzureEnvironment);
+            var wrapper = PowerAppsUtility.GetWrapper(Connection.HttpClient, environmentName, powerAppsServiceAccessToken, appName, Connection.AzureEnvironment);
 
             if (wrapper.Status == Model.PowerPlatform.PowerApp.Enums.PowerAppExportStatus.Succeeded)
             {
@@ -78,11 +79,11 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerApps
                     creator = PackageCreatedBy,
                     sourceEnvironment = PackageSourceEnvironment
                 };
-                var responseLocation = PowerAppsUtility.GetResponseLocation(Connection.HttpClient, environmentName, AccessToken, appName, wrapper, objectDetails);
+                var responseLocation = PowerAppsUtility.GetResponseLocation(Connection.HttpClient, environmentName, powerAppsServiceAccessToken, appName, wrapper, objectDetails, Connection.AzureEnvironment);
 
 
-                var packageLink = PowerAppsUtility.GetPackageLink(Connection.HttpClient, Convert.ToString(responseLocation), AccessToken);
-                var getFileByteArray = PowerAppsUtility.GetFileByteArray(Connection.HttpClient, packageLink, AccessToken);
+                var packageLink = PowerAppsUtility.GetPackageLink(Connection.HttpClient, Convert.ToString(responseLocation), powerAppsServiceAccessToken);
+                var getFileByteArray = PowerAppsUtility.GetFileByteArray(Connection.HttpClient, packageLink, powerAppsServiceAccessToken);
                 var fileName = string.Empty;
                 if (ParameterSpecified(nameof(OutPath)))
                 {

--- a/src/Commands/PowerPlatform/PowerAutomate/ExportFlow.cs
+++ b/src/Commands/PowerPlatform/PowerAutomate/ExportFlow.cs
@@ -6,10 +6,12 @@ using System;
 using System.Management.Automation;
 using System.Net.Http;
 using System.Text.Json;
+using PnP.PowerShell.Commands.Attributes;
 
 namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
 {
     [Cmdlet(VerbsData.Export, "PnPFlow")]
+    [RequiredApiDelegatedPermissions("azure/user_impersonation", "https://service.powerapps.com/user")]
     public class ExportFlow : PnPAzureManagementApiCmdlet
     {
         private const string ParameterSet_ASJSON = "As Json";
@@ -71,6 +73,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
 
             if (AsZipPackage)
             {
+                var powerAppsServiceAccessToken = PowerAppsServiceAccessToken;
                 var postData = new
                 {
                     baseResourceIds = new[] {
@@ -78,7 +81,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
                 }
                 };
                 string baseUrl = PowerPlatformUtility.GetBapEndpoint(Connection.AzureEnvironment);
-                var wrapper = RestHelper.Post<Model.PowerPlatform.PowerAutomate.FlowExportPackageWrapper>(Connection.HttpClient, $"{baseUrl}/providers/Microsoft.BusinessAppPlatform/environments/{environmentName}/listPackageResources?api-version=2016-11-01", AccessToken, payload: postData);
+                var wrapper = RestHelper.Post<Model.PowerPlatform.PowerAutomate.FlowExportPackageWrapper>(Connection.HttpClient, $"{baseUrl}/providers/Microsoft.BusinessAppPlatform/environments/{environmentName}/listPackageResources?api-version=2016-11-01", powerAppsServiceAccessToken, payload: postData);
 
                 if (wrapper.Status == Model.PowerPlatform.PowerAutomate.Enums.FlowExportStatus.Succeeded)
                 {
@@ -111,7 +114,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
                         resources = wrapper.Resources
                     };
 
-                    var resultElement = RestHelper.Post<JsonElement>(Connection.HttpClient, $"{baseUrl}/providers/Microsoft.BusinessAppPlatform/environments/{environmentName}/exportPackage?api-version=2016-11-01", AccessToken, payload: exportPostData);
+                    var resultElement = RestHelper.Post<JsonElement>(Connection.HttpClient, $"{baseUrl}/providers/Microsoft.BusinessAppPlatform/environments/{environmentName}/exportPackage?api-version=2016-11-01", powerAppsServiceAccessToken, payload: exportPostData);
                     if (resultElement.TryGetProperty("status", out JsonElement statusElement))
                     {
                         if (statusElement.GetString() == "Succeeded")

--- a/src/Commands/PowerPlatform/PowerAutomate/ImportFlow.cs
+++ b/src/Commands/PowerPlatform/PowerAutomate/ImportFlow.cs
@@ -9,7 +9,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
 {
     [Cmdlet(VerbsData.Import, "PnPFlow")]
     [ApiNotAvailableUnderApplicationPermissions]
-    [RequiredApiDelegatedPermissions("azure/user_impersonation")]
+    [RequiredApiDelegatedPermissions("azure/user_impersonation", "https://service.powerapps.com/user")]
     public class ImportFlow : PnPAzureManagementApiCmdlet
     {
         private const string ParameterSet_BYIDENTITY = "By Identity";
@@ -36,7 +36,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
         {
             var environmentName = GetEnvironmentName();
             string baseUrl = PowerPlatformUtility.GetBapEndpoint(Connection.AzureEnvironment);
-            var importStatus = ImportFlowUtility.ExecuteImportFlow(Connection.HttpClient, AccessToken, baseUrl, environmentName, PackagePath, Name, RetryCount, Delay);
+            var importStatus = ImportFlowUtility.ExecuteImportFlow(Connection.HttpClient, PowerAppsServiceAccessToken, baseUrl, environmentName, PackagePath, Name, RetryCount, Delay);
             WriteObject(importStatus);
         }
 


### PR DESCRIPTION
Before creating a pull request, make sure that you have read the contribution file located at

https://github.com/pnp/powerShell/blob/dev/CONTRIBUTING.md

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Follow-up to #5404.

## What is in this Pull Request ? ##
Power Apps and Business Applications package endpoints in sovereign clouds require the cloud-specific Power Apps service audience. Some Power Apps and BAP callers still used the ARM token, causing government cloud calls such as `Export-PnPPowerApp` to fail even after the endpoint mapping fix in #5404.

This PR updates `Export-PnPPowerApp` to use the Power Apps service token for all BAP package calls and to pass the current Azure environment into each BAP helper call. It also switches `Get-PnPPowerPlatformCustomConnector` to the Power Apps request helper, aligns its admin list endpoint, and applies the same BAP token fix to ZIP package flow export/import paths while leaving ProcessSimple flow APIs on ARM.

Documentation and the current nightly changelog now list the additional Power Apps audience requirement for the affected cmdlets.

### Guidance ###
N/A