### PR TITLE
Url requirement removed on Connect-PnPOnline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
+- Changed `Connect-PnPOnline` to allow authentication-only connections without `-Url` for non-SharePoint cmdlets. Omitting `-Url` no longer creates a SharePoint `ClientContext` or `PnPContext`.
 
 ### Fixed
 

--- a/MIGRATE-3.0-to-4.0.md
+++ b/MIGRATE-3.0-to-4.0.md
@@ -42,6 +42,7 @@ Recommend reading these 2 links:
 |  `Get-PnPPowerShellTelemetryEnabled` | All PnP Telemetry has been removed |
 | `Enable-PnPPowerShellTelemetry` | All PnP Telemetry has been removed |
 | `Disable-PnPPowerShellTelemetry` | All PnP Telemetry has been removed |
+| `Connect-PnPOnline` | `-Url` is no longer mandatory for most authentication methods. Omitting it creates an authentication-only connection without a SharePoint `ClientContext` or `PnPContext`. SharePoint cmdlets, `Get-PnPContext`, `-CreateDrive`, `-ValidateConnection`, `-TransformationOnPrem`, `-CurrentCredentials` and SharePoint ACS app-only connections still require a SharePoint URL. Scripts that assume every connection has `Connection.Url`, `Connection.Context` or `Connection.PnPContext` must check for `$null` or pass `-Url`. |
 
 ## Other notable changes
 

--- a/documentation/Connect-PnPOnline.md
+++ b/documentation/Connect-PnPOnline.md
@@ -10,19 +10,19 @@ title: Connect-PnPOnline
 # Connect-PnPOnline
 
 ## SYNOPSIS
-Connect to a SharePoint site
+Connect and authenticate to PnP PowerShell
 
 ## SYNTAX
 
 ### Interactive for Multi Factor Authentication (Default)
 ```powershell
-Connect-PnPOnline -Interactive [-ReturnConnection] -Url <String> [-PersistLogin] [-CreateDrive] [-DriveName <String>]
+Connect-PnPOnline -Interactive [-ReturnConnection] [-Url <String>] [-PersistLogin] [-CreateDrive] [-DriveName <String>]
  [-ClientId <String>] [-AzureEnvironment <AzureEnvironment>] [-TenantAdminUrl <String>] [-ForceAuthentication] [-ValidateConnection] [-MicrosoftGraphEndPoint <string>] [-AzureADLoginEndPoint <string>] [-Connection <PnPConnection>]
 ```
 
 ### Credentials
 ```powershell
-Connect-PnPOnline [-ReturnConnection] [-Url] <String> [-Credentials <CredentialPipeBind>] [-CurrentCredentials] [-PersistLogin]
+Connect-PnPOnline [-ReturnConnection] [-Url <String>] [-Credentials <CredentialPipeBind>] [-CurrentCredentials] [-PersistLogin]
  [-CreateDrive] [-DriveName <String>] [-ClientId <String>] [-RedirectUri <String>]
  [-AzureEnvironment <AzureEnvironment>] [-TenantAdminUrl <String>]
  [-TransformationOnPrem] [-ValidateConnection] [-MicrosoftGraphEndPoint <string>]
@@ -39,7 +39,7 @@ Connect-PnPOnline [-ReturnConnection] [-Url] <String> [-Realm <String>] -ClientS
 
 ### App-Only with Azure Active Directory
 ```powershell
-Connect-PnPOnline [-ReturnConnection] [-Url] <String> [-CreateDrive] [-DriveName <String>] -ClientId <String>
+Connect-PnPOnline [-ReturnConnection] [-Url <String>] [-CreateDrive] [-DriveName <String>] -ClientId <String>
  -Tenant <String> [-CertificatePath <String>] [-CertificateBase64Encoded <String>]
  [-CertificatePassword <SecureString>] [-AzureEnvironment <AzureEnvironment>] [-TenantAdminUrl <String>]
  [-ValidateConnection] [-MicrosoftGraphEndPoint <string>]
