### PR TITLE
Refactor Power Platform Export and Import Cmdlets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `Standard` and `EDU_Staff` template support to `New-PnPTeamsTeam` and provision Teams templates through Microsoft Graph team templates. Note that `EDU_Class` and `EDU_PLC` are now also provisioned through Microsoft Graph team templates (`POST /teams`) instead of the previous Microsoft 365 Group creation and teamify flow. [#999](https://github.com/pnp/powershell/issues/999)
 
 ### Changed
+- Changed `Export-PnPFlow -AsZipPackage` and `Export-PnPPowerApp` to ask for confirmation before overwriting an existing file when `-OutPath` is omitted, as they already did when `-OutPath` is specified. Unattended scripts that rely on the previous silent overwrite need to specify `-Force`. [#5421](https://github.com/pnp/powershell/pull/5421)
 
 ### Fixed
 - Fixed an issue with `Add-PnPListItem` and `Set-PnPListItem` cmdlets when trying to set taxonomy fields by passing in a GUID or term instance using a Batch. [#5174](https://github.com/pnp/powershell/pull/5174)
@@ -22,6 +23,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed multi-geo compatibility issues with `Get-PnPGeoAdministrator` response handling, `Set-PnPMultiGeoExperience` confirmation prompts, and unsupported-version errors for `Set-PnPMultiGeoCompanyAllowedDataLocation`. [#5401](https://github.com/pnp/powershell/pull/5401)
 - Fixed Power Apps cmdlets to use cloud-specific Power Apps service audiences and endpoints for government clouds. [#5404](https://github.com/pnp/powershell/pull/5404)
 - Fixed `Export-PnPPowerApp`, `Get-PnPPowerPlatformCustomConnector`, `Export-PnPFlow -AsZipPackage`, and `Import-PnPFlow` to use the Power Apps service audience when calling Power Apps and Business Applications endpoints in sovereign clouds. [#5408](https://github.com/pnp/powershell/pull/5408)
+- Fixed `Export-PnPFlow -AsZipPackage` silently doing nothing when the export failed. Failures are now reported on the PowerShell error stream and incomplete or unsuccessful package responses are rejected instead of resulting in an empty or invalid file. [#1340](https://github.com/pnp/powershell/issues/1340)
+- Fixed `Export-PnPPowerApp` silently doing nothing when the export failed, and no longer polling forever when the service reports a failed export. The cmdlet now waits up to 30 minutes for the package to be prepared, following the polling interval requested by the service. [#1340](https://github.com/pnp/powershell/issues/1340)
+- Fixed `Import-PnPFlow` ignoring its documented default polling behavior when `-RetryCount` and `-Delay` were omitted, which made the import fail with a missing property error. Both parameters now validate their range and a run that never becomes ready reports why. [#5421](https://github.com/pnp/powershell/pull/5421)
+- Fixed `Set-PnPPlannerPlan` failing to update a plan that was modified by someone else while the update was in flight, and returning nothing instead of an error when the update could not be applied. [#5421](https://github.com/pnp/powershell/pull/5421)
+- Fixed `Get-PnPUserProfilePhoto` and other Microsoft Graph backed cmdlets silently ignoring a failed request when the error response could be parsed but did not contain any error details. [#5421](https://github.com/pnp/powershell/pull/5421)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed multi-geo compatibility issues with `Get-PnPGeoAdministrator` response handling, `Set-PnPMultiGeoExperience` confirmation prompts, and unsupported-version errors for `Set-PnPMultiGeoCompanyAllowedDataLocation`. [#5401](https://github.com/pnp/powershell/pull/5401)
 - Fixed Power Apps cmdlets to use cloud-specific Power Apps service audiences and endpoints for government clouds. [#5404](https://github.com/pnp/powershell/pull/5404)
 - Fixed `Export-PnPPowerApp`, `Get-PnPPowerPlatformCustomConnector`, `Export-PnPFlow -AsZipPackage`, and `Import-PnPFlow` to use the Power Apps service audience when calling Power Apps and Business Applications endpoints in sovereign clouds. [#5408](https://github.com/pnp/powershell/pull/5408)
-- Fixed `Export-PnPFlow -AsZipPackage` to emit capturable PowerShell errors for failed exports and reject incomplete or unsuccessful package responses. [#1340](https://github.com/pnp/powershell/issues/1340)
-- Fixed `Export-PnPPowerApp` to emit capturable PowerShell errors for failed exports, reject incomplete or unsuccessful package responses, and stop polling for the export status indefinitely when the service reports a failure. [#1340](https://github.com/pnp/powershell/issues/1340)
-- Fixed `Import-PnPFlow` to honor the documented default polling behavior when `-RetryCount` and `-Delay` are omitted, and to report a clear error instead of a missing property when the import parameters never become available. [#PRNUMBER](https://github.com/pnp/powershell/pull/PRNUMBER)
-- Fixed Microsoft Graph backed cmdlets silently ignoring a failed request when the error response body could be parsed but contained no error details. [#PRNUMBER](https://github.com/pnp/powershell/pull/PRNUMBER)
-- Fixed `Set-PnPPlannerPlan` retrying the update when the plan was modified by someone else while the update was in flight, and reporting the reason instead of returning nothing when the update fails. [#PRNUMBER](https://github.com/pnp/powershell/pull/PRNUMBER)
-- Fixed `Export-PnPFlow -AsZipPackage` and `Export-PnPPowerApp` silently overwriting an existing file when `-OutPath` was omitted. The overwrite is now confirmed unless `-Force` is specified, as it already was when `-OutPath` is used. [#PRNUMBER](https://github.com/pnp/powershell/pull/PRNUMBER)
-- Fixed `Export-PnPPowerApp` giving up on a Power App that takes a while to export. The cmdlet now waits up to 30 minutes and follows the polling interval requested by the service. [#PRNUMBER](https://github.com/pnp/powershell/pull/PRNUMBER)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed multi-geo compatibility issues with `Get-PnPGeoAdministrator` response handling, `Set-PnPMultiGeoExperience` confirmation prompts, and unsupported-version errors for `Set-PnPMultiGeoCompanyAllowedDataLocation`. [#5401](https://github.com/pnp/powershell/pull/5401)
 - Fixed Power Apps cmdlets to use cloud-specific Power Apps service audiences and endpoints for government clouds. [#5404](https://github.com/pnp/powershell/pull/5404)
 - Fixed `Export-PnPPowerApp`, `Get-PnPPowerPlatformCustomConnector`, `Export-PnPFlow -AsZipPackage`, and `Import-PnPFlow` to use the Power Apps service audience when calling Power Apps and Business Applications endpoints in sovereign clouds. [#5408](https://github.com/pnp/powershell/pull/5408)
+- Fixed `Export-PnPFlow -AsZipPackage` to emit capturable PowerShell errors for failed exports and reject incomplete or unsuccessful package responses. [#1340](https://github.com/pnp/powershell/issues/1340)
+- Fixed `Export-PnPPowerApp` to emit capturable PowerShell errors for failed exports, reject incomplete or unsuccessful package responses, and stop polling for the export status indefinitely when the service reports a failure. [#1340](https://github.com/pnp/powershell/issues/1340)
+- Fixed `Import-PnPFlow` to honor the documented default polling behavior when `-RetryCount` and `-Delay` are omitted, and to report a clear error instead of a missing property when the import parameters never become available. [#PRNUMBER](https://github.com/pnp/powershell/pull/PRNUMBER)
+- Fixed Microsoft Graph backed cmdlets silently ignoring a failed request when the error response body could be parsed but contained no error details. [#PRNUMBER](https://github.com/pnp/powershell/pull/PRNUMBER)
+- Fixed `Set-PnPPlannerPlan` retrying the update when the plan was modified by someone else while the update was in flight, and reporting the reason instead of returning nothing when the update fails. [#PRNUMBER](https://github.com/pnp/powershell/pull/PRNUMBER)
+- Fixed `Export-PnPFlow -AsZipPackage` and `Export-PnPPowerApp` silently overwriting an existing file when `-OutPath` was omitted. The overwrite is now confirmed unless `-Force` is specified, as it already was when `-OutPath` is used. [#PRNUMBER](https://github.com/pnp/powershell/pull/PRNUMBER)
+- Fixed `Export-PnPPowerApp` giving up on a Power App that takes a while to export. The cmdlet now waits up to 30 minutes and follows the polling interval requested by the service. [#PRNUMBER](https://github.com/pnp/powershell/pull/PRNUMBER)
 
 ### Removed
 

--- a/documentation/Export-PnPFlow.md
+++ b/documentation/Export-PnPFlow.md
@@ -37,7 +37,9 @@ Export-PnPFlow [-Environment <PowerAutomateEnvironmentPipeBind>] -Identity <Powe
 ## DESCRIPTION
 This cmdlet exports a Microsoft Power Automate Flow either as a json file or as a zip package.
 
-Many times exporting a Microsoft Power Automate Flow will not be possible due to various reasons such as connections having gone stale, SharePoint sites referenced no longer existing or other configuration errors in the Flow. To display these errors when trying to export a Flow, provide the -Verbose flag with your export request. If not provided, these errors will silently be ignored.
+Exporting a Microsoft Power Automate Flow might fail due to stale connections, SharePoint sites that no longer exist, or other configuration errors in the Flow. ZIP package export failures are written to the PowerShell error stream. By default, these errors are non-terminating so batch exports can continue. Use `-ErrorVariable` to capture them, or `-ErrorAction Stop` to handle a failed export with `try`/`catch`.
+
+The cmdlet uses the module's shared HTTP behavior. Throttled requests (HTTP 429) are retried automatically; other failures, such as server errors or timeouts, are reported immediately without a retry. There are no timeout or retry settings specific to this cmdlet.
 
 ## EXAMPLES
 
@@ -61,6 +63,27 @@ Get-PnPPowerPlatformEnvironment | foreach { Get-PnPFlow -Environment $_.Name } |
 ```
 
 This will export all the Microsoft Power Automate Flows available within the tenant from all users from all the available Power Platform environments as a ZIP package for each of them to a local folder c:\flows
+
+### Example 4
+```powershell
+$exportErrors = @()
+Export-PnPFlow -Environment "myenvironment" -Identity fba63225-baf9-4d76-86a1-1b42c917a182 -OutPath "c:\flows\flow.zip" -AsZipPackage -ErrorAction Continue -ErrorVariable +exportErrors
+$exportErrors | Out-File "c:\flows\export-errors.log"
+```
+
+This attempts to export the Flow and captures any export failure in the `$exportErrors` variable for logging.
+
+### Example 5
+```powershell
+try {
+    Export-PnPFlow -Environment "myenvironment" -Identity fba63225-baf9-4d76-86a1-1b42c917a182 -OutPath "c:\flows\flow.zip" -AsZipPackage -ErrorAction Stop
+}
+catch {
+    Write-Host "Flow export failed: $($_.Exception.Message)"
+}
+```
+
+This turns an export failure into a terminating error so it can be handled with `try`/`catch`.
 
 ## PARAMETERS
 
@@ -110,21 +133,6 @@ Accept pipeline input: True
 Accept wildcard characters: False
 ```
 
-### -Identity
-The value of the Name property of a Microsoft Power Automate Flow that you wish to export
-
-```yaml
-Type: PowerAutomateFlowPipeBind
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Force
 If specified and the file exported already exists it will be overwritten without confirmation.
 
@@ -140,8 +148,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Identity
+The value of the Name property of a Microsoft Power Automate Flow that you wish to export
+
+```yaml
+Type: PowerAutomateFlowPipeBind
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -OutPath
-Optional file name of the file to export to. If not provided, it will store the ZIP package to the current location from where the cmdlet is being run.
+Optional file name of the file to export to. If not provided, it will store the ZIP package to the current location from where the cmdlet is being run, using the filename returned by the service. Either way, when a file with that name already exists you are asked to confirm the overwrite unless `-Force` is specified.
 
 ```yaml
 Type: String

--- a/documentation/Export-PnPPowerApp.md
+++ b/documentation/Export-PnPPowerApp.md
@@ -30,7 +30,9 @@ Export-PnPPowerApp [-Environment <PowerPlatformEnvironmentPipeBind>] -Identity <
 ## DESCRIPTION
 This cmdlet exports a Microsoft Power App as zip package.
 
-Many times exporting a Microsoft Power App will not be possible due to various reasons such as connections having gone stale, SharePoint sites referenced no longer existing or other configuration errors in the App. To display these errors when trying to export a App, provide the -Verbose flag with your export request. If not provided, these errors will silently be ignored.
+Export failures are written to the PowerShell error stream. By default, these errors are non-terminating so batch exports can continue. Use `-ErrorVariable` to capture them, or `-ErrorAction Stop` to handle a failed export with `try`/`catch`.
+
+Exporting a Power App is an asynchronous operation. The cmdlet waits for the service to finish preparing the package for up to 30 minutes, following the polling interval requested by the service where it provides one.
 
 ## EXAMPLES
 
@@ -87,21 +89,6 @@ Accept pipeline input: True
 Accept wildcard characters: False
 ```
 
-### -Identity
-The value of the Name property of a Microsoft Power App that you wish to export
-
-```yaml
-Type: PowerAppPipeBind
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Force
 If specified and the file exported already exists it will be overwritten without confirmation.
 
@@ -117,8 +104,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Identity
+The value of the Name property of a Microsoft Power App that you wish to export
+
+```yaml
+Type: PowerAppPipeBind
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -OutPath
-Optional file name of the file to export to. If not provided, it will store the ZIP package to the current location from where the cmdlet is being run.
+Optional file name of the file to export to. If not provided, it will store the ZIP package to the current location from where the cmdlet is being run, using the filename returned by the service. Either way, when a file with that name already exists you are asked to confirm the overwrite unless `-Force` is specified.
 
 ```yaml
 Type: String

--- a/documentation/Import-PnPFlow.md
+++ b/documentation/Import-PnPFlow.md
@@ -29,7 +29,7 @@ Import-PnPFlow [-Environment <PowerAutomateEnvironmentPipeBind>] [-PackagePath <
 ## DESCRIPTION
 This cmdlet imports a Microsoft Power Automate Flow from a ZIP package. At present, only flows originating from the same tenant are supported.
 
-Many times Importing a Microsoft Power Automate Flow will not be possible due to various reasons such as connections having gone stale, SharePoint sites referenced no longer existing or other configuration errors in the Flow. To display these errors when trying to Import a Flow, provide the -Verbose flag with your Import request. If not provided, these errors will silently be ignored.
+Importing a Flow might fail due to stale connections, SharePoint sites that no longer exist, or other configuration errors in the Flow. A failed import raises a terminating error describing the cause, so the cmdlet no longer completes silently. Use `-Verbose` to display progress details while the package is processed.
 
 ## EXAMPLES
 
@@ -59,7 +59,7 @@ This will Import a flow to the default environment. The flow will be imported as
 Import-PnPFlow -PackagePath C:\Temp\Export-ReEnableFlow_20250414140636.zip -Name NewFlowName -Verbose
 ```
 
-This will Import a flow to the default environment. The flow will be imported as a zip package. The name of the flow will be set to NewFlowName. With the -Verbose flag, any errors that occur during the import process will be displayed in the console.
+This will Import a flow to the default environment. The flow will be imported as a zip package. The name of the flow will be set to NewFlowName. The `-Verbose` flag displays progress details during the import.
 
 ### Example 5
 ```powershell
@@ -86,6 +86,21 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Delay
+Delay in milliseconds between attempts to poll for the import parameters. Accepts a value between 500 and 300000. If omitted, the cmdlet uses its default delay policy which is 5000ms.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Environment
 The name of the Power Platform environment or an Environment instance. If omitted, the default environment will be used.
 
@@ -98,21 +113,6 @@ Required: False
 Position: Named
 Default value: The default environment
 Accept pipeline input: True
-Accept wildcard characters: False
-```
-
-### -PackagePath
-Local path of the .zip package to import. The path must be a valid path on the local file system.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: true
-Position: Named
-Default value: None
-Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -131,23 +131,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -RetryCount
-Number of times to poll for import operations to become available. If omitted, the cmdlet uses its default retry policy which is 10.
+### -PackagePath
+Local path of the .zip package to import. The path must be a valid path on the local file system.
 
 ```yaml
-Type: Int32
+Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: true
 Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Delay
-Delay in milliseconds between polling attempts. If omitted, the cmdlet uses its default delay policy which is 5000ms.
+### -RetryCount
+Number of times to poll for the import parameters to become available. Accepts a value between 1 and 100. If omitted, the cmdlet uses its default retry policy which is 10.
 
 ```yaml
 Type: Int32

--- a/src/Commands/PowerPlatform/PowerApps/ExportPowerApp.cs
+++ b/src/Commands/PowerPlatform/PowerApps/ExportPowerApp.cs
@@ -105,7 +105,6 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerApps
             };
             var responseLocation = PowerAppsUtility.GetResponseLocation(Connection.HttpClient, environmentName, powerAppsServiceAccessToken, appName, wrapper, objectDetails, Connection.AzureEnvironment);
             var packageLink = PowerAppsUtility.GetPackageLink(Connection.HttpClient, Convert.ToString(responseLocation), powerAppsServiceAccessToken);
-            var fileBytes = Utilities.REST.RestHelper.GetByteArray(Connection.HttpClient, packageLink, null, "application/zip");
 
             string fileName;
             if (ParameterSpecified(nameof(OutPath)))
@@ -130,6 +129,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerApps
                 }
             }
 
+            var fileBytes = Utilities.REST.RestHelper.GetByteArray(Connection.HttpClient, packageLink, null, "application/zip");
             System.IO.File.WriteAllBytes(fileName, fileBytes);
             var returnObject = new PSObject();
             returnObject.Properties.Add(new PSNoteProperty("Filename", fileName));

--- a/src/Commands/PowerPlatform/PowerApps/ExportPowerApp.cs
+++ b/src/Commands/PowerPlatform/PowerApps/ExportPowerApp.cs
@@ -3,6 +3,7 @@ using PnP.PowerShell.Commands.Base;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 using PnP.PowerShell.Commands.Utilities;
 using System;
+using System.Linq;
 using System.Management.Automation;
 
 namespace PnP.PowerShell.Commands.PowerPlatform.PowerApps
@@ -11,6 +12,8 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerApps
     [RequiredApiApplicationPermissions("https://management.azure.com/user_impersonation", "https://service.powerapps.com/user")]
     public class ExportPowerApp : PnPAzureManagementApiCmdlet
     {
+        private const string ExportPowerAppFailedErrorId = "ExportPnPPowerAppFailed";
+
         [Parameter(Mandatory = false)]
         public PowerPlatformEnvironmentPipeBind Environment;
 
@@ -59,59 +62,84 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerApps
 
             var environmentName = ParameterSpecified(nameof(Environment)) ? Environment.GetName() : PowerPlatformUtility.GetDefaultEnvironment(ArmRequestHelper, Connection.AzureEnvironment)?.Name;
             var appName = Identity.GetName();
-            var powerAppsServiceAccessToken = PowerAppsServiceAccessToken;
+            PowerPlatformExportUtility.RunExport(() => ExportPackage(environmentName, appName), details => WriteExportError(appName, details));
+        }
 
+        private void ExportPackage(string environmentName, string appName)
+        {
+            var powerAppsServiceAccessToken = PowerAppsServiceAccessToken;
             var wrapper = PowerAppsUtility.GetWrapper(Connection.HttpClient, environmentName, powerAppsServiceAccessToken, appName, Connection.AzureEnvironment);
 
-            if (wrapper.Status == Model.PowerPlatform.PowerApp.Enums.PowerAppExportStatus.Succeeded)
+            if (wrapper == null)
             {
-                foreach (var resource in wrapper.Resources)
-                {
-                    if (resource.Value.Type == "Microsoft.PowerApps/apps")
-                    {
-                        resource.Value.SuggestedCreationType = "Update";
-                    }
-                }
-                var objectDetails = new
-                {
-                    displayName = PackageDisplayName,
-                    description = PackageDescription,
-                    creator = PackageCreatedBy,
-                    sourceEnvironment = PackageSourceEnvironment
-                };
-                var responseLocation = PowerAppsUtility.GetResponseLocation(Connection.HttpClient, environmentName, powerAppsServiceAccessToken, appName, wrapper, objectDetails, Connection.AzureEnvironment);
+                WriteExportError(appName, "The service returned an unexpected response when listing the package resources.");
+                return;
+            }
 
+            if (wrapper.Status != Model.PowerPlatform.PowerApp.Enums.PowerAppExportStatus.Succeeded)
+            {
+                WriteExportError(appName, PowerPlatformExportUtility.DescribeFailure(wrapper.Errors?.Where(error => error != null).Select(error => (error.Code, error.Message)), wrapper.StatusRaw));
+                return;
+            }
 
-                var packageLink = PowerAppsUtility.GetPackageLink(Connection.HttpClient, Convert.ToString(responseLocation), powerAppsServiceAccessToken);
-                var getFileByteArray = PowerAppsUtility.GetFileByteArray(Connection.HttpClient, packageLink, powerAppsServiceAccessToken);
-                var fileName = string.Empty;
-                if (ParameterSpecified(nameof(OutPath)))
-                {
-                    if (!System.IO.Path.IsPathRooted(OutPath))
-                    {
-                        OutPath = System.IO.Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, OutPath);
-                    }
-                    fileName = OutPath;
-                }
-                else
-                {
-                    fileName = new System.Text.RegularExpressions.Regex("([^\\/]+\\.zip)").Match(packageLink).Value;
-                    fileName = System.IO.Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, fileName);
-                }
+            if (wrapper.Resources == null || wrapper.Resources.Count == 0 || wrapper.Resources.Any(resource => resource.Value == null))
+            {
+                WriteExportError(appName, "The service returned a successful status without valid package resources.");
+                return;
+            }
 
-                System.IO.File.WriteAllBytes(fileName, getFileByteArray);
-                var returnObject = new PSObject();
-                returnObject.Properties.Add(new PSNoteProperty("Filename", fileName));
-                WriteObject(returnObject);
+            foreach (var resource in wrapper.Resources)
+            {
+                if (resource.Value.Type == "Microsoft.PowerApps/apps")
+                {
+                    resource.Value.SuggestedCreationType = "Update";
+                }
+            }
+
+            var objectDetails = new
+            {
+                displayName = PackageDisplayName,
+                description = PackageDescription,
+                creator = PackageCreatedBy,
+                sourceEnvironment = PackageSourceEnvironment
+            };
+            var responseLocation = PowerAppsUtility.GetResponseLocation(Connection.HttpClient, environmentName, powerAppsServiceAccessToken, appName, wrapper, objectDetails, Connection.AzureEnvironment);
+            var packageLink = PowerAppsUtility.GetPackageLink(Connection.HttpClient, Convert.ToString(responseLocation), powerAppsServiceAccessToken);
+            var fileBytes = Utilities.REST.RestHelper.GetByteArray(Connection.HttpClient, packageLink, null, "application/zip");
+
+            string fileName;
+            if (ParameterSpecified(nameof(OutPath)))
+            {
+                fileName = OutPath;
             }
             else
             {
-                // Errors have been reported in the export request result
-                foreach (var error in wrapper.Errors)
+                fileName = PowerPlatformExportUtility.GetFileNameFromPackageLink(packageLink);
+                if (string.IsNullOrWhiteSpace(fileName))
                 {
-                    LogDebug($"Export failed for {appName} with error {error.Code}: {error.Message}");
+                    WriteExportError(appName, "The package link did not contain a ZIP filename. Specify -OutPath to provide a filename.");
+                    return;
+                }
+                fileName = System.IO.Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, fileName);
+
+                // The filename is only known once the service returned the package link, so unlike with OutPath the
+                // confirmation to overwrite an existing file can only be asked for here
+                if (System.IO.File.Exists(fileName) && !Force && !ShouldContinue($"File '{fileName}' exists. Overwrite?", Properties.Resources.Confirm))
+                {
+                    return;
                 }
             }
+
+            System.IO.File.WriteAllBytes(fileName, fileBytes);
+            var returnObject = new PSObject();
+            returnObject.Properties.Add(new PSNoteProperty("Filename", fileName));
+            WriteObject(returnObject);
+        }
+
+        private void WriteExportError(string appName, string details)
+        {
+            var message = $"Export failed for Power App '{appName}': {details}";
+            WriteError(new ErrorRecord(new PSInvalidOperationException(message), ExportPowerAppFailedErrorId, ErrorCategory.InvalidOperation, appName));
         }
 
     }

--- a/src/Commands/PowerPlatform/PowerAutomate/ExportFlow.cs
+++ b/src/Commands/PowerPlatform/PowerAutomate/ExportFlow.cs
@@ -1,12 +1,12 @@
-﻿using PnP.PowerShell.Commands.Base;
+using PnP.PowerShell.Commands.Attributes;
+using PnP.PowerShell.Commands.Base;
 using PnP.PowerShell.Commands.Base.PipeBinds;
 using PnP.PowerShell.Commands.Utilities;
 using PnP.PowerShell.Commands.Utilities.REST;
 using System;
+using System.Linq;
 using System.Management.Automation;
-using System.Net.Http;
 using System.Text.Json;
-using PnP.PowerShell.Commands.Attributes;
 
 namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
 {
@@ -16,6 +16,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
     {
         private const string ParameterSet_ASJSON = "As Json";
         private const string ParameterSet_ASPACKAGE = "As ZIP Package";
+        private const string ExportFlowFailedErrorId = "ExportPnPFlowFailed";
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_ASPACKAGE)]
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_ASJSON)]
@@ -62,7 +63,6 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
                 {
                     if (!Force && !ShouldContinue($"File '{OutPath}' exists. Overwrite?", Properties.Resources.Confirm))
                     {
-                        // Exit cmdlet
                         return;
                     }
                 }
@@ -73,96 +73,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
 
             if (AsZipPackage)
             {
-                var powerAppsServiceAccessToken = PowerAppsServiceAccessToken;
-                var postData = new
-                {
-                    baseResourceIds = new[] {
-                    $"/providers/Microsoft.Flow/flows/{flowName}"
-                }
-                };
-                string baseUrl = PowerPlatformUtility.GetBapEndpoint(Connection.AzureEnvironment);
-                var wrapper = RestHelper.Post<Model.PowerPlatform.PowerAutomate.FlowExportPackageWrapper>(Connection.HttpClient, $"{baseUrl}/providers/Microsoft.BusinessAppPlatform/environments/{environmentName}/listPackageResources?api-version=2016-11-01", powerAppsServiceAccessToken, payload: postData);
-
-                if (wrapper.Status == Model.PowerPlatform.PowerAutomate.Enums.FlowExportStatus.Succeeded)
-                {
-                    foreach (var resource in wrapper.Resources)
-                    {
-                        if (resource.Value.Type == "Microsoft.Flow/flows")
-                        {
-                            resource.Value.SuggestedCreationType = "Update";
-                        }
-                        else
-                        {
-                            resource.Value.SuggestedCreationType = "Existing";
-                        }
-                    }
-                    dynamic details = new System.Dynamic.ExpandoObject();
-
-                    var exportPostData = new
-                    {
-                        includedResourceIds = new[]
-                        {
-                             $"/providers/Microsoft.Flow/flows/{flowName}"
-                        },
-                        details = new
-                        {
-                            displayName = PackageDisplayName,
-                            description = PackageDescription,
-                            creator = PackageCreatedBy,
-                            sourceEnvironment = PackageSourceEnvironment
-                        },
-                        resources = wrapper.Resources
-                    };
-
-                    var resultElement = RestHelper.Post<JsonElement>(Connection.HttpClient, $"{baseUrl}/providers/Microsoft.BusinessAppPlatform/environments/{environmentName}/exportPackage?api-version=2016-11-01", powerAppsServiceAccessToken, payload: exportPostData);
-                    if (resultElement.TryGetProperty("status", out JsonElement statusElement))
-                    {
-                        if (statusElement.GetString() == "Succeeded")
-                        {
-                            if (resultElement.TryGetProperty("packageLink", out JsonElement packageLinkElement))
-                            {
-                                if (packageLinkElement.TryGetProperty("value", out JsonElement valueElement))
-                                {
-                                    var packageLink = valueElement.GetString();
-                                    using (var requestMessage = new HttpRequestMessage(HttpMethod.Get, packageLink))
-                                    {
-                                        requestMessage.Version = new Version(2, 0);
-                                        //requestMessage.Headers.Add("Authorization", $"Bearer {AccessToken}");
-                                        var response = Connection.HttpClient.SendAsync(requestMessage).GetAwaiter().GetResult();
-                                        var byteArray = response.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult();
-                                        var fileName = string.Empty;
-                                        if (ParameterSpecified(nameof(OutPath)))
-                                        {
-                                            if (!System.IO.Path.IsPathRooted(OutPath))
-                                            {
-                                                OutPath = System.IO.Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, OutPath);
-                                            }
-                                            fileName = OutPath;
-                                        }
-                                        else
-                                        {
-                                            fileName = new System.Text.RegularExpressions.Regex("([^\\/]+\\.zip)").Match(packageLink).Value;
-                                            fileName = System.IO.Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, fileName);
-                                        }
-
-                                        System.IO.File.WriteAllBytes(fileName, byteArray);
-                                        var returnObject = new PSObject();
-                                        returnObject.Properties.Add(new PSNoteProperty("Filename", fileName));
-                                        WriteObject(returnObject);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    // Errors have been reported in the export request result
-                    foreach (var error in wrapper.Errors)
-                    {
-                        LogDebug($"Export failed for {flowName} with error {error.Code}: {error.Message}");
-                    }
-                }
+                PowerPlatformExportUtility.RunExport(() => ExportAsZipPackage(environmentName, flowName), details => WriteExportError(flowName, details));
             }
             else
             {
@@ -170,6 +81,133 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
                 var json = RestHelper.Post(Connection.HttpClient, $"{baseUrl}/providers/Microsoft.ProcessSimple/environments/{environmentName}/flows/{flowName}/exportToARMTemplate?api-version=2016-11-01", AccessToken);
                 WriteObject(json);
             }
+        }
+
+        private void ExportAsZipPackage(string environmentName, string flowName)
+        {
+            var powerAppsServiceAccessToken = PowerAppsServiceAccessToken;
+            var postData = new
+            {
+                baseResourceIds = new[] {
+                    $"/providers/Microsoft.Flow/flows/{flowName}"
+                }
+            };
+            string baseUrl = PowerPlatformUtility.GetBapEndpoint(Connection.AzureEnvironment);
+            var wrapper = RestHelper.Post<Model.PowerPlatform.PowerAutomate.FlowExportPackageWrapper>(Connection.HttpClient, $"{baseUrl}/providers/Microsoft.BusinessAppPlatform/environments/{environmentName}/listPackageResources?api-version=2016-11-01", powerAppsServiceAccessToken, payload: postData);
+
+            if (wrapper == null)
+            {
+                WriteExportError(flowName, "The service returned an unexpected response when listing the package resources.");
+                return;
+            }
+
+            if (wrapper.Status != Model.PowerPlatform.PowerAutomate.Enums.FlowExportStatus.Succeeded)
+            {
+                WriteExportError(flowName, PowerPlatformExportUtility.DescribeFailure(wrapper.Errors?.Where(error => error != null).Select(error => (error.Code, error.Message)), wrapper.StatusRaw));
+                return;
+            }
+
+            if (wrapper.Resources == null || wrapper.Resources.Count == 0)
+            {
+                WriteExportError(flowName, "The service returned a successful status without any package resources.");
+                return;
+            }
+
+            if (wrapper.Resources.Any(resource => resource.Value == null))
+            {
+                WriteExportError(flowName, "The service returned a package resource without its details.");
+                return;
+            }
+
+            foreach (var resource in wrapper.Resources)
+            {
+                if (resource.Value.Type == "Microsoft.Flow/flows")
+                {
+                    resource.Value.SuggestedCreationType = "Update";
+                }
+                else
+                {
+                    resource.Value.SuggestedCreationType = "Existing";
+                }
+            }
+
+            var exportPostData = new
+            {
+                includedResourceIds = new[]
+                {
+                    $"/providers/Microsoft.Flow/flows/{flowName}"
+                },
+                details = new
+                {
+                    displayName = PackageDisplayName,
+                    description = PackageDescription,
+                    creator = PackageCreatedBy,
+                    sourceEnvironment = PackageSourceEnvironment
+                },
+                resources = wrapper.Resources
+            };
+
+            var resultElement = RestHelper.Post<JsonElement>(Connection.HttpClient, $"{baseUrl}/providers/Microsoft.BusinessAppPlatform/environments/{environmentName}/exportPackage?api-version=2016-11-01", powerAppsServiceAccessToken, payload: exportPostData);
+            if (resultElement.ValueKind != JsonValueKind.Object)
+            {
+                WriteExportError(flowName, "The service returned an unexpected response when creating the export package.");
+                return;
+            }
+
+            var exportStatus = PowerPlatformExportUtility.GetStringProperty(resultElement, "status");
+            if (!string.Equals(exportStatus, "Succeeded", StringComparison.OrdinalIgnoreCase))
+            {
+                WriteExportError(flowName, PowerPlatformExportUtility.DescribeFailure(resultElement, exportStatus));
+                return;
+            }
+
+            if (!resultElement.TryGetProperty("packageLink", out JsonElement packageLinkElement) || packageLinkElement.ValueKind != JsonValueKind.Object)
+            {
+                WriteExportError(flowName, "The service returned a successful status without a package link.");
+                return;
+            }
+
+            var packageLink = PowerPlatformExportUtility.GetStringProperty(packageLinkElement, "value");
+            if (string.IsNullOrWhiteSpace(packageLink))
+            {
+                WriteExportError(flowName, "The service returned a successful status with an empty package link.");
+                return;
+            }
+
+            var byteArray = RestHelper.GetByteArray(Connection.HttpClient, packageLink, null, "application/zip");
+            string fileName;
+            if (ParameterSpecified(nameof(OutPath)))
+            {
+                fileName = OutPath;
+            }
+            else
+            {
+                fileName = PowerPlatformExportUtility.GetFileNameFromPackageLink(packageLink);
+                if (string.IsNullOrWhiteSpace(fileName))
+                {
+                    WriteExportError(flowName, "The package link did not contain a ZIP filename. Specify -OutPath to provide a filename.");
+                    return;
+                }
+                fileName = System.IO.Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, fileName);
+
+                // The filename is only known once the service returned the package link, so unlike with OutPath the
+                // confirmation to overwrite an existing file can only be asked for here
+                if (System.IO.File.Exists(fileName) && !Force && !ShouldContinue($"File '{fileName}' exists. Overwrite?", Properties.Resources.Confirm))
+                {
+                    return;
+                }
+            }
+
+            System.IO.File.WriteAllBytes(fileName, byteArray);
+            var returnObject = new PSObject();
+            returnObject.Properties.Add(new PSNoteProperty("Filename", fileName));
+            WriteObject(returnObject);
+        }
+
+        private void WriteExportError(string flowName, string details)
+        {
+            var message = $"Export failed for flow '{flowName}': {details}";
+            WriteError(new ErrorRecord(new PSInvalidOperationException(message), ExportFlowFailedErrorId, ErrorCategory.InvalidOperation, flowName));
         }
     }
 }

--- a/src/Commands/PowerPlatform/PowerAutomate/ExportFlow.cs
+++ b/src/Commands/PowerPlatform/PowerAutomate/ExportFlow.cs
@@ -174,7 +174,6 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
                 return;
             }
 
-            var byteArray = RestHelper.GetByteArray(Connection.HttpClient, packageLink, null, "application/zip");
             string fileName;
             if (ParameterSpecified(nameof(OutPath)))
             {
@@ -198,6 +197,7 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
                 }
             }
 
+            var byteArray = RestHelper.GetByteArray(Connection.HttpClient, packageLink, null, "application/zip");
             System.IO.File.WriteAllBytes(fileName, byteArray);
             var returnObject = new PSObject();
             returnObject.Properties.Add(new PSNoteProperty("Filename", fileName));

--- a/src/Commands/PowerPlatform/PowerAutomate/ImportFlow.cs
+++ b/src/Commands/PowerPlatform/PowerAutomate/ImportFlow.cs
@@ -27,16 +27,20 @@ namespace PnP.PowerShell.Commands.PowerPlatform.PowerAutomate
         public string Name;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_ALL)]
+        [ValidateRange(1, 100)]
         public int RetryCount;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_ALL)]
+        [ValidateRange(500, 300000)]
         public int Delay;
 
         protected override void ExecuteCmdlet()
         {
             var environmentName = GetEnvironmentName();
             string baseUrl = PowerPlatformUtility.GetBapEndpoint(Connection.AzureEnvironment);
-            var importStatus = ImportFlowUtility.ExecuteImportFlow(Connection.HttpClient, PowerAppsServiceAccessToken, baseUrl, environmentName, PackagePath, Name, RetryCount, Delay);
+            int? retryCount = ParameterSpecified(nameof(RetryCount)) ? RetryCount : null;
+            int? delay = ParameterSpecified(nameof(Delay)) ? Delay : null;
+            var importStatus = ImportFlowUtility.ExecuteImportFlow(Connection.HttpClient, PowerAppsServiceAccessToken, baseUrl, environmentName, PackagePath, Name, retryCount, delay);
             WriteObject(importStatus);
         }
 

--- a/src/Commands/UserProfiles/GetUserProfilePhoto.cs
+++ b/src/Commands/UserProfiles/GetUserProfilePhoto.cs
@@ -87,13 +87,11 @@ namespace PnP.PowerShell.Commands.UserProfiles
             }
             if (getphoto)
             {
-                var response = GraphRequestHelper.GetResponse($"users/{user.Id}/photo/$value");
-                if (response.IsSuccessStatusCode)
-                {
-                    var content = response.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult();
-                    System.IO.File.WriteAllBytes(Filename, content);
-                    WriteObject($"File saved as: {Filename}");
-                }
+                // A non successful response will throw from within GetResponse
+                using var response = GraphRequestHelper.GetResponse($"users/{user.Id}/photo/$value");
+                var content = response.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult();
+                System.IO.File.WriteAllBytes(Filename, content);
+                WriteObject($"File saved as: {Filename}");
             }
         }
 

--- a/src/Commands/Utilities/ImportFlowUtility.cs
+++ b/src/Commands/Utilities/ImportFlowUtility.cs
@@ -127,7 +127,10 @@ namespace PnP.PowerShell.Commands.Utilities
 
                 retryCount++;
                 Log.Debug("ImportFlowUtility", $"Import operations not ready yet. Retry {retryCount}/{resolvedMaxRetries}...");
-                Thread.Sleep(resolvedDelayMs);
+                if (retryCount < resolvedMaxRetries)
+                {
+                    Thread.Sleep(resolvedDelayMs);
+                }
             }
 
             Log.Debug("ImportFlowUtility", "Import operations did not become available within the allowed number of retries");

--- a/src/Commands/Utilities/ImportFlowUtility.cs
+++ b/src/Commands/Utilities/ImportFlowUtility.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Text.Json.Nodes;
 using PnP.PowerShell.Commands.Model.PowerPlatform.PowerAutomate;
 using System.Threading;
+using System.Management.Automation;
 
 namespace PnP.PowerShell.Commands.Utilities
 {
@@ -68,7 +69,7 @@ namespace PnP.PowerShell.Commands.Utilities
                 if (!uploadResponse.IsSuccessStatusCode)
                 {
                     var errorContent = uploadResponse.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-                    throw new Exception($"Upload failed: {uploadResponse.StatusCode} - {errorContent}");
+                    throw new PSInvalidOperationException($"Upload failed: {uploadResponse.StatusCode} - {errorContent}");
                 }
             }
         }
@@ -99,7 +100,6 @@ namespace PnP.PowerShell.Commands.Utilities
             int resolvedMaxRetries = maxRetries ?? DefaultImportOperationsMaxRetries;
             int resolvedDelayMs = delayMs ?? DefaultImportOperationsDelayMs;
             int retryCount = 0;
-            JsonElement importOperationsData = default;
 
             while (retryCount < resolvedMaxRetries)
             {
@@ -109,7 +109,7 @@ namespace PnP.PowerShell.Commands.Utilities
                     accessToken,
                     accept: "application/json"
                 );
-                importOperationsData = JsonSerializer.Deserialize<JsonElement>(listImportOperations);
+                var importOperationsData = JsonSerializer.Deserialize<JsonElement>(listImportOperations);
 
                 if (importOperationsData.TryGetProperty("properties", out JsonElement propertiesElement))
                 {
@@ -130,15 +130,15 @@ namespace PnP.PowerShell.Commands.Utilities
                 Thread.Sleep(resolvedDelayMs);
             }
 
-            Log.Debug("ImportFlowUtility", "Import operations retrieved (max retries reached)");
-            return importOperationsData;
+            Log.Debug("ImportFlowUtility", "Import operations did not become available within the allowed number of retries");
+            throw new PSInvalidOperationException($"Import failed: the import parameters were not available after {resolvedMaxRetries} attempts. Increase -RetryCount or -Delay and try again.");
         }
 
         public static JsonElement GetPropertiesElement(JsonElement importOperationsData)
         {
             if (!importOperationsData.TryGetProperty("properties", out JsonElement propertiesElement))
             {
-                throw new Exception("Import failed: 'properties' section missing.");
+                throw new PSInvalidOperationException("Import failed: 'properties' section missing.");
             }
             return propertiesElement;
         }
@@ -152,11 +152,11 @@ namespace PnP.PowerShell.Commands.Utilities
 
             if (!(hasStatus && hasPackageLink && hasDetails && hasResources))
             {
-                throw new Exception("Import failed: One or more required fields are missing in 'properties'. The API may still be processing the request.");
+                throw new PSInvalidOperationException("Import failed: One or more required fields are missing in 'properties'. The API may still be processing the request.");
             }
             if (!propertiesElement.TryGetProperty("resources", out JsonElement resourcesElement))
             {
-                throw new Exception("Import failed: 'resources' section missing in 'properties'.");
+                throw new PSInvalidOperationException("Import failed: 'resources' section missing in 'properties'.");
             }
         }
 
@@ -164,7 +164,7 @@ namespace PnP.PowerShell.Commands.Utilities
         {
             if (!propertiesElement.TryGetProperty("resources", out JsonElement resourcesElement))
             {
-                throw new Exception("Import failed: 'resources' section missing in 'properties'.");
+                throw new PSInvalidOperationException("Import failed: 'resources' section missing in 'properties'.");
             }
             return JsonNode.Parse(resourcesElement.GetRawText()) as JsonObject;
         }
@@ -257,7 +257,7 @@ namespace PnP.PowerShell.Commands.Utilities
                 else
                 {
                     Log.Warning("ImportFlowUtility", "Failed to retrieve the status from the response.");
-                    throw new Exception("Import status could not be determined.");
+                    throw new PSInvalidOperationException("Import status could not be determined.");
                 }
 
                 if (status == "Running")
@@ -274,7 +274,7 @@ namespace PnP.PowerShell.Commands.Utilities
 
             if (status == "Running")
             {
-                throw new Exception("Import failed to complete after 5 attempts.");
+                throw new PSInvalidOperationException("Import failed to complete after 5 attempts.");
             }
             return MapToImportFlowResult(importResultDataElement);
         }
@@ -295,13 +295,13 @@ namespace PnP.PowerShell.Commands.Utilities
                                 ? codeElement.GetString()
                                 : "Unknown error";
 
-                        throw new Exception($"Import failed: {errorMessage}");
+                        throw new PSInvalidOperationException($"Import failed: {errorMessage}");
                     }
                 }
-                throw new Exception("Import failed: No error details found in resources.");
+                throw new PSInvalidOperationException("Import failed: No error details found in resources.");
             }
 
-            throw new Exception("Import failed: Unknown error.");
+            throw new PSInvalidOperationException("Import failed: Unknown error.");
         }
 
 

--- a/src/Commands/Utilities/PlannerUtility.cs
+++ b/src/Commands/Utilities/PlannerUtility.cs
@@ -3,6 +3,7 @@ using PnP.PowerShell.Commands.Model.Planner;
 using PnP.PowerShell.Commands.Utilities.REST;
 using System.Collections.Generic;
 using System.Linq;
+using System.Management.Automation;
 using System.Net.Http;
 using System.Text.Json;
 
@@ -10,6 +11,11 @@ namespace PnP.PowerShell.Commands.Utilities
 {
     internal static class PlannerUtility
     {
+        /// <summary>
+        /// Number of times updating a plan is retried when it keeps being modified by someone else while the update is in flight
+        /// </summary>
+        private const int MaxPlanUpdateAttempts = 5;
+
         #region Plans
         public static IEnumerable<PlannerPlan> GetPlans(ApiRequestHelper requestHelper, string groupId, bool resolveDisplayNames)
         {
@@ -62,21 +68,45 @@ namespace PnP.PowerShell.Commands.Utilities
 
         public static PlannerPlan UpdatePlan(ApiRequestHelper requestHelper, PlannerPlan plan, string title)
         {
-            var stringContent = new StringContent(JsonSerializer.Serialize(new { title }));
-            stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-            var responseMessage = requestHelper.Patch(stringContent, $"v1.0/planner/plans/{plan.Id}", new Dictionary<string, string>() { { "IF-MATCH", plan.ETag } });
-            while (responseMessage.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+            var planId = plan.Id;
+
+            // An outdated ETag makes Microsoft Graph respond with an HTTP 412. Retrieve the plan again to pick up its
+            // current ETag and retry. PatchWithoutValidation is used so the 412 can be handled here rather than thrown.
+            for (var attempt = 0; attempt < MaxPlanUpdateAttempts; attempt++)
             {
-                // retrieve the plan again
-                plan = requestHelper.Get<PlannerPlan>($"v1.0/planner/plans/{plan.Id}");
-                responseMessage = requestHelper.Patch(stringContent, $"v1.0/planner/plans/{plan.Id}", new Dictionary<string, string>() { { "IF-MATCH", plan.ETag } });
+                // The request content is consumed by the send, so it has to be recreated for every attempt
+                var stringContent = new StringContent(JsonSerializer.Serialize(new { title }));
+                stringContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+
+                using var responseMessage = requestHelper.PatchWithoutValidation(stringContent, $"v1.0/planner/plans/{planId}", new Dictionary<string, string>() { { "IF-MATCH", plan.ETag } });
+                if (responseMessage.IsSuccessStatusCode)
+                {
+                    var responseContent = responseMessage.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                    return JsonSerializer.Deserialize<PlannerPlan>(responseContent);
+                }
+
+                if (responseMessage.StatusCode != System.Net.HttpStatusCode.PreconditionFailed)
+                {
+                    throw new PSInvalidOperationException(DescribePlanUpdateFailure(requestHelper, responseMessage, planId));
+                }
+
+                plan = requestHelper.Get<PlannerPlan>($"v1.0/planner/plans/{planId}");
+                if (plan == null)
+                {
+                    throw new PSInvalidOperationException($"Failed to update Planner plan '{planId}' because it could no longer be retrieved to resolve a concurrent modification.");
+                }
             }
-            if (responseMessage.IsSuccessStatusCode)
+
+            throw new PSInvalidOperationException($"Failed to update Planner plan '{planId}' after {MaxPlanUpdateAttempts} attempts because it kept being modified by someone else.");
+        }
+
+        private static string DescribePlanUpdateFailure(ApiRequestHelper requestHelper, HttpResponseMessage responseMessage, string planId)
+        {
+            if (requestHelper.TryGetGraphException(responseMessage, out GraphException ex) && !string.IsNullOrWhiteSpace(ex.Error?.Message))
             {
-                var responseContent = responseMessage.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-                return JsonSerializer.Deserialize<PlannerPlan>(responseContent);
+                return $"Failed to update Planner plan '{planId}': {ex.Error.Message}";
             }
-            return null;
+            return $"Failed to update Planner plan '{planId}'. Microsoft Graph returned HTTP {(int)responseMessage.StatusCode} {responseMessage.StatusCode}.";
         }
 
         public static void DeletePlan(ApiRequestHelper requestHelper, string planId)

--- a/src/Commands/Utilities/PlannerUtility.cs
+++ b/src/Commands/Utilities/PlannerUtility.cs
@@ -81,8 +81,7 @@ namespace PnP.PowerShell.Commands.Utilities
                 using var responseMessage = requestHelper.PatchWithoutValidation(stringContent, $"v1.0/planner/plans/{planId}", new Dictionary<string, string>() { { "IF-MATCH", plan.ETag } });
                 if (responseMessage.IsSuccessStatusCode)
                 {
-                    var responseContent = responseMessage.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-                    return JsonSerializer.Deserialize<PlannerPlan>(responseContent);
+                    return requestHelper.Get<PlannerPlan>($"v1.0/planner/plans/{planId}");
                 }
 
                 if (responseMessage.StatusCode != System.Net.HttpStatusCode.PreconditionFailed)

--- a/src/Commands/Utilities/PlannerUtility.cs
+++ b/src/Commands/Utilities/PlannerUtility.cs
@@ -81,7 +81,13 @@ namespace PnP.PowerShell.Commands.Utilities
                 using var responseMessage = requestHelper.PatchWithoutValidation(stringContent, $"v1.0/planner/plans/{planId}", new Dictionary<string, string>() { { "IF-MATCH", plan.ETag } });
                 if (responseMessage.IsSuccessStatusCode)
                 {
-                    return requestHelper.Get<PlannerPlan>($"v1.0/planner/plans/{planId}");
+                    // Microsoft Graph answers a successful plan update with an HTTP 204 without a body, so the updated plan has to be read back separately
+                    var updatedPlan = requestHelper.Get<PlannerPlan>($"v1.0/planner/plans/{planId}");
+                    if (updatedPlan == null)
+                    {
+                        throw new PSInvalidOperationException($"Planner plan '{planId}' was updated but the updated plan could not be retrieved.");
+                    }
+                    return updatedPlan;
                 }
 
                 if (responseMessage.StatusCode != System.Net.HttpStatusCode.PreconditionFailed)

--- a/src/Commands/Utilities/PowerAppsUtility.cs
+++ b/src/Commands/Utilities/PowerAppsUtility.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
+using System.Management.Automation;
 using PnP.Framework;
 using PnP.PowerShell.Commands.Utilities.REST;
 
@@ -9,6 +10,21 @@ namespace PnP.PowerShell.Commands.Utilities
 {
     internal static class PowerAppsUtility
     {
+        /// <summary>
+        /// How long to keep waiting for an export to complete. Exporting a large Power App takes a while, so this is generous.
+        /// </summary>
+        private static readonly TimeSpan ExportStatusMaxWaitTime = TimeSpan.FromMinutes(30);
+
+        /// <summary>
+        /// How long to wait between two export status checks when the service does not ask for a specific delay through a Retry-After header
+        /// </summary>
+        private static readonly TimeSpan ExportStatusPollingDelay = TimeSpan.FromSeconds(3);
+
+        /// <summary>
+        /// Upper bound on the delay taken from a Retry-After header, so one unexpected value cannot stall the export
+        /// </summary>
+        private static readonly TimeSpan ExportStatusMaxPollingDelay = TimeSpan.FromSeconds(60);
+
         internal static Model.PowerPlatform.PowerApp.PowerAppPackageWrapper GetWrapper(HttpClient connection, string environmentName, string accessToken, string appName, AzureEnvironment azureEnvironment = AzureEnvironment.Production)
         {
             var postData = new
@@ -45,52 +61,57 @@ namespace PnP.PowerShell.Commands.Utilities
 
         internal static string GetPackageLink(HttpClient connection, string location, string accessToken)
         {
-            var status = Model.PowerPlatform.PowerApp.Enums.PowerAppExportStatus.Running;
-            var packageLink = "";
-            if (location != null)
+            if (string.IsNullOrWhiteSpace(location))
             {
-                do
+                throw new PSInvalidOperationException("The Power App export response did not include a status location.");
+            }
+
+            var deadline = DateTimeOffset.UtcNow.Add(ExportStatusMaxWaitTime);
+            while (true)
+            {
+                var runningResponse = RestHelper.Get<JsonElement>(connection, location, accessToken, out TimeSpan? retryAfter);
+                if (runningResponse.ValueKind != JsonValueKind.Object ||
+                    !runningResponse.TryGetProperty("properties", out JsonElement properties) ||
+                    !properties.TryGetProperty("status", out JsonElement statusElement) ||
+                    statusElement.ValueKind != JsonValueKind.String)
                 {
-                    var runningresponse = RestHelper.Get<JsonElement>(connection, location, accessToken);
+                    throw new PSInvalidOperationException("The Power App export status response was incomplete.");
+                }
 
-                    if (runningresponse.TryGetProperty("properties", out JsonElement properties))
+                var status = statusElement.GetString();
+                if (string.Equals(status, Model.PowerPlatform.PowerApp.Enums.PowerAppExportStatus.Succeeded.ToString(), StringComparison.OrdinalIgnoreCase))
+                {
+                    if (properties.TryGetProperty("packageLink", out JsonElement packageLinkElement) &&
+                        packageLinkElement.ValueKind == JsonValueKind.Object &&
+                        packageLinkElement.TryGetProperty("value", out JsonElement valueElement) &&
+                        valueElement.ValueKind == JsonValueKind.String &&
+                        !string.IsNullOrWhiteSpace(valueElement.GetString()))
                     {
-                        if (properties.TryGetProperty("status", out JsonElement runningstatusElement))
-                        {
-                            if (runningstatusElement.GetString() == Model.PowerPlatform.PowerApp.Enums.PowerAppExportStatus.Succeeded.ToString())
-                            {
-                                status = Model.PowerPlatform.PowerApp.Enums.PowerAppExportStatus.Succeeded;
-                                if (properties.TryGetProperty("packageLink", out JsonElement packageLinkElement))
-                                {
-                                    if (packageLinkElement.TryGetProperty("value", out JsonElement valueElement))
-                                    {
-                                        packageLink = valueElement.GetString();
-                                    }
-                                }
-                            }
-                            else
-                            {
-                                //if status is still running, sleep the thread for 3 seconds
-                                Thread.Sleep(3000);
-                            }
-                        }
+                        return valueElement.GetString();
                     }
-                } while (status == Model.PowerPlatform.PowerApp.Enums.PowerAppExportStatus.Running);
-            }
-            return packageLink;
-        }
 
-        internal static byte[] GetFileByteArray(HttpClient connection, string packageLink, string accessToken)
-        {
-            using (var requestMessage = new HttpRequestMessage(HttpMethod.Get, packageLink))
-            {
-                requestMessage.Version = new Version(2, 0);
-                //requestMessage.Headers.Add("Authorization", $"Bearer {AccessToken}");
-                var fileresponse = connection.SendAsync(requestMessage).GetAwaiter().GetResult();
-                var byteArray = fileresponse.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult();
-                return byteArray;
-            }
+                    throw new PSInvalidOperationException("The Power App export completed without a package link.");
+                }
 
+                if (!string.Equals(status, Model.PowerPlatform.PowerApp.Enums.PowerAppExportStatus.Running.ToString(), StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new PSInvalidOperationException($"The Power App export returned status '{status ?? "unknown"}'.");
+                }
+
+                // Follow the delay the service asks for, but never wait longer than the upper bound for a single check
+                var delay = retryAfter ?? ExportStatusPollingDelay;
+                if (delay > ExportStatusMaxPollingDelay)
+                {
+                    delay = ExportStatusMaxPollingDelay;
+                }
+
+                if (DateTimeOffset.UtcNow.Add(delay) >= deadline)
+                {
+                    throw new PSInvalidOperationException($"The Power App export did not complete within {ExportStatusMaxWaitTime.TotalMinutes:0} minutes.");
+                }
+
+                Thread.Sleep(delay);
+            }
         }
     }
 }

--- a/src/Commands/Utilities/PowerPlatformExportUtility.cs
+++ b/src/Commands/Utilities/PowerPlatformExportUtility.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace PnP.PowerShell.Commands.Utilities
+{
+    /// <summary>
+    /// Shared logic for the Power Platform export cmdlets to run an export and to describe why the service refused it
+    /// </summary>
+    internal static class PowerPlatformExportUtility
+    {
+        /// <summary>
+        /// Runs the provided export and turns the failures that are to be expected during an export into a message handed to
+        /// <paramref name="writeError"/>, so a batch export can continue with the next item. Any other exception is left to bubble up.
+        /// </summary>
+        /// <param name="export">The export to run</param>
+        /// <param name="writeError">Called with the description of the failure when the export did not succeed</param>
+        internal static void RunExport(Action export, Action<string> writeError)
+        {
+            try
+            {
+                export();
+            }
+            catch (HttpRequestException ex)
+            {
+                writeError(ex.Message);
+            }
+            catch (TaskCanceledException ex)
+            {
+                writeError($"The request timed out. {ex.Message}");
+            }
+            catch (UriFormatException ex)
+            {
+                writeError($"The service returned an invalid package link. {ex.Message}");
+            }
+            catch (System.IO.IOException ex)
+            {
+                writeError($"The package file could not be written. {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                writeError($"The package file could not be written. {ex.Message}");
+            }
+            catch (PSInvalidOperationException ex)
+            {
+                writeError(ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Describes why an export failed based on the errors reported by the service, falling back to the status when the
+        /// service did not report any error details
+        /// </summary>
+        /// <param name="errors">The error codes and messages reported by the service</param>
+        /// <param name="status">The status reported by the service</param>
+        internal static string DescribeFailure(IEnumerable<(string Code, string Message)> errors, string status)
+        {
+            var details = errors?
+                .Where(error => !string.IsNullOrWhiteSpace(error.Code) || !string.IsNullOrWhiteSpace(error.Message))
+                .Select(error => FormatError(error.Code, error.Message))
+                .ToArray();
+
+            if (details?.Length > 0)
+            {
+                return string.Join("; ", details);
+            }
+
+            return $"The service returned status '{(string.IsNullOrWhiteSpace(status) ? "unknown" : status)}' without error details.";
+        }
+
+        /// <summary>
+        /// Describes why an export failed based on the errors in a raw service response
+        /// </summary>
+        /// <param name="response">The response returned by the service</param>
+        /// <param name="status">The status reported by the service</param>
+        internal static string DescribeFailure(JsonElement response, string status)
+        {
+            var errors = new List<(string Code, string Message)>();
+            if (response.ValueKind == JsonValueKind.Object && response.TryGetProperty("errors", out JsonElement errorsElement) && errorsElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var errorElement in errorsElement.EnumerateArray())
+                {
+                    if (errorElement.ValueKind != JsonValueKind.Object)
+                    {
+                        continue;
+                    }
+
+                    errors.Add((GetStringProperty(errorElement, "code"), GetStringProperty(errorElement, "message")));
+                }
+            }
+
+            return DescribeFailure(errors, status);
+        }
+
+        /// <summary>
+        /// Returns the name of the ZIP file contained in the package link returned by the service, or an empty string when it does not contain one
+        /// </summary>
+        /// <param name="packageLink">The package link returned by the service</param>
+        internal static string GetFileNameFromPackageLink(string packageLink)
+        {
+            return new System.Text.RegularExpressions.Regex("([^\\/]+\\.zip)").Match(packageLink ?? string.Empty).Value;
+        }
+
+        /// <summary>
+        /// Returns the value of the requested property when it is present and holds a string, otherwise null
+        /// </summary>
+        /// <param name="element">The element to read the property from</param>
+        /// <param name="propertyName">Name of the property to read</param>
+        internal static string GetStringProperty(JsonElement element, string propertyName)
+        {
+            return element.TryGetProperty(propertyName, out JsonElement property) && property.ValueKind == JsonValueKind.String
+                ? property.GetString()
+                : null;
+        }
+
+        private static string FormatError(string code, string message)
+        {
+            if (string.IsNullOrWhiteSpace(code))
+            {
+                return message;
+            }
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                return code;
+            }
+            return $"{code}: {message}";
+        }
+    }
+}

--- a/src/Commands/Utilities/REST/ApiRequestHelper.cs
+++ b/src/Commands/Utilities/REST/ApiRequestHelper.cs
@@ -380,6 +380,16 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             return GetResponseMessage(message);
         }
 
+        /// <summary>
+        /// Sends a PATCH request and returns the response without throwing on a failed status code. Use when the caller
+        /// needs to handle a specific failure itself, such as retrying an HTTP 412 caused by a stale ETag.
+        /// </summary>
+        public HttpResponseMessage PatchWithoutValidation(HttpContent content, string url, IDictionary<string, string> additionalHeaders = null)
+        {
+            var message = GetMessage(url, HttpMethod.Patch, content, additionalHeaders);
+            return GetResponseMessageWithoutValidation(message);
+        }
+
         #endregion
 
         #region POST
@@ -539,7 +549,12 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             }
         }
 
-        public HttpResponseMessage GetResponseMessage(HttpRequestMessage message)
+        /// <summary>
+        /// Sends the request, retrying while the service reports throttling, and returns the response as it came back from the service.
+        /// Use this when the caller needs to act on a specific failure status code, such as an HTTP 412 caused by a stale ETag.
+        /// Use <see cref="GetResponseMessage"/> instead when any failure should surface as an exception.
+        /// </summary>
+        public HttpResponseMessage GetResponseMessageWithoutValidation(HttpRequestMessage message)
         {
             LogDebug($"Making {message.Method} call to {message.RequestUri}");
 
@@ -556,22 +571,24 @@ namespace PnP.PowerShell.Commands.Utilities.REST
                 response = Connection.HttpClient.SendAsync(CloneMessage(message)).GetAwaiter().GetResult();
             }
 
+            return response;
+        }
+
+        public HttpResponseMessage GetResponseMessage(HttpRequestMessage message)
+        {
+            var response = GetResponseMessageWithoutValidation(message);
+
             // Validate if the response was successful, if not throw an exception
             if (!response.IsSuccessStatusCode)
             {
                 LogDebug($"Response failed with HTTP {(int)response.StatusCode} {response.StatusCode}");
 
-                if (TryGetGraphException(response, out GraphException ex))
+                if (TryGetGraphException(response, out GraphException ex) && ex.Error != null)
                 {
-                    if (ex.Error != null)
-                    {
-                        throw new PSInvalidOperationException($"Call to Microsoft Graph URL {message.RequestUri} failed with status code {response.StatusCode}{(!string.IsNullOrEmpty(ex.Error.Message) ? $": {ex.Error.Message}" : "")}");
-                    }
+                    throw new PSInvalidOperationException($"Call to Microsoft Graph URL {message.RequestUri} failed with status code {response.StatusCode}{(!string.IsNullOrEmpty(ex.Error.Message) ? $": {ex.Error.Message}" : "")}");
                 }
-                else
-                {
-                    throw new PSInvalidOperationException($"Call to Microsoft Graph URL {message.RequestUri} failed with status code {response.StatusCode}");
-                }
+
+                throw new PSInvalidOperationException($"Call to Microsoft Graph URL {message.RequestUri} failed with status code {response.StatusCode}");
             }
             else
             {

--- a/src/Commands/Utilities/REST/RestHelper.cs
+++ b/src/Commands/Utilities/REST/RestHelper.cs
@@ -166,6 +166,34 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             return default(T);
         }
 
+        /// <summary>
+        /// Executes a GET request and reports the delay the service asked to wait for through its Retry-After response header.
+        /// Use when polling a long running operation so the polling interval can follow what the service asks for.
+        /// </summary>
+        /// <param name="retryAfter">The delay requested by the service, or null when it did not request one</param>
+        public static T Get<T>(HttpClient httpClient, string url, string accessToken, out TimeSpan? retryAfter, bool camlCasePolicy = true)
+        {
+            var message = GetMessage(url, HttpMethod.Get, accessToken);
+            var stringContent = SendMessage(httpClient, message, out retryAfter);
+            if (stringContent != null)
+            {
+                var options = new JsonSerializerOptions() { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+                if (camlCasePolicy)
+                {
+                    options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+                }
+                try
+                {
+                    return JsonSerializer.Deserialize<T>(stringContent, options);
+                }
+                catch (Exception)
+                {
+                    return default(T);
+                }
+            }
+            return default(T);
+        }
+
         public static T Get<T>(HttpClient httpClient, string url, ClientContext clientContext, bool camlCasePolicy = true)
         {
             var stringContent = Get(httpClient, url, clientContext);
@@ -604,8 +632,14 @@ namespace PnP.PowerShell.Commands.Utilities.REST
 
         private static string SendMessage(HttpClient httpClient, HttpRequestMessage message)
         {
+            return SendMessage(httpClient, message, out _);
+        }
+
+        private static string SendMessage(HttpClient httpClient, HttpRequestMessage message, out TimeSpan? retryAfter)
+        {
             HttpResponseMessage response = null;
             var retryAttempt = 0;
+            retryAfter = null;
             try
             {
                 response = httpClient.SendAsync(message).GetAwaiter().GetResult();
@@ -621,6 +655,7 @@ namespace PnP.PowerShell.Commands.Utilities.REST
                 }
                 if (response.IsSuccessStatusCode)
                 {
+                    retryAfter = GetRetryAfterDelay(response);
                     return response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
                 }
                 else
@@ -704,7 +739,10 @@ namespace PnP.PowerShell.Commands.Utilities.REST
             }
         }
 
-        private static TimeSpan GetRetryDelay(HttpResponseMessage response, int retryAttempt)
+        /// <summary>
+        /// Returns the delay the service asked to wait for through its Retry-After response header, or null when it did not ask for one
+        /// </summary>
+        private static TimeSpan? GetRetryAfterDelay(HttpResponseMessage response)
         {
             var retryAfter = response.Headers.RetryAfter;
             if (retryAfter?.Delta is TimeSpan delta && delta > TimeSpan.Zero)
@@ -719,6 +757,16 @@ namespace PnP.PowerShell.Commands.Utilities.REST
                 {
                     return dateDelay;
                 }
+            }
+
+            return null;
+        }
+
+        private static TimeSpan GetRetryDelay(HttpResponseMessage response, int retryAttempt)
+        {
+            if (GetRetryAfterDelay(response) is TimeSpan retryAfterDelay)
+            {
+                return retryAfterDelay;
             }
 
             var fallbackSeconds = Math.Min(Math.Pow(2, retryAttempt - 1), 30);


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [x] New Feature
- [ ] Sample

## Related Issues? ##
Addresses the error-handling portion of #1340. The timeout and retry-option requests remain open.

## What is in this Pull Request ? ##
Refactors Power Platform export and import cmdlets to improve error reporting, response validation, polling, and file handling. Also surfaces previously silent Microsoft Graph failures in related cmdlets.
