### PR TITLE
Fix apostrophes in user profile REST calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Fixed
+- Using UPNs with an apostrophe in it not working with `Remove-PnPUserProfile`, `Export-PnPUserProfile`, `Export-PnPUserInfo`, and `Remove-PnPUserInfo`. The apostrophe is now escaped in the API request. [#5459](https://github.com/pnp/powershell/pull/5459)
 
 ## [3.4.1]
 
@@ -24,6 +25,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Contributors
 
 - Gautam Sheth [gautamdsheth]
+- [till-llit]
 
 ## [3.4.0]
 

--- a/src/Commands/Principals/ExportUserInfo.cs
+++ b/src/Commands/Principals/ExportUserInfo.cs
@@ -32,7 +32,7 @@ namespace PnP.PowerShell.Commands.Principals
             var site = Tenant.GetSiteByUrl(siteUrl);
             AdminContext.Load(site);
             AdminContext.ExecuteQueryRetry();
-            var normalizedUserName = UrlUtilities.UrlEncode($"i:0#.f|membership|{LoginName}");
+            var normalizedUserName = UrlUtilities.UrlEncode($"i:0#.f|membership|{LoginName}".Replace("'", "''"));
             var results = RestHelper.Get<RestResultCollection<ExportEntity>>(Connection.HttpClient, $"{hostUrl}/_api/sp.userprofiles.peoplemanager/GetSPUserInformation(accountName=@a,siteId=@b)?@a='{normalizedUserName}'&@b='{site.Id}'", AdminContext, false);
             var record = new PSObject();
             foreach (var item in results.Items)

--- a/src/Commands/Principals/RemoveUserInfo.cs
+++ b/src/Commands/Principals/RemoveUserInfo.cs
@@ -35,7 +35,7 @@ namespace PnP.PowerShell.Commands.Principals
             var site = Tenant.GetSiteByUrl(siteUrl);
             AdminContext.Load(site);
             AdminContext.ExecuteQueryRetry();
-            var normalizedUserName = UrlUtilities.UrlEncode($"i:0#.f|membership|{LoginName}");
+            var normalizedUserName = UrlUtilities.UrlEncode($"i:0#.f|membership|{LoginName}".Replace("'", "''"));
             RestResultCollection<ExportEntity> results = null;
             if (!ParameterSpecified(nameof(RedactName)))
             {
@@ -43,7 +43,8 @@ namespace PnP.PowerShell.Commands.Principals
             }
             else
             {
-                results = RestHelper.Post<RestResultCollection<ExportEntity>>(HttpClient, $"{hostUrl}/_api/sp.userprofiles.peoplemanager/RemoveSPUserInformation(accountName=@a,siteId=@b,redactName=@c)?@a='{normalizedUserName}'&@b='{site.Id}'&@c='{RedactName}'", this.AccessToken, false);
+                var redactName = UrlUtilities.UrlEncode(RedactName.Replace("'", "''"));
+                results = RestHelper.Post<RestResultCollection<ExportEntity>>(HttpClient, $"{hostUrl}/_api/sp.userprofiles.peoplemanager/RemoveSPUserInformation(accountName=@a,siteId=@b,redactName=@c)?@a='{normalizedUserName}'&@b='{site.Id}'&@c='{redactName}'", this.AccessToken, false);
             }
             var record = new PSObject();
             foreach (var item in results.Items)

--- a/src/Commands/UserProfiles/ExportUserProfile.cs
+++ b/src/Commands/UserProfiles/ExportUserProfile.cs
@@ -20,7 +20,7 @@ namespace PnP.PowerShell.Commands.UserProfiles
             {
                 hostUrl = hostUrl.Substring(0, hostUrl.Length - 1);
             }
-            var normalizedUserName = UrlUtilities.UrlEncode($"i:0#.f|membership|{LoginName}");
+            var normalizedUserName = UrlUtilities.UrlEncode($"i:0#.f|membership|{LoginName}".Replace("'", "''"));
             var results = RestHelper.Get<RestResultCollection<ExportEntity>>(Connection.HttpClient, $"{hostUrl}/_api/sp.userprofiles.peoplemanager/GetUserProfileProperties(accountName=@a)?@a='{normalizedUserName}'", AdminContext, false);
             var record = new PSObject();
             foreach (var item in results.Items)

--- a/src/Commands/UserProfiles/RemoveUserProfile.cs
+++ b/src/Commands/UserProfiles/RemoveUserProfile.cs
@@ -22,7 +22,7 @@ namespace PnP.PowerShell.Commands.UserProfiles
             {
                 hostUrl = hostUrl.Substring(0, hostUrl.Length - 1);
             }
-            var normalizedUserName = UrlUtilities.UrlEncode($"i:0#.f|membership|{LoginName}");
+            var normalizedUserName = UrlUtilities.UrlEncode($"i:0#.f|membership|{LoginName}".Replace("'", "''"));
 
             if (!ParameterSpecified(nameof(UserId)))
             {


### PR DESCRIPTION

## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
Fixes #5458 

## What is in this Pull Request ? ##

Fixes SharePoint REST/OData requests for UPNs containing apostrophes.
Doubles apostrophes before URL encoding, as required by OData string literals.
Applies to:

- ExportUserProfile.cs
- ExportUserInfo.cs
- RemoveUserProfile.cs
- RemoveUserInfo.cs

Also safely encodes RedactName in Remove-PnPUserInfo.
This resolves errors such as The query string "accountName" is missing or invalid. for users like alex.o'connor@example.com.