@@ -48,7 +48,7 @@ Connect-PnPOnline [-ReturnConnection] [-Url] <String> [-CreateDrive] [-DriveName
 
 ### App-Only with Azure Active Directory using a certificate from the Windows Certificate Management Store by thumbprint
 ```powershell
-Connect-PnPOnline [-ReturnConnection] [-Url] <String> [-CreateDrive] [-DriveName <String>] -ClientId <String>
+Connect-PnPOnline [-ReturnConnection] [-Url <String>] [-CreateDrive] [-DriveName <String>] -ClientId <String>
  -Tenant <String> -Thumbprint <String> [-AzureEnvironment <AzureEnvironment>] [-TenantAdminUrl <String>]
  [-ValidateConnection] [-MicrosoftGraphEndPoint <string>]
  [-AzureADLoginEndPoint <string>] [-Connection <PnPConnection>]
@@ -56,7 +56,7 @@ Connect-PnPOnline [-ReturnConnection] [-Url] <String> [-CreateDrive] [-DriveName
 
 ### DeviceLogin
 ```powershell
-Connect-PnPOnline [-ReturnConnection] [-Url] <String> [-PersistLogin] [-CreateDrive] [-DriveName <String>] -DeviceLogin -Tenant <String>
+Connect-PnPOnline [-ReturnConnection] [-Url <String>] [-PersistLogin] [-CreateDrive] [-DriveName <String>] -DeviceLogin -Tenant <String>
  [-ClientId <String>] [-AzureEnvironment <AzureEnvironment>] 
  [-ValidateConnection] [-MicrosoftGraphEndPoint <string>]
  [-AzureADLoginEndPoint <string>] [-Connection <PnPConnection>]
@@ -69,7 +69,7 @@ Connect-PnPOnline -Url <String> -TransformationOnPrem [-CurrentCredential]
 
 ### Access Token
 ```
-Connect-PnPOnline -Url <String> -AccessToken <String> [-AzureEnvironment <AzureEnvironment>] [-MicrosoftGraphEndPoint <string>] [-AzureADLoginEndPoint <string>] [-ReturnConnection]
+Connect-PnPOnline [-Url <String>] -AccessToken <String> [-AzureEnvironment <AzureEnvironment>] [-MicrosoftGraphEndPoint <string>] [-AzureADLoginEndPoint <string>] [-ReturnConnection]
 ```
 
 ### System Assigned Managed Identity
@@ -94,7 +94,7 @@ Connect-PnPOnline [-Url <String>] -ManagedIdentity -UserAssignedManagedIdentityA
 
 ### Environment Variable
 ```powershell
-Connect-PnPOnline [-ReturnConnection] [-Url] <String> [-EnvironmentVariable] [-CurrentCredentials]
+Connect-PnPOnline [-ReturnConnection] [-Url <String>] [-EnvironmentVariable] [-CurrentCredentials]
  [-CreateDrive] [-DriveName <String>] [-RedirectUri <String>]
  [-AzureEnvironment <AzureEnvironment>] [-TenantAdminUrl <String>]
  [-TransformationOnPrem] [-ValidateConnection] [-MicrosoftGraphEndPoint <string>] [-AzureADLoginEndPoint <string>] [-Connection <PnPConnection>]
@@ -102,13 +102,13 @@ Connect-PnPOnline [-ReturnConnection] [-Url] <String> [-EnvironmentVariable] [-C
 
 ### Azure AD Workload Identity
 ```powershell
-Connect-PnPOnline [-ReturnConnection] [-ValidateConnection] [-Url] <String>
+Connect-PnPOnline [-ReturnConnection] [-ValidateConnection] [-Url <String>]
  [-AzureADWorkloadIdentity] [-Connection <PnPConnection>]
 ```
 
 ### OS login
 ```powershell
-Connect-PnPOnline -OSLogin [-ReturnConnection] [-Url] <String> [-PersistLogin] [-CreateDrive] [-DriveName <String>] 
+Connect-PnPOnline -OSLogin [-ReturnConnection] [-Url <String>] [-PersistLogin] [-CreateDrive] [-DriveName <String>]
  [-ClientId <String>] [-AzureEnvironment <AzureEnvironment>] [-TenantAdminUrl <String>] [-ForceAuthentication] [-ValidateConnection] [-MicrosoftGraphEndPoint <string>] [-AzureADLoginEndPoint <string>] [-Connection <PnPConnection>]
 ```
 
@@ -118,12 +118,21 @@ Connect-PnPOnline [-Url <String>] [-Tenant <String>] -FederatedIdentity [-AzureE
 ```
 
 ## DESCRIPTION
-Connects to a SharePoint site or another API and creates a context that is required for the other PnP Cmdlets.
+Connects and authenticates to PnP PowerShell. When `-Url` is provided, the connection includes a SharePoint ClientContext and PnPContext for SharePoint cmdlets. When `-Url` is omitted, the connection is authentication-only and can be used by Graph, Azure Resource Manager, Planner, Graph Connector Service and other non-SharePoint cmdlets that do not require a SharePoint context.
+
+A SharePoint URL is still required for SharePoint cmdlets, `-CreateDrive`, `-ValidateConnection`, `-TransformationOnPrem`, `-CurrentCredentials` and SharePoint ACS app-only connections.
 See https://pnp.github.io/powershell/articles/connecting.html for more information on the options to connect.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
+```powershell
+Connect-PnPOnline -Interactive -ClientId 6c5c98c7-e05a-4a0f-bcfa-0cfc65aa1f28
+```
+
+Authenticate without creating a SharePoint context. This connection can be used with cmdlets that only need Microsoft Graph or another non-SharePoint API.
+
+### EXAMPLE 2
 ```powershell
 Connect-PnPOnline -Url "https://contoso.sharepoint.com"
 ```
@@ -131,21 +140,21 @@ Connect-PnPOnline -Url "https://contoso.sharepoint.com"
 Connect to SharePoint prompting for the username and password.
 When a generic credential is added to the Windows Credential Manager with https://contoso.sharepoint.com, PowerShell will not prompt for username and password and use those stored credentials instead. You will have to register your own App first, by means of `Register-PnPEntraIDApp` to use this method. You will also have to provide the `-ClientId` parameter starting September 9, 2024. Alternatively, create an environment variable, call it `ENTRAID_APP_ID` or `ENTRAID_CLIENT_ID` and set the value to the app id you created
 
-### EXAMPLE 2
+### EXAMPLE 3
 ```powershell
 Connect-PnPOnline -Url "https://contoso.sharepoint.com" -Credentials (Get-Credential)
 ```
 
 Connect to SharePoint prompting for the username and password to use to authenticate.
 
-### EXAMPLE 3
+### EXAMPLE 4
 ```powershell
 Connect-PnPOnline -Url "https://contoso.sharepoint.de" -ClientId 344b8aab-389c-4e4a-8fa1-4c1ae2c0a60d -ClientSecret $clientSecret
 ```
 
 This will authenticate you to the site using Legacy ACS authentication
 
-### EXAMPLE 4
+### EXAMPLE 5
 ```powershell
 Connect-PnPOnline -Url "https://contoso.sharepoint.com" -DeviceLogin -ClientId 6c5c98c7-e05a-4a0f-bcfa-0cfc65aa1f28
 ```
@@ -153,7 +162,7 @@ Connect-PnPOnline -Url "https://contoso.sharepoint.com" -DeviceLogin -ClientId 6
 This will authenticate you using the specified Entra ID App registration. Alternatively, create an environment variable, call it `ENTRAID_APP_ID` or `ENTRAID_CLIENT_ID` and set the value to the app id you created.
 A browser window will automatically open and the code you need to enter will be automatically copied to your clipboard. 
 
-### EXAMPLE 5
+### EXAMPLE 6
 ```powershell
 $password = (ConvertTo-SecureString -AsPlainText 'myprivatekeypassword' -Force)
 Connect-PnPOnline -Url "https://contoso.sharepoint.com" -ClientId 6c5c98c7-e05a-4a0f-bcfa-0cfc65aa1f28 -CertificatePath 'c:\mycertificate.pfx' -CertificatePassword $password  -Tenant 'contoso.onmicrosoft.com'
@@ -162,7 +171,7 @@ Connect-PnPOnline -Url "https://contoso.sharepoint.com" -ClientId 6c5c98c7-e05a-
 Connects using an Azure Active Directory registered application using a locally available certificate containing a private key.
 See https://learn.microsoft.com/sharepoint/dev/solution-guidance/security-apponly-azuread for a sample on how to get started.
 
-### EXAMPLE 6
+### EXAMPLE 7
 ```powershell
 Connect-PnPOnline -Url "https://contoso.sharepoint.com" -ClientId 6c5c98c7-e05a-4a0f-bcfa-0cfc65aa1f28 -Tenant 'contoso.onmicrosoft.com' -Thumbprint 34CFAA860E5FB8C44335A38A097C1E41EEA206AA
 ```
@@ -171,7 +180,7 @@ Connects to SharePoint using app-only tokens via an app's declared permission sc
 See https://github.com/SharePoint/PnP-PowerShell/tree/master/Samples/SharePoint.ConnectUsingAppPermissions for a sample on how to get started.
 Ensure you have imported the private key certificate, typically the .pfx file, into the Windows Certificate Store for the certificate with the provided thumbprint.
 
-### EXAMPLE 7
+### EXAMPLE 8
 ```powershell
 Connect-PnPOnline -Url "https://contoso.sharepoint.com" -ClientId 6c5c98c7-e05a-4a0f-bcfa-0cfc65aa1f28 -CertificateBase64Encoded $base64encodedstring -Tenant 'contoso.onmicrosoft.com'
 ```
@@ -180,7 +189,7 @@ Connects using an Azure Active Directory registered application using a certific
 See https://learn.microsoft.com/sharepoint/dev/solution-guidance/security-apponly-azuread for a sample on how to get started.
 
 
-### EXAMPLE 8
+### EXAMPLE 9
 ```powershell
 Connect-PnPOnline -Url "https://contoso.sharepoint.com" -Interactive -ClientId 6c5c98c7-e05a-4a0f-bcfa-0cfc65aa1f28
 ```
@@ -188,7 +197,7 @@ Connect-PnPOnline -Url "https://contoso.sharepoint.com" -Interactive -ClientId 6
 Connects to the Azure AD, acquires an access token and allows PnP PowerShell to access both SharePoint and the Microsoft Graph. Notice that you will have to register your own App first, by means of `Register-PnPEntraIDApp` to use this method. You will also have to provide the `-ClientId` parameter starting September 9, 2024. Alternatively, create an environment variable, call it `ENTRAID_APP_ID` or `ENTRAID_CLIENT_ID` and set the value to the app id you created. If you use -Interactive and this environment variable is present you will not have to use -ClientId.
 
 
-### EXAMPLE 9
+### EXAMPLE 10
 ```powershell
 Connect-PnPOnline -Url "https://portal.contoso.com" -TransformationOnPrem -CurrentCredential
 ```
@@ -198,7 +207,7 @@ This option is only supported for being able to transform on-premises classic wi
 Although other PnP cmdlets might work as well, they're officially not supported for being used in an on-premises context.
 See http://aka.ms/sharepoint/modernization/pages for more details on page transformation.
 
-### EXAMPLE 10
+### EXAMPLE 11
 ```powershell
 Connect-PnPOnline -Url "https://contoso.sharepoint.com" -ManagedIdentity
 Get-PnPTeamsTeam
@@ -206,7 +215,7 @@ Get-PnPTeamsTeam
 
 Connects using a system assigned managed identity to Microsoft Graph. Using this way of connecting only works with environments that support managed identities: Azure Functions, Azure Automation Runbooks and the Azure Cloud Shell. Read up on [this article](https://pnp.github.io/powershell/articles/azurefunctions.html#by-using-a-managed-identity) how it can be used.
 
-### EXAMPLE 11
+### EXAMPLE 12
 ```powershell
 Connect-PnPOnline -Url "https://contoso.sharepoint.com" -ManagedIdentity -UserAssignedManagedIdentityObjectId 363c1b31-6872-47fd-a616-574d3aec2a51
 Get-PnPList
@@ -214,7 +223,7 @@ Get-PnPList
 
 Connects using an user assigned managed identity with object/principal ID 363c1b31-6872-47fd-a616-574d3aec2a51 to SharePoint Online. Using this way of connecting only works with environments that support managed identities: Azure Functions, Azure Automation Runbooks and the Azure Cloud Shell. Read up on [this article](https://pnp.github.io/powershell/articles/azurefunctions.html#by-using-a-managed-identity) how it can be used.
 
-### EXAMPLE 12
+### EXAMPLE 13
 ```powershell
 Connect-PnPOnline -Url "https://contoso.sharepoint.com" -AccessToken $token
 ```
@@ -222,7 +231,7 @@ Connect-PnPOnline -Url "https://contoso.sharepoint.com" -AccessToken $token
 This method assumes you have acquired a valid OAuth2 access token from Azure AD with the correct audience and permissions set.
 Using this method PnP PowerShell will not acquire tokens dynamically and if the token expires (typically after 1 hour) cmdlets will fail to work using this method.
 
-### EXAMPLE 13
+### EXAMPLE 14
 ```powershell
 Connect-PnPOnline -Url contoso.sharepoint.com -EnvironmentVariable -Tenant 'contoso.onmicrosoft.com'
 ```
@@ -231,7 +240,7 @@ This example uses the `AZURE_CLIENT_CERTIFICATE_PATH` and `AZURE_CLIENT_CERTIFIC
 
 If these environment variables are not present, it will try to find `ENTRAID_APP_CERTIFICATE_PATH` or `ENTRAID_CLIENT_CERTIFICATE_PATH` and for certificate password use `ENTRAID_APP_CERTIFICATE_PASSWORD` or `ENTRAID_CLIENT_CERTIFICATE_PASSWORD` as fallback.
 
-### EXAMPLE 14
+### EXAMPLE 15
 ```powershell
 Connect-PnPOnline -Url contoso.sharepoint.com -EnvironmentVariable
 ```
@@ -250,21 +259,21 @@ If `ENTRAID_USERNAME`, `ENTRAID_PASSWORD` and `ENTRAID_APP_ID` , we will use the
 
 We support only Service principal with certificate and Username with password mode for authentication. Configuration will be attempted in that order. For example, if values for a certificate and username+password are both present, the client certificate method will be used.
 
-### EXAMPLE 15
+### EXAMPLE 16
 ```
 Connect-PnPOnline -Url contoso.sharepoint.com -AzureEnvironment Custom -MicrosoftGraphEndPoint "custom.graph.microsoft.com" -AzureADLoginEndPoint "https://custom.login.microsoftonline.com"
 ```
 
 Use this method to connect to a custom Azure Environment. You can also specify the `MicrosoftGraphEndPoint` and `AzureADLoginEndPoint` parameters if applicable. If specified, then these values will be used to make requests to Graph and to retrieve access token.
 
-### EXAMPLE 16
+### EXAMPLE 17
 ```powershell
 Connect-PnPOnline -Url contoso.sharepoint.com -AzureADWorkloadIdentity
 ```
 
 This example uses Azure AD Workload Identity to retrieve access tokens. For more information about this, please refer to this article, [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/introduction.html). We are following the guidance mentioned in [this sample](https://github.com/Azure/azure-workload-identity/blob/main/examples/msal-net/akvdotnet/TokenCredential.cs) to retrieve the access tokens.
 
-### EXAMPLE 17
+### EXAMPLE 18
 ```powershell
 Connect-PnPOnline -Url "https://contoso.sharepoint.com" -ClientId 6c5c98c7-e05a-4a0f-bcfa-0cfc65aa1f28 -OSLogin
 ```
@@ -273,7 +282,7 @@ Connects to the Azure AD with WAM (aka native Windows authentication prompt), ac
 
 WAM is a more secure & faster way of authenticating in Windows OS. It supports Windows Hello, FIDO keys , conditional access policies and more.
 
-### EXAMPLE 18
+### EXAMPLE 19
 ```powershell
 $keyStorageflags = [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::MachineKeySet -bor [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet
 
@@ -285,7 +294,7 @@ See [Security App-only EntraId guidance](https://learn.microsoft.com/sharepoint/
 
 See [X509 key storage flags](https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.x509keystorageflags) for information on how to configure key storage when creating the certificate.
 
-### EXAMPLE 19
+### EXAMPLE 20
 ```powershell
 Connect-PnPOnline -Url "https://contoso.sharepoint.com" -Credentials "https://contoso.sharepoint.com"
 ```
@@ -294,21 +303,21 @@ Connect to SharePoint using Credentials (username and password) from Credential 
 
 On Windows, this entry needs to be under "Generic Credentials".
 
-### EXAMPLE 20
+### EXAMPLE 21
 ```powershell
 Connect-PnPOnline -Url "https://contoso.sharepoint.com" -ClientId 6c5c98c7-e05a-4a0f-bcfa-0cfc65aa1f28 -Tenant 'contoso.onmicrosoft.com' -FederatedIdentity
 ```
 > This functionality is only available in the nightly release.
 Connect to SharePoint/Microsoft Graph using federated identity credentials in Github.
 
-### EXAMPLE 21
+### EXAMPLE 22
 ```powershell
 Connect-PnPOnline -Url "https://contoso.sharepoint.com" -FederatedIdentity
 ```
 
 Connect to SharePoint/Microsoft Graph using federated identity credentials in Azure DevOps. This option is available from version 3.1.51-nightly onwards.
 
-### EXAMPLE 22
+### EXAMPLE 23
 ```powershell
 Connect-PnPOnline -Url "https://contoso.sharepoint.com" -ClientId 6c5c98c7-e05a-4a0f-bcfa-0cfc65aa1f28 -Tenant 'contoso.onmicrosoft.com' -FederatedIdentity
 ```
@@ -536,13 +545,13 @@ Accept wildcard characters: False
 ```
 
 ### -PersistLogin
-Persist the current access token and related information in a locally stored cache. This cache will be retained between PowerShell sessions and will also be available after a reboot. You only need to provide this switch one time on Connect-PnPOnline cmdlet, it will after that retain the information and reuse it for new connections to the same tenant. Notice that while using a cached token, if you change the permissions of an application registration, the token associated with that registration will not be updated automatically in the cache. You will have to clear the cache entry first and reauthenticate: use `Disconnect-PnPOnline -ClearPersistedLogin`
+Persist the current access token and related information in a locally stored cache. This cache will be retained between PowerShell sessions and will also be available after a reboot. You only need to provide this switch one time on Connect-PnPOnline cmdlet, it will after that retain the information and reuse it for new connections to the same tenant. When `-Url` is omitted, the persisted login is keyed to the Microsoft Graph endpoint for the selected Azure environment. Notice that while using a cached token, if you change the permissions of an application registration, the token associated with that registration will not be updated automatically in the cache. You will have to clear the cache entry first and reauthenticate: use `Disconnect-PnPOnline -ClearPersistedLogin`
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: Credentials, DeviceLogin, Interactive, OSLogin
 
-Required: True
+Required: False
 Position: Named
 Default value: False
 Accept pipeline input: False
@@ -642,14 +651,14 @@ Accept wildcard characters: False
 ```
 
 ### -Url
-The Url of the site collection or subsite to connect to, i.e. tenant.sharepoint.com, https://tenant.sharepoint.com, tenant.sharepoint.com/sites/hr, etc.
+The URL of the site collection or subsite to connect to, i.e. tenant.sharepoint.com, https://tenant.sharepoint.com, tenant.sharepoint.com/sites/hr, etc. If omitted, Connect-PnPOnline creates an authentication-only connection without a SharePoint ClientContext or PnPContext.
 
 ```yaml
 Type: String
-Parameter Sets: Credentials, SharePoint ACS (Legacy) App Only, App-Only with Azure Active Directory, App-Only with Azure Active Directory using a certificate from the Windows Certificate Management Store by thumbprint, DeviceLogin, Web Login for Multi Factor Authentication, Interactive for Multi Factor Authentication, Access Token, Environment Variable, Azure AD Workload Identity, Federated Identity
+Parameter Sets: Credentials, SharePoint ACS (Legacy) App Only, App-Only with Azure Active Directory, App-Only with Azure Active Directory using a certificate from the Windows Certificate Management Store by thumbprint, DeviceLogin, Interactive for Multi Factor Authentication, Access Token, Environment Variable, Managed Identity, Azure AD Workload Identity, OS login, Federated Identity
 Aliases:
 
-Required: True (Except when using -ManagedIdentity and -AzureADWorkloadIdentity)
+Required: False, except for SharePoint ACS (Legacy) App Only
 Position: 0
 Default value: None
 Accept pipeline input: True (ByValue)
@@ -657,11 +666,11 @@ Accept wildcard characters: False
 ```
 
 ### -ValidateConnection
-When provided, the cmdlet will check to ensure the SharePoint Online site specified through `-Url` exists and if not, will throw an exception. If you omit this flag or set it to $false, it will blindly set up a connection without validating that the site actually exists. Making use of this option does make one extra call on the connection attempt, so it is recommended to only use it in scenarios where you know the site you're trying to connect o may not exist and would like to have feedback on this during the connect.
+When provided, the cmdlet will check to ensure the SharePoint Online site specified through `-Url` exists and if not, will throw an exception. `-ValidateConnection` requires `-Url`. If you omit this flag or set it to $false, it will blindly set up a connection without validating that the site actually exists. Making use of this option does make one extra call on the connection attempt, so it is recommended to only use it in scenarios where you know the site you're trying to connect to may not exist and would like to have feedback on this during the connect.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Credentials, SharePoint ACS (Legacy) App Only, App-Only with Azure Active Directory, App-Only with Azure Active Directory using a certificate from the Windows Certificate Management Store by thumbprint, DeviceLogin, Web Login for Multi Factor Authentication, Interactive for Multi Factor Authentication, Access Token, Environment Variable, Azure AD Workload Identity, Federated Identity
+Parameter Sets: Credentials, SharePoint ACS (Legacy) App Only, App-Only with Azure Active Directory, App-Only with Azure Active Directory using a certificate from the Windows Certificate Management Store by thumbprint, DeviceLogin, Interactive for Multi Factor Authentication, Access Token, Environment Variable, Managed Identity, Azure AD Workload Identity, OS login, Federated Identity
 Aliases:
 
 Required: False
@@ -812,7 +821,7 @@ Custom Microsoft Graph endpoint to be used if we are using Azure Custom environm
 
 ```yaml
 Type: String
-Parameter Sets: Credentials, SharePoint ACS (Legacy) App Only, App-Only with Azure Active Directory, App-Only with Azure Active Directory using a certificate from the Windows Certificate Management Store by thumbprint, DeviceLogin, Interactive, Access Token, Environment Variable, Federated Identity, OS Login
+Parameter Sets: Credentials, SharePoint ACS (Legacy) App Only, App-Only with Azure Active Directory, App-Only with Azure Active Directory using a certificate from the Windows Certificate Management Store by thumbprint, DeviceLogin, Interactive, Access Token, Environment Variable, Managed Identity, Azure AD Workload Identity, Federated Identity, OS Login
 Aliases:
 
 Required: False
@@ -827,7 +836,7 @@ Custom Azure AD login endpoint to be used if we are using Azure Custom environme
 
 ```yaml
 Type: String
-Parameter Sets: Credentials, SharePoint ACS (Legacy) App Only, App-Only with Azure Active Directory, App-Only with Azure Active Directory using a certificate from the Windows Certificate Management Store by thumbprint, DeviceLogin, Interactive, Access Token, Environment Variable, Federated Identity
+Parameter Sets: Credentials, SharePoint ACS (Legacy) App Only, App-Only with Azure Active Directory, App-Only with Azure Active Directory using a certificate from the Windows Certificate Management Store by thumbprint, DeviceLogin, Interactive, Access Token, Environment Variable, Managed Identity, Azure AD Workload Identity, Federated Identity, OS Login
 Aliases:
 
 Required: False

--- a/src/Commands/Base/ConnectOnline.cs
+++ b/src/Commands/Base/ConnectOnline.cs
@@ -73,21 +73,21 @@ namespace PnP.PowerShell.Commands.Base
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_FEDERATEDIDENTITY, ValueFromPipeline = true)]
         public SwitchParameter ValidateConnection;
 
-        [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSet_CREDENTIALS, ValueFromPipeline = true)]
+        [Parameter(Mandatory = false, Position = 0, ParameterSetName = ParameterSet_CREDENTIALS, ValueFromPipeline = true)]
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSet_ACSAPPONLY, ValueFromPipeline = true)]
-        [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSet_APPONLYAADCERTIFICATE, ValueFromPipeline = true)]
-        [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSet_APPONLYAADTHUMBPRINT, ValueFromPipeline = true)]
-        [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSet_ACCESSTOKEN, ValueFromPipeline = true)]
-        [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSet_DEVICELOGIN, ValueFromPipeline = true)]
-        [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSet_INTERACTIVE, ValueFromPipeline = true)]
+        [Parameter(Mandatory = false, Position = 0, ParameterSetName = ParameterSet_APPONLYAADCERTIFICATE, ValueFromPipeline = true)]
+        [Parameter(Mandatory = false, Position = 0, ParameterSetName = ParameterSet_APPONLYAADTHUMBPRINT, ValueFromPipeline = true)]
+        [Parameter(Mandatory = false, Position = 0, ParameterSetName = ParameterSet_ACCESSTOKEN, ValueFromPipeline = true)]
+        [Parameter(Mandatory = false, Position = 0, ParameterSetName = ParameterSet_DEVICELOGIN, ValueFromPipeline = true)]
+        [Parameter(Mandatory = false, Position = 0, ParameterSetName = ParameterSet_INTERACTIVE, ValueFromPipeline = true)]
         [Parameter(Mandatory = false, Position = 0, ParameterSetName = ParameterSet_SYSTEMASSIGNEDMANAGEDIDENTITY, ValueFromPipeline = true)]
         [Parameter(Mandatory = false, Position = 0, ParameterSetName = ParameterSet_USERASSIGNEDMANAGEDIDENTITYBYCLIENTID, ValueFromPipeline = true)]
         [Parameter(Mandatory = false, Position = 0, ParameterSetName = ParameterSet_USERASSIGNEDMANAGEDIDENTITYBYPRINCIPALID, ValueFromPipeline = true)]
         [Parameter(Mandatory = false, Position = 0, ParameterSetName = ParameterSet_USERASSIGNEDMANAGEDIDENTITYBYAZURERESOURCEID, ValueFromPipeline = true)]
-        [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSet_ENVIRONMENTVARIABLE, ValueFromPipeline = true)]
+        [Parameter(Mandatory = false, Position = 0, ParameterSetName = ParameterSet_ENVIRONMENTVARIABLE, ValueFromPipeline = true)]
         [Parameter(Mandatory = false, Position = 0, ParameterSetName = ParameterSet_AZUREAD_WORKLOAD_IDENTITY, ValueFromPipeline = true)]
-        [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSet_OSLOGIN, ValueFromPipeline = true)]
-        [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSet_FEDERATEDIDENTITY, ValueFromPipeline = true)]
+        [Parameter(Mandatory = false, Position = 0, ParameterSetName = ParameterSet_OSLOGIN, ValueFromPipeline = true)]
+        [Parameter(Mandatory = false, Position = 0, ParameterSetName = ParameterSet_FEDERATEDIDENTITY, ValueFromPipeline = true)]
         public string Url;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterSet_CREDENTIALS)]
@@ -332,10 +332,20 @@ namespace PnP.PowerShell.Commands.Base
 
             if (ValidateConnection)
             {
+                if (string.IsNullOrEmpty(Url))
+                {
+                    throw new PSArgumentException("The -ValidateConnection parameter requires -Url because only SharePoint connections can be validated during connect.", nameof(ValidateConnection));
+                }
+
                 if (PingHost(new Uri(Url).Host) == false)
                 {
                     throw new PSArgumentException("Host not reachable");
                 }
+            }
+
+            if (CreateDrive && string.IsNullOrEmpty(Url))
+            {
+                throw new PSArgumentException("The -CreateDrive parameter requires -Url because a SharePoint context is required to create a drive.", nameof(CreateDrive));
             }
 
             if (ParameterSpecified(nameof(Connection)))
@@ -417,7 +427,7 @@ namespace PnP.PowerShell.Commands.Base
                 Environment.SetEnvironmentVariable("PNPPSSITE", "GRAPH");
             }
 
-            if (ValidateConnection)
+            if (ValidateConnection && newConnection.Context != null)
             {
                 // Try requesting the site Id to validate that the site to which is being connected exists
                 newConnection.Context.Load(newConnection.Context.Site, p => p.Id);
@@ -522,10 +532,13 @@ namespace PnP.PowerShell.Commands.Base
             var messageWriter = new CmdletMessageWriter(this);
             PnPConnection connection = null;
             Exception connectionException = null;
-            var uri = new Uri(Url);
-            if ($"https://{uri.Host}".Equals(Url.ToLower()))
+            if (!string.IsNullOrEmpty(Url))
             {
-                Url += "/";
+                var uri = new Uri(Url);
+                if ($"https://{uri.Host}".Equals(Url.ToLower()))
+                {
+                    Url += "/";
+                }
             }
             Task.Factory.StartNew(() =>
             {
@@ -540,7 +553,7 @@ namespace PnP.PowerShell.Commands.Base
                             oldUri = new Uri(Connection.Url);
                         }
                     }
-                    if (oldUri != null && oldUri.Host == new Uri(Url).Host && Connection?.ConnectionMethod == ConnectionMethod.DeviceLogin)
+                    if (oldUri != null && !string.IsNullOrEmpty(Url) && oldUri.Host == new Uri(Url).Host && Connection?.ConnectionMethod == ConnectionMethod.DeviceLogin)
                     {
                         ReuseAuthenticationManager();
                     }
@@ -570,7 +583,7 @@ namespace PnP.PowerShell.Commands.Base
                             messageWriter.LogDebug("Using Managed AppId from secure store");
                         }
                     }
-                    if (string.IsNullOrWhiteSpace(Tenant))
+                    if (string.IsNullOrWhiteSpace(Tenant) && !string.IsNullOrEmpty(Url))
                     {
                         Tenant = TenantExtensions.GetTenantIdByUrl(Url, AzureEnvironment);
                     }
@@ -631,7 +644,7 @@ namespace PnP.PowerShell.Commands.Base
                     ReuseAuthenticationManager();
                 }
 
-                return PnPConnection.CreateWithCert(new Uri(Url), ClientId, Tenant, TenantAdminUrl, AzureEnvironment, certificate, true);
+                return PnPConnection.CreateWithCert(!string.IsNullOrEmpty(Url) ? new Uri(Url) : null, ClientId, Tenant, TenantAdminUrl, AzureEnvironment, certificate, true);
             }
             else if (ParameterSpecified(nameof(CertificateBase64Encoded)))
             {
@@ -651,7 +664,7 @@ namespace PnP.PowerShell.Commands.Base
                     ReuseAuthenticationManager();
                 }
                 // The key container behind this certificate was created by loading the bytes above, so it is ours to remove again on disconnect
-                return PnPConnection.CreateWithCert(new Uri(Url), ClientId, Tenant, TenantAdminUrl, AzureEnvironment, certificate, true);
+                return PnPConnection.CreateWithCert(!string.IsNullOrEmpty(Url) ? new Uri(Url) : null, ClientId, Tenant, TenantAdminUrl, AzureEnvironment, certificate, true);
             }
             else if (ParameterSpecified(nameof(Thumbprint)))
             {
@@ -673,7 +686,7 @@ namespace PnP.PowerShell.Commands.Base
                 {
                     ReuseAuthenticationManager();
                 }
-                return PnPConnection.CreateWithCert(new Uri(Url), ClientId, Tenant, TenantAdminUrl, AzureEnvironment, certificate);
+                return PnPConnection.CreateWithCert(!string.IsNullOrEmpty(Url) ? new Uri(Url) : null, ClientId, Tenant, TenantAdminUrl, AzureEnvironment, certificate);
             }
             else
             {
@@ -689,7 +702,7 @@ namespace PnP.PowerShell.Commands.Base
         {
             LogDebug("Connecting using a provided Access Token");
 
-            return PnPConnection.CreateWithAccessToken(!string.IsNullOrEmpty(Url) ? new Uri(Url) : null, AccessToken, TenantAdminUrl);
+            return PnPConnection.CreateWithAccessToken(!string.IsNullOrEmpty(Url) ? new Uri(Url) : null, AccessToken, TenantAdminUrl, AzureEnvironment);
         }
 
         /// <summary>
@@ -699,6 +712,11 @@ namespace PnP.PowerShell.Commands.Base
         private PnPConnection ConnectCredentials(PSCredential credentials, InitializationType initializationType = InitializationType.Credentials)
         {
             LogDebug("Connecting using username and password");
+
+            if (string.IsNullOrEmpty(Url) && (CurrentCredentials || TransformationOnPrem))
+            {
+                throw new PSArgumentException("The -CurrentCredentials and -TransformationOnPrem parameters require -Url because they create a SharePoint context.", nameof(Url));
+            }
 
             if (!CurrentCredentials && credentials == null)
             {
@@ -746,14 +764,14 @@ namespace PnP.PowerShell.Commands.Base
                 }
             }
             LogDebug($"Using ClientID {ClientId}");
-            return PnPConnection.CreateWithCredentials(this, new Uri(Url),
+            return PnPConnection.CreateWithCredentials(this, !string.IsNullOrEmpty(Url) ? new Uri(Url) : null,
                                                                credentials,
                                                                CurrentCredentials,
                                                                TenantAdminUrl,
                                                                PersistLogin,
                                                                AzureEnvironment,
                                                                ClientId,
-                                                               RedirectUri, TransformationOnPrem, initializationType);
+                                                               RedirectUri, TransformationOnPrem, initializationType, ErrorActionSetting);
         }
 
 
@@ -790,7 +808,7 @@ namespace PnP.PowerShell.Commands.Base
                     LogDebug("Using Managed AppId from secure store");
                 }
             }
-            if (Connection?.ClientId == ClientId && Connection?.ConnectionMethod == ConnectionMethod.Credentials)
+            if (Connection?.ClientId == ClientId && Connection?.ConnectionMethod == ConnectionMethod.Credentials && !string.IsNullOrEmpty(Url) && !string.IsNullOrEmpty(Connection.Url))
             {
                 if (IsSameOrAdminHost(new Uri(Url), new Uri(Connection.Url)))
                 {
@@ -798,7 +816,7 @@ namespace PnP.PowerShell.Commands.Base
                 }
             }
             LogDebug($"Using ClientID {ClientId}");
-            return PnPConnection.CreateWithInteractiveLogin(this, new Uri(Url.ToLower()), ClientId, TenantAdminUrl, AzureEnvironment, cancellationTokenSource, ForceAuthentication, Tenant, false, PersistLogin, Host, ErrorActionSetting);
+            return PnPConnection.CreateWithInteractiveLogin(this, !string.IsNullOrEmpty(Url) ? new Uri(Url.ToLower()) : null, ClientId, TenantAdminUrl, AzureEnvironment, cancellationTokenSource, ForceAuthentication, Tenant, false, PersistLogin, Host, ErrorActionSetting);
         }
 
         private PnPConnection ConnectEnvironmentVariable(InitializationType initializationType = InitializationType.EnvironmentVariable)
@@ -862,7 +880,7 @@ namespace PnP.PowerShell.Commands.Base
 
                 LogDebug($"ClientID: {azureClientId}");
 
-                return PnPConnection.CreateWithCert(new Uri(Url), azureClientId, Tenant, TenantAdminUrl, AzureEnvironment, certificate, true);
+                return PnPConnection.CreateWithCert(!string.IsNullOrEmpty(Url) ? new Uri(Url) : null, azureClientId, Tenant, TenantAdminUrl, AzureEnvironment, certificate, true);
             }
 
             else if (!string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
@@ -886,14 +904,14 @@ namespace PnP.PowerShell.Commands.Base
                 }
                 LogDebug($"ClientID: {azureClientId}");
 
-                return PnPConnection.CreateWithCredentials(this, new Uri(Url),
+                return PnPConnection.CreateWithCredentials(this, !string.IsNullOrEmpty(Url) ? new Uri(Url) : null,
                                                                    credentials,
                                                                    CurrentCredentials,
                                                                    TenantAdminUrl,
                                                                    PersistLogin,
                                                                    AzureEnvironment,
                                                                    azureClientId,
-                                                                   RedirectUri, TransformationOnPrem, initializationType);
+                                                                   RedirectUri, TransformationOnPrem, initializationType, ErrorActionSetting);
             }
 
             return null;
@@ -926,7 +944,7 @@ namespace PnP.PowerShell.Commands.Base
                     LogDebug("Using Managed AppId from secure store");
                 }
             }
-            if (Connection?.ClientId == ClientId && Connection?.ConnectionMethod == ConnectionMethod.Credentials)
+            if (Connection?.ClientId == ClientId && Connection?.ConnectionMethod == ConnectionMethod.Credentials && !string.IsNullOrEmpty(Url) && !string.IsNullOrEmpty(Connection.Url))
             {
                 if (IsSameOrAdminHost(new Uri(Url), new Uri(Connection.Url)))
                 {
@@ -935,11 +953,12 @@ namespace PnP.PowerShell.Commands.Base
             }
 
             LogDebug($"Using ClientID {ClientId}");
-            if (PnPConnection.CacheEnabled(Url, ClientId))
+            var cacheUrl = !string.IsNullOrEmpty(Url) ? Url : PnPConnection.GetDefaultTokenCacheUrl(AzureEnvironment);
+            if (PnPConnection.CacheEnabled(cacheUrl, ClientId))
             {
                 WriteObject("Cache used. Clear the cache entry with Disconnect-PnPOnline");
             }
-            return PnPConnection.CreateWithInteractiveLogin(this, new Uri(Url.ToLower()), ClientId, TenantAdminUrl, AzureEnvironment, cancellationTokenSource, ForceAuthentication, Tenant, true, PersistLogin, Host, ErrorActionSetting);
+            return PnPConnection.CreateWithInteractiveLogin(this, !string.IsNullOrEmpty(Url) ? new Uri(Url.ToLower()) : null, ClientId, TenantAdminUrl, AzureEnvironment, cancellationTokenSource, ForceAuthentication, Tenant, true, PersistLogin, Host, ErrorActionSetting);
         }
 
         private PnPConnection ConnectFederatedIdentity()
@@ -967,6 +986,11 @@ namespace PnP.PowerShell.Commands.Base
         }
         private PSCredential GetCredentials()
         {
+            if (string.IsNullOrEmpty(Url))
+            {
+                return null;
+            }
+
             var connectionUri = new Uri(Url);
 
             // Try to get the credentials by full url
@@ -1015,6 +1039,11 @@ namespace PnP.PowerShell.Commands.Base
 
         private string GetAppId()
         {
+            if (string.IsNullOrEmpty(Url))
+            {
+                return PnPConnection.GetCacheClientId(PnPConnection.GetDefaultTokenCacheUrl(AzureEnvironment));
+            }
+
             var connectionUri = new Uri(Url);
             // Try to get the credentials by full url
             string appId = PnPConnection.GetCacheClientId(connectionUri.ToString()) ?? Utilities.CredentialManager.GetAppId(connectionUri.ToString());

--- a/src/Commands/Base/GetAccessToken.cs
+++ b/src/Commands/Base/GetAccessToken.cs
@@ -81,7 +81,11 @@ namespace PnP.PowerShell.Commands.Base
 
             if (ParameterSpecified(nameof(Scopes)))
             {
-                var authManager = Connection.Context.GetContextSettings().AuthenticationManager;
+                var authManager = Connection.Context?.GetContextSettings().AuthenticationManager ?? Connection.AuthenticationManager;
+                if (authManager == null)
+                {
+                    throw new PSInvalidOperationException("The current connection cannot acquire tokens for explicit scopes.");
+                }
                 accessTokenValue = authManager.GetAccessTokenAsync(Scopes).GetAwaiter().GetResult();
             }
 

--- a/src/Commands/Base/PnPConnectedCmdlet.cs
+++ b/src/Commands/Base/PnPConnectedCmdlet.cs
@@ -98,7 +98,7 @@ namespace PnP.PowerShell.Commands.Base
                     throw new PSInvalidOperationException(errorMessage, ex);
                 }
 
-                if (Connection.Context.Url != Connection.Url)
+                if (Connection?.Context != null && Connection.Url != null && Connection.Context.Url != Connection.Url)
                 {
                     Connection.RestoreCachedContext(Connection.Url);
                 }
@@ -106,7 +106,10 @@ namespace PnP.PowerShell.Commands.Base
                 // With ErrorAction:Ignore, the $Error variable should not be populated with the error, otherwise it should
                 if (!new[] { "ignore" }.Contains(ErrorActionSetting.ToLowerInvariant()))
                 {
-                    ex.Data["CorrelationId"] = Connection.Context.TraceCorrelationId;
+                    if (Connection?.Context != null)
+                    {
+                        ex.Data["CorrelationId"] = Connection.Context.TraceCorrelationId;
+                    }
                     ex.Data["TimeStampUtc"] = DateTime.UtcNow;
 
                     LogError(errorMessage);

--- a/src/Commands/Base/PnPConnection.cs
+++ b/src/Commands/Base/PnPConnection.cs
@@ -102,6 +102,11 @@ namespace PnP.PowerShell.Commands.Base
         public string ClientSecret { get; protected set; }
 
         /// <summary>
+        /// Static access token used to set up the connection
+        /// </summary>
+        public string AccessToken { get; protected set; }
+
+        /// <summary>
         /// Url of the SharePoint Online site to connect to
         /// </summary>
         public string Url { get; protected set; }
@@ -158,7 +163,7 @@ namespace PnP.PowerShell.Commands.Base
         #endregion
 
         #region Creators
-        internal static PnPConnection CreateWithAccessToken(Uri url, string accessToken, string tenantAdminUrl)
+        internal static PnPConnection CreateWithAccessToken(Uri url, string accessToken, string tenantAdminUrl, AzureEnvironment azureEnvironment = AzureEnvironment.Production)
         {
             using (var authManager = new PnP.Framework.AuthenticationManager(new System.Net.NetworkCredential("", accessToken).SecurePassword))
             {
@@ -179,7 +184,13 @@ namespace PnP.PowerShell.Commands.Base
                     }
                 }
 
-                var connection = new PnPConnection(context, connectionType, null, url != null ? url.ToString() : null, tenantAdminUrl, PnPPSVersionTag, InitializationType.Token);
+                var connection = new PnPConnection(context, connectionType, null, url != null ? url.ToString() : null, tenantAdminUrl, PnPPSVersionTag, InitializationType.Token)
+                {
+                    AccessToken = accessToken,
+                    ConnectionMethod = ConnectionMethod.AccessToken,
+                    AzureEnvironment = azureEnvironment,
+                    _graphEndPoint = GetGraphEndPoint(azureEnvironment)
+                };
                 return connection;
             }
         }
@@ -250,19 +261,19 @@ namespace PnP.PowerShell.Commands.Base
 
         internal static PnPConnection CreateWithDeviceLogin(Cmdlet cmdlet, string clientId, string url, string tenantId, CmdletMessageWriter messageWriter, AzureEnvironment azureEnvironment, CancellationTokenSource cancellationTokenSource, bool persistLogin, System.Management.Automation.Host.PSHost host, string ErrorActionSetting = null)
         {
+            var cacheUrl = !string.IsNullOrEmpty(url) ? url : GetDefaultTokenCacheUrl(azureEnvironment);
             if (persistLogin)
             {
-                EnableCaching(url, clientId);
+                EnableCaching(cacheUrl, clientId);
             }
-            if (CacheEnabled(url, clientId))
+            if (CacheEnabled(cacheUrl, clientId))
             {
                 if (!errorActionSourceArray.Contains(ErrorActionSetting.ToLowerInvariant()))
                 {
                     messageWriter.LogDebug("Connecting using token cache. See https://pnp.github.io/powershell/articles/persistedlogin.html for more information.");
                 }
             }
-            var connectionUri = new Uri(url);
-            var scopes = new[] { $"{connectionUri.Scheme}://{connectionUri.Authority}//.default" }; // the second double slash is not a typo.
+
             Framework.AuthenticationManager authManager = null;
             if (CachedAuthenticationManager != null)
             {
@@ -272,55 +283,69 @@ namespace PnP.PowerShell.Commands.Base
             else
             {
                 authManager = Framework.AuthenticationManager.CreateWithDeviceLogin(clientId, tenantId, (deviceCodeResult) =>
-                 {
-                     if (PSUtility.IsAzureCloudShell())
-                     {
-                         messageWriter.LogWarning($"\n\nTo sign in, use a web browser to open the page {deviceCodeResult.VerificationUrl} and enter the code {deviceCodeResult.UserCode} to authenticate.\n\n");
-                     }
-                     else
-                     {
-                         var copiedToClipboard = true;
-                         try
-                         {
-                             ClipboardService.SetText(deviceCodeResult.UserCode);
-                         }
-                         catch
-                         {
-                             copiedToClipboard = false;
-                         }
+                {
+                    if (PSUtility.IsAzureCloudShell())
+                    {
+                        messageWriter.LogWarning($"\n\nTo sign in, use a web browser to open the page {deviceCodeResult.VerificationUrl} and enter the code {deviceCodeResult.UserCode} to authenticate.\n\n");
+                    }
+                    else
+                    {
+                        var copiedToClipboard = true;
+                        try
+                        {
+                            ClipboardService.SetText(deviceCodeResult.UserCode);
+                        }
+                        catch
+                        {
+                            copiedToClipboard = false;
+                        }
 
-                         var browserOpened = true;
-                         try
-                         {
-                             BrowserHelper.OpenBrowserForInteractiveLogin(deviceCodeResult.VerificationUrl, BrowserHelper.FindFreeLocalhostRedirectUri(), cancellationTokenSource);
-                         }
-                         catch
-                         {
-                             browserOpened = false;
-                         }
+                        var browserOpened = true;
+                        try
+                        {
+                            BrowserHelper.OpenBrowserForInteractiveLogin(deviceCodeResult.VerificationUrl, BrowserHelper.FindFreeLocalhostRedirectUri(), cancellationTokenSource);
+                        }
+                        catch
+                        {
+                            browserOpened = false;
+                        }
 
-                         if (copiedToClipboard && browserOpened)
-                         {
-                             messageWriter.LogWarning($"\n\nCode {deviceCodeResult.UserCode} has been copied to your clipboard and a new tab in the browser has been opened. Please paste this code in there and proceed.\n\n");
-                         }
-                         else
-                         {
+                        if (copiedToClipboard && browserOpened)
+                        {
+                            messageWriter.LogWarning($"\n\nCode {deviceCodeResult.UserCode} has been copied to your clipboard and a new tab in the browser has been opened. Please paste this code in there and proceed.\n\n");
+                        }
+                        else
+                        {
                             messageWriter.LogWarning($"\n\nOpen a browser, navigate to {deviceCodeResult.VerificationUrl} and authenticate using code {deviceCodeResult.UserCode} to proceed.\n\n");
-                         }
-                     }
+                        }
+                    }
 
-                     return Task.FromResult(0);
-                 }, azureEnvironment, tokenCacheCallback: async (tokenCache) =>
-                 {
-                     await MSALCacheHelper(tokenCache, url, clientId);
-                 });
+                    return Task.FromResult(0);
+                }, azureEnvironment, tokenCacheCallback: async (tokenCache) =>
+                {
+                    await MSALCacheHelper(tokenCache, cacheUrl, clientId);
+                });
             }
+
+            if (string.IsNullOrEmpty(url))
+            {
+                authManager.GetAccessToken($"https://{GetGraphEndPoint(azureEnvironment)}/.default");
+                return new PnPConnection(null, ConnectionType.O365, null, null, null, PnPPSVersionTag, InitializationType.DeviceLogin)
+                {
+                    ConnectionMethod = ConnectionMethod.DeviceLogin,
+                    AuthenticationManager = authManager,
+                    ClientId = clientId,
+                    Tenant = tenantId,
+                    AzureEnvironment = azureEnvironment,
+                    _graphEndPoint = GetGraphEndPoint(azureEnvironment)
+                };
+            }
+
             using (authManager)
             {
                 try
                 {
                     var clientContext = authManager.GetContext(url.ToString(), cancellationTokenSource.Token);
-
                     var context = PnPClientContext.ConvertFrom(clientContext);
                     context.ExecutingWebRequest += (sender, e) =>
                     {
@@ -363,6 +388,21 @@ namespace PnP.PowerShell.Commands.Base
             {
                 authManager = Framework.AuthenticationManager.CreateWithCertificate(clientId, certificate, tenant, azureEnvironment: azureEnvironment);
             }
+            if (url == null)
+            {
+                authManager.GetAccessToken($"https://{GetGraphEndPoint(azureEnvironment)}/.default");
+                return new PnPConnection(null, ConnectionType.O365, null, clientId, null, null, tenantAdminUrl, PnPPSVersionTag, InitializationType.ClientIDCertificate)
+                {
+                    ConnectionMethod = ConnectionMethod.AzureADAppOnly,
+                    AuthenticationManager = authManager,
+                    Certificate = certificate,
+                    Tenant = tenant,
+                    DeleteCertificateFromCacheOnDisconnect = certificateFromFile,
+                    AzureEnvironment = azureEnvironment,
+                    _graphEndPoint = GetGraphEndPoint(azureEnvironment)
+                };
+            }
+
             using (authManager)
             {
                 var clientContext = authManager.GetContext(url.ToString());
@@ -457,6 +497,8 @@ namespace PnP.PowerShell.Commands.Base
                     UserAssignedManagedIdentityClientId = userAssignedManagedIdentityClientId,
                     UserAssignedManagedIdentityAzureResourceId = userAssignedManagedIdentityAzureResourceId,
                     ConnectionMethod = ConnectionMethod.ManagedIdentity,
+                    AzureEnvironment = azureEnvironment,
+                    _graphEndPoint = GetGraphEndPoint(azureEnvironment)
                 };
                 return connection;
             }
@@ -464,22 +506,23 @@ namespace PnP.PowerShell.Commands.Base
 
         internal static PnPConnection CreateWithCredentials(Cmdlet cmdlet, Uri url, PSCredential credentials, bool currentCredentials, string tenantAdminUrl, bool persistLogin, AzureEnvironment azureEnvironment = AzureEnvironment.Production, string clientId = null, string redirectUrl = null, bool onPrem = false, InitializationType initializationType = InitializationType.Credentials, string ErrorActionSetting = null)
         {
+            var cacheUrl = url?.ToString() ?? GetDefaultTokenCacheUrl(azureEnvironment);
             if (persistLogin)
             {
-                EnableCaching(url.ToString(), clientId);
+                EnableCaching(cacheUrl, clientId);
             }
-            if (CacheEnabled(url.ToString(), clientId))
+            if (CacheEnabled(cacheUrl, clientId))
             {
                 if (!errorActionSourceArray.Contains(ErrorActionSetting.ToLowerInvariant()))
                 {
                     WriteCacheEnabledMessage(cmdlet);
                 }
             }
-            var context = new PnPClientContext(url.AbsoluteUri)
+            var context = url != null ? new PnPClientContext(url.AbsoluteUri)
             {
                 ApplicationName = Resources.ApplicationName,
                 DisableReturnValueCache = true,
-            };
+            } : null;
             PnPConnection spoConnection = null;
             if (!onPrem)
             {
@@ -496,9 +539,28 @@ namespace PnP.PowerShell.Commands.Base
                     {
                         authManager = PnP.Framework.AuthenticationManager.CreateWithCredentials(clientId, credentials.UserName, credentials.Password, redirectUrl, azureEnvironment, tokenCacheCallback: async (tokenCache) =>
                         {
-                            await MSALCacheHelper(tokenCache, url.ToString(), clientId);
+                            await MSALCacheHelper(tokenCache, cacheUrl, clientId);
                         });
                     }
+                    if (url == null)
+                    {
+                        Log.Debug("PnPConnection", "Acquiring token");
+                        var accessToken = authManager.GetAccessToken($"https://{GetGraphEndPoint(azureEnvironment)}/.default");
+                        Log.Debug("PnPConnection", "Token acquired");
+                        var parsedToken = new Microsoft.IdentityModel.JsonWebTokens.JsonWebToken(accessToken);
+                        tenantId = parsedToken.Claims.FirstOrDefault(c => c.Type == "tid")?.Value;
+
+                        return new PnPConnection(null, ConnectionType.O365, credentials, null, tenantAdminUrl, PnPPSVersionTag, initializationType)
+                        {
+                            ConnectionMethod = ConnectionMethod.Credentials,
+                            AuthenticationManager = authManager,
+                            AzureEnvironment = azureEnvironment,
+                            Tenant = tenantId,
+                            ClientId = clientId,
+                            _graphEndPoint = GetGraphEndPoint(azureEnvironment)
+                        };
+                    }
+
                     using (authManager)
                     {
                         var clientContext = authManager.GetContext(url.ToString());
@@ -587,11 +649,12 @@ namespace PnP.PowerShell.Commands.Base
 
         internal static PnPConnection CreateWithInteractiveLogin(Cmdlet cmdlet, Uri uri, string clientId, string tenantAdminUrl, AzureEnvironment azureEnvironment, CancellationTokenSource cancellationTokenSource, bool forceAuthentication, string tenant, bool enableLoginWithWAM, bool persistLogin, System.Management.Automation.Host.PSHost host, string ErrorActionSetting)
         {
+            var cacheUrl = uri?.ToString() ?? GetDefaultTokenCacheUrl(azureEnvironment);
             if (persistLogin)
             {
-                EnableCaching(uri.ToString(), clientId);
+                EnableCaching(cacheUrl, clientId);
             }
-            if (CacheEnabled(uri.ToString(), clientId))
+            if (CacheEnabled(cacheUrl, clientId))
             {
                 if (!errorActionSourceArray.Contains(ErrorActionSetting.ToLowerInvariant()))
                 {
@@ -619,9 +682,22 @@ namespace PnP.PowerShell.Commands.Base
                 htmlMessageFailure,
                 azureEnvironment: azureEnvironment, tokenCacheCallback: async (tokenCache) =>
                 {
-                    await MSALCacheHelper(tokenCache, uri.ToString(), clientId);
+                    await MSALCacheHelper(tokenCache, cacheUrl, clientId);
                 }, useWAM: enableLoginWithWAM);
             }
+            if (uri == null)
+            {
+                authManager.GetAccessToken($"https://{GetGraphEndPoint(azureEnvironment)}/.default");
+                return new PnPConnection(null, ConnectionType.O365, null, clientId, null, null, tenantAdminUrl, PnPPSVersionTag, InitializationType.ClientIDCertificate)
+                {
+                    ConnectionMethod = ConnectionMethod.Credentials,
+                    AuthenticationManager = authManager,
+                    Tenant = tenant,
+                    AzureEnvironment = azureEnvironment,
+                    _graphEndPoint = GetGraphEndPoint(azureEnvironment)
+                };
+            }
+
             using (authManager)
             {
                 var clientContext = authManager.GetContext(uri.ToString(), cancellationTokenSource.Token);
@@ -776,6 +852,11 @@ namespace PnP.PowerShell.Commands.Base
             // Custom clouds carry their endpoint in configuration, which Connect-PnPOnline -MicrosoftGraphEndPoint writes.
             using var authManager = new Framework.AuthenticationManager();
             return authManager.GetGraphEndPointForCustomAzureEnvironmentConfiguration();
+        }
+
+        internal static string GetDefaultTokenCacheUrl(AzureEnvironment azureEnvironment)
+        {
+            return $"https://{GetGraphEndPoint(azureEnvironment)}";
         }
         #endregion
 
@@ -1140,6 +1221,11 @@ namespace PnP.PowerShell.Commands.Base
 
         internal static bool CacheEnabled(string url, string clientid)
         {
+            if (string.IsNullOrEmpty(url))
+            {
+                return false;
+            }
+
             var settings = Settings.Current;
 
             var cacheEntries = settings.Cache;
@@ -1154,6 +1240,11 @@ namespace PnP.PowerShell.Commands.Base
 
         internal static string GetCacheClientId(string url)
         {
+            if (string.IsNullOrEmpty(url))
+            {
+                return null;
+            }
+
             var settings = Settings.Current;
 
             var cacheEntries = settings.Cache;
@@ -1168,15 +1259,19 @@ namespace PnP.PowerShell.Commands.Base
 
         private static List<string> GetCheckUrls(string url)
         {
-            var urls = new List<string>();
             var uri = new Uri(url);
             var baseAuthority = uri.Authority;
-            baseAuthority = baseAuthority.Replace("-admin.sharepoint.com", ".sharepoint.com").Replace("-my.sharepoint.com", ".sharepoint.com");
-            var baseUri = new Uri($"https://{baseAuthority}");
-            var host = baseUri.Host.Split('.')[0];
-            urls = [$"https://{host}.sharepoint.com", $"https://{host}-my.sharepoint.com", $"https://{host}-admin.sharepoint.com"];
+            if (!baseAuthority.Contains(".sharepoint.", StringComparison.OrdinalIgnoreCase))
+            {
+                return [uri.GetLeftPart(UriPartial.Authority).TrimEnd('/')];
+            }
 
-            return urls;
+            baseAuthority = baseAuthority
+                .Replace("-admin.sharepoint.", ".sharepoint.", StringComparison.OrdinalIgnoreCase)
+                .Replace("-my.sharepoint.", ".sharepoint.", StringComparison.OrdinalIgnoreCase);
+            var host = baseAuthority.Split('.')[0];
+            var suffix = baseAuthority[host.Length..];
+            return [$"https://{host}{suffix}", $"https://{host}-my{suffix}", $"https://{host}-admin{suffix}"];
         }
 
         private static void EnableCaching(string url, string clientid)
@@ -1189,8 +1284,20 @@ namespace PnP.PowerShell.Commands.Base
             }
             else
             {
-                var baseAuthority = new Uri(url).Authority.Replace("-admin.sharepoint.com", ".sharepoint.com").Replace("-my.sharepoint.com", ".sharepoint.com");
-                var baseUrl = $"https://{baseAuthority}";
+                var uri = new Uri(url);
+                var baseAuthority = uri.Authority;
+                string baseUrl;
+                if (baseAuthority.Contains(".sharepoint.", StringComparison.OrdinalIgnoreCase))
+                {
+                    baseAuthority = baseAuthority
+                        .Replace("-admin.sharepoint.", ".sharepoint.", StringComparison.OrdinalIgnoreCase)
+                        .Replace("-my.sharepoint.", ".sharepoint.", StringComparison.OrdinalIgnoreCase);
+                    baseUrl = $"https://{baseAuthority}";
+                }
+                else
+                {
+                    baseUrl = uri.GetLeftPart(UriPartial.Authority).TrimEnd('/');
+                }
                 Settings.Current.Cache.Add(new TokenCacheConfiguration() { ClientId = clientid, Url = baseUrl, Enabled = true });
             }
             Settings.Current.Save();
@@ -1203,7 +1310,8 @@ namespace PnP.PowerShell.Commands.Base
 
         internal static void ClearCache(PnPConnection connection)
         {
-            var urls = GetCheckUrls(connection.Url);
+            var cacheUrl = connection.Url ?? GetDefaultTokenCacheUrl(connection.AzureEnvironment);
+            var urls = GetCheckUrls(cacheUrl);
             var entry = Settings.Current.Cache?.FirstOrDefault(c => urls.Contains(c.Url) && c.ClientId == connection.ClientId);
             if (entry != null)
             {

--- a/src/Commands/Base/TokenHandler.cs
+++ b/src/Commands/Base/TokenHandler.cs
@@ -298,6 +298,10 @@ namespace PnP.PowerShell.Commands.Base
                 PnP.Framework.Diagnostics.Log.Debug("TokenHandler", $"Acquiring token for resource {requestedAudience} using Federated Identity");
                 accessToken = GetFederatedIdentityTokenAsync(connection.ClientId, connection.Tenant, requestedAudience, connection.AzureEnvironment).GetAwaiter().GetResult();
             }
+            else if (connection.ConnectionMethod == ConnectionMethod.AccessToken)
+            {
+                accessToken = connection.AccessToken;
+            }
             else
             {
                 if (connection.Context != null)
@@ -314,6 +318,10 @@ namespace PnP.PowerShell.Commands.Base
 
                         accessToken = authManager.GetAccessToken(requestedAudience);
                     }
+                }
+                else if (connection.AuthenticationManager != null)
+                {
+                    accessToken = connection.AuthenticationManager.GetAccessToken(requestedAudience);
                 }
             }
             if (string.IsNullOrEmpty(accessToken))

--- a/src/Commands/Properties/Resources.Designer.cs
+++ b/src/Commands/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace PnP.PowerShell.Commands.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -205,15 +205,6 @@ namespace PnP.PowerShell.Commands.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The client version &apos;{0}&apos; is not supported. Please try to upgrade client version first..
-        /// </summary>
-        internal static string CrossGeoInvalidVersion {
-            get {
-                return ResourceManager.GetString("CrossGeoInvalidVersion", resourceCulture);
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to Server does not support suppressing the warning..
         /// </summary>
         internal static string CrossGeoConfirmationNotSupported {
@@ -221,7 +212,16 @@ namespace PnP.PowerShell.Commands.Properties {
                 return ResourceManager.GetString("CrossGeoConfirmationNotSupported", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The client version &apos;{0}&apos; is not supported. Please try to upgrade client version first..
+        /// </summary>
+        internal static string CrossGeoInvalidVersion {
+            get {
+                return ResourceManager.GetString("CrossGeoInvalidVersion", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to There are apps instantiated on the site. Confirm to initiate the site move. After the site move completes, the apps may need to be instantiated or reconfigured at the destination geo location..
         /// </summary>
@@ -230,7 +230,7 @@ namespace PnP.PowerShell.Commands.Properties {
                 return ResourceManager.GetString("CrossGeoSiteContainsMarketplaceAppsWithConfirm", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to There is Workflow 2013 instantiated on the site. Confirm to initiate the site move. After the site move completes, Workflow may need to be instantiated or reconfigured at the destination geo location..
         /// </summary>
@@ -239,7 +239,25 @@ namespace PnP.PowerShell.Commands.Properties {
                 return ResourceManager.GetString("CrossGeoSiteRunsWorkflow2013WithConfirm", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to I acknowledge that I am responsible for copying or moving the data from this location before I delete the location..
+        /// </summary>
+        internal static string CrossGeoWarning2RemoveAdl {
+            get {
+                return ResourceManager.GetString("CrossGeoWarning2RemoveAdl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Did you move all data from this location?.
+        /// </summary>
+        internal static string CrossGeoWarning2RemoveAdlQuery {
+            get {
+                return ResourceManager.GetString("CrossGeoWarning2RemoveAdlQuery", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to The new location will use the following addresses for OneDrive and SharePoint sites:
         ///
@@ -253,7 +271,7 @@ namespace PnP.PowerShell.Commands.Properties {
                 return ResourceManager.GetString("CrossGeoWarningAddAdlMessage", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Do you want to set up this location?.
         /// </summary>
@@ -262,7 +280,7 @@ namespace PnP.PowerShell.Commands.Properties {
                 return ResourceManager.GetString("CrossGeoWarningAddAdlMessageQuery", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Successfully started setting up the new location. You will receive a notification when the process completes. You can check status using the following command: Get-PnPMultiGeoCompanyAllowedDataLocation..
         /// </summary>
@@ -271,7 +289,7 @@ namespace PnP.PowerShell.Commands.Properties {
                 return ResourceManager.GetString("CrossGeoWarningAddAdlSuccessMessage", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Any remaining user data in this location will be permanently deleted. This includes all OneDrive for Business data, SharePoint sites and Group sites. Make sure all data is moved to another location before continuing.
         ///
@@ -283,34 +301,7 @@ namespace PnP.PowerShell.Commands.Properties {
                 return ResourceManager.GetString("CrossGeoWarningRemoveAdl", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Do you want to permanently delete this location and all its data: {0}?.
-        /// </summary>
-        internal static string CrossGeoWarningRemoveAdlQuery {
-            get {
-                return ResourceManager.GetString("CrossGeoWarningRemoveAdlQuery", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to I acknowledge that I am responsible for copying or moving the data from this location before I delete the location..
-        /// </summary>
-        internal static string CrossGeoWarning2RemoveAdl {
-            get {
-                return ResourceManager.GetString("CrossGeoWarning2RemoveAdl", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Did you move all data from this location?.
-        /// </summary>
-        internal static string CrossGeoWarning2RemoveAdlQuery {
-            get {
-                return ResourceManager.GetString("CrossGeoWarning2RemoveAdlQuery", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The delete operation was canceled..
         /// </summary>
@@ -319,7 +310,16 @@ namespace PnP.PowerShell.Commands.Properties {
                 return ResourceManager.GetString("CrossGeoWarningRemoveAdlCancelMessage", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do you want to permanently delete this location and all its data: {0}?.
+        /// </summary>
+        internal static string CrossGeoWarningRemoveAdlQuery {
+            get {
+                return ResourceManager.GetString("CrossGeoWarningRemoveAdlQuery", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Deleting the location might take a few hours. After the location is deleted, you&apos;ll be disconnected from the SharePoint Online Administration center in this location..
         /// </summary>
@@ -328,7 +328,7 @@ namespace PnP.PowerShell.Commands.Properties {
                 return ResourceManager.GetString("CrossGeoWarningRemoveAdlSuccessMessage", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Current site is not a tenant administration site.
         /// </summary>
@@ -520,7 +520,7 @@ namespace PnP.PowerShell.Commands.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are not signed in. Please use Connect-PnPOnline to connect..
+        ///   Looks up a localized string similar to You are not signed in to SharePoint Online. Please use Connect-PnPOnline &lt;SharePoint URL&gt; to connect..
         /// </summary>
         internal static string NoDefaultSharePointConnection {
             get {

--- a/src/Commands/Properties/Resources.resx
+++ b/src/Commands/Properties/Resources.resx
@@ -190,7 +190,7 @@
     <value>No list found with id, title or url '{0}'</value>
   </data>
   <data name="NoDefaultSharePointConnection" xml:space="preserve">
-    <value>You are not signed in. Please use Connect-PnPOnline to connect.</value>
+    <value>You are not signed in to SharePoint Online. Please use Connect-PnPOnline &lt;SharePoint URL&gt; to connect.</value>
   </data>
   <data name="NoSharePointConnectionInProvidedConnection" xml:space="preserve">
     <value>The provided connection through -Connection holds no SharePoint context. Please use one of the Connect-PnPOnline commands which uses the -Url argument to connect.</value>


### PR DESCRIPTION
## Type ##
- [ ] Bug Fix
- [X] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
`Connect-PnPOnline` now no longer requires a SharePoint Online URL to be provided. This can be handy when not needing SharePoint specific cmdlets, but i.e. working with Graph, Entra or one of the other supported targets.